### PR TITLE
feat: add dedicated event ingestor worker

### DIFF
--- a/src/indexer/eventIngestor.ts
+++ b/src/indexer/eventIngestor.ts
@@ -1,0 +1,131 @@
+import { xdr } from '@stellar/stellar-sdk';
+import { prisma } from '../db';
+import { decodeEvent } from './decoder';
+import { fetchEvents, LedgerEvent } from './rpc';
+
+/**
+ * Parse DiagnosticEvents from a raw TransactionMeta XDR (base64).
+ * Falls back to an empty array if the meta lacks diagnostic events.
+ */
+export function extractEventsFromMeta(metaXdr: string): Array<{
+  contractId: string;
+  topics: string[];
+  data: string;
+}> {
+  let meta: xdr.TransactionMeta;
+  try {
+    meta = xdr.TransactionMeta.fromXDR(metaXdr, 'base64');
+  } catch {
+    return [];
+  }
+
+  // TransactionMeta v3 carries sorobanMeta with events
+  if (meta.switch() !== 3) return [];
+
+  const sorobanMeta = (meta as any).v3().sorobanMeta();
+  if (!sorobanMeta) return [];
+
+  const diagnosticEvents: xdr.DiagnosticEvent[] = sorobanMeta.diagnosticEvents?.() ?? [];
+
+  return diagnosticEvents
+    .filter((de) => {
+      // Only include contract events (not system/diagnostic noise)
+      const ev = de.event();
+      return ev.type().name === 'contract';
+    })
+    .map((de) => {
+      const ev = de.event();
+      // contractId() returns null | Buffer — encode as hex string
+      const contractIdBuf: Buffer | null = ev.contractId();
+      const contractId = contractIdBuf ? contractIdBuf.toString('hex') : '';
+      const topics = (ev.body() as any).v0().topics().map((t: xdr.ScVal) => t.toXDR('base64'));
+      const data: string = (ev.body() as any).v0().data().toXDR('base64');
+      return { contractId, topics, data };
+    });
+}
+
+/**
+ * Ingest events for a ledger range:
+ *  1. Fetch events from the RPC events endpoint (primary source).
+ *  2. Decode topics/data vectors via the decoder.
+ *  3. Upsert into the Event table, skipping duplicates.
+ */
+export async function ingestEvents(startLedger: number, endLedger: number): Promise<number> {
+  const events = await fetchEvents(startLedger, endLedger);
+  let stored = 0;
+
+  for (const event of events) {
+    stored += await storeEvent(event);
+  }
+
+  return stored;
+}
+
+/**
+ * Ingest events extracted directly from a transaction's meta XDR.
+ * Used when you already have the raw meta and want richer diagnostic data.
+ */
+export async function ingestEventsFromMeta(
+  txHash: string,
+  ledger: number,
+  ledgerCloseTime: Date,
+  metaXdr: string
+): Promise<number> {
+  const raw = extractEventsFromMeta(metaXdr);
+  let stored = 0;
+
+  for (const ev of raw) {
+    const ledgerEvent: LedgerEvent = {
+      contractId: ev.contractId,
+      transactionHash: txHash,
+      ledger,
+      ledgerCloseTime,
+      topics: ev.topics,
+      data: ev.data,
+    };
+    stored += await storeEvent(ledgerEvent);
+  }
+
+  return stored;
+}
+
+async function storeEvent(event: LedgerEvent): Promise<number> {
+  if (!event.contractId || !event.transactionHash) return 0;
+
+  // Ensure the contract row exists before inserting the event (FK constraint)
+  await prisma.contract.upsert({
+    where: { address: event.contractId },
+    update: {},
+    create: { address: event.contractId },
+  });
+
+  // Ensure the transaction row exists (Event has a required FK to Transaction)
+  const txExists = await prisma.transaction.findUnique({
+    where: { hash: event.transactionHash },
+    select: { hash: true },
+  });
+  if (!txExists) return 0; // transaction not yet indexed; skip
+
+  const { eventType, decoded } = decodeEvent(event.topics, event.data);
+
+  // Stable dedup key: hash + first topic (mirrors existing indexer logic)
+  const id = `${event.transactionHash}-${event.topics[0] ?? '0'}`;
+
+  await prisma.event.upsert({
+    where: { id },
+    update: {},
+    create: {
+      id,
+      transactionHash: event.transactionHash,
+      contractAddress: event.contractId,
+      eventType,
+      topics: event.topics,
+      data: { raw: event.data },
+      decoded: decoded as object,
+      ledger: event.ledger,
+      ledgerCloseTime: event.ledgerCloseTime,
+    },
+  });
+
+  return 1;
+}

--- a/src/indexer/indexer.ts
+++ b/src/indexer/indexer.ts
@@ -2,7 +2,8 @@ import WebSocket from 'ws';
 import { prisma } from '../db';
 import { config } from '../config';
 import { fetchEvents, getLatestLedger, getRpcWebsocketUrl, getTransaction } from './rpc';
-import { decodeTransaction, decodeEvent } from './decoder';
+import { decodeTransaction } from './decoder';
+import { ingestEvents } from './eventIngestor';
 
 const BATCH = config.indexerBatchSize;
 
@@ -23,6 +24,7 @@ async function processLedgerRange(start: number, end: number) {
   console.log(`Indexing ledgers ${start} → ${end}`);
   const events = await fetchEvents(start, end);
 
+  // Index transactions first so the event ingestor can satisfy the FK constraint
   for (const event of events) {
     await prisma.contract.upsert({
       where: { address: event.contractId },
@@ -61,26 +63,11 @@ async function processLedgerRange(start: number, end: number) {
         },
       });
     }
-
-    const { eventType, decoded } = decodeEvent(event.topics, event.data);
-    await prisma.event.upsert({
-      where: { id: `${event.transactionHash}-${event.topics[0] ?? '0'}` },
-      update: {},
-      create: {
-        id: `${event.transactionHash}-${event.topics[0] ?? '0'}`,
-        transactionHash: event.transactionHash,
-        contractAddress: event.contractId,
-        eventType,
-        topics: event.topics,
-        data: { raw: event.data },
-        decoded: decoded as object,
-        ledger: event.ledger,
-        ledgerCloseTime: event.ledgerCloseTime,
-      },
-    });
   }
 
-  console.log(`Processed ${events.length} events in ledgers ${start}–${end}`);
+  // Delegate event extraction, decoding, and storage to the dedicated ingestor
+  const stored = await ingestEvents(start, end);
+  console.log(`Processed ${events.length} transactions, stored ${stored} events in ledgers ${start}–${end}`);
 }
 
 function sleep(ms: number) {


### PR DESCRIPTION
- Add src/indexer/eventIngestor.ts with:
  - extractEventsFromMeta: parses DiagnosticEvents from TransactionMeta v3 XDR
  - ingestEvents: fetches from RPC events endpoint, decodes topics/data, upserts to DB
  - ingestEventsFromMeta: ingests events from raw meta XDR path
- Update indexer.ts to delegate event storage to the ingestor worker
closes #27 