### PR TITLE
feat: add async decode error queue for failed ledger/tx XDR

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,3 +78,21 @@ model IndexerState {
   lastLedger    Int      @default(0)
   updatedAt     DateTime @updatedAt
 }
+
+model FailedItem {
+  id          String   @id @default(cuid())
+  itemType    String   // "transaction" | "event"
+  itemId      String   // tx hash or event id
+  ledger      Int
+  rawXdr      String?  // raw XDR that failed to decode
+  errorMsg    String
+  errorStack  String?
+  context     Json?    // extra context (topics, data, etc.)
+  retryCount  Int      @default(0)
+  dead        Boolean  @default(false)  // true = max retries exceeded
+  createdAt   DateTime @default(now())
+  lastTriedAt DateTime @default(now())
+
+  @@index([itemType, dead])
+  @@index([ledger])
+}

--- a/src/indexer/errorQueue.ts
+++ b/src/indexer/errorQueue.ts
@@ -1,0 +1,82 @@
+import { prisma } from '../db';
+
+const MAX_RETRIES = 3;
+
+export interface FailedItemInput {
+  itemType: 'transaction' | 'event';
+  itemId: string;
+  ledger: number;
+  rawXdr?: string;
+  error: unknown;
+  context?: Record<string, unknown>;
+}
+
+/** Persist a failed decode item. Idempotent — increments retryCount on conflict. */
+export async function enqueueFailure(item: FailedItemInput): Promise<void> {
+  const err = item.error instanceof Error ? item.error : new Error(String(item.error));
+  const existing = await prisma.failedItem.findFirst({
+    where: { itemId: item.itemId, itemType: item.itemType },
+  });
+
+  if (existing) {
+    const retryCount = existing.retryCount + 1;
+    await prisma.failedItem.update({
+      where: { id: existing.id },
+      data: {
+        errorMsg: err.message,
+        errorStack: err.stack ?? null,
+        retryCount,
+        dead: retryCount >= MAX_RETRIES,
+        lastTriedAt: new Date(),
+      },
+    });
+  } else {
+    await prisma.failedItem.create({
+      data: {
+        itemType: item.itemType,
+        itemId: item.itemId,
+        ledger: item.ledger,
+        rawXdr: item.rawXdr ?? null,
+        errorMsg: err.message,
+        errorStack: err.stack ?? null,
+        context: item.context ?? null,
+        retryCount: 0,
+        dead: false,
+      },
+    });
+  }
+
+  console.error(
+    `[errorQueue] ${item.itemType} ${item.itemId} (ledger ${item.ledger}) failed: ${err.message}`
+  );
+}
+
+/**
+ * Retry all non-dead failed items by calling the provided handler.
+ * Items that succeed are deleted; items that fail again are re-enqueued.
+ */
+export async function retryFailures(
+  handler: (item: { itemType: string; itemId: string; ledger: number; rawXdr: string | null; context: unknown }) => Promise<void>
+): Promise<void> {
+  const pending = await prisma.failedItem.findMany({
+    where: { dead: false },
+    orderBy: { createdAt: 'asc' },
+  });
+
+  for (const item of pending) {
+    try {
+      await handler(item);
+      await prisma.failedItem.delete({ where: { id: item.id } });
+      console.log(`[errorQueue] Retry succeeded for ${item.itemType} ${item.itemId}`);
+    } catch (err) {
+      await enqueueFailure({
+        itemType: item.itemType as 'transaction' | 'event',
+        itemId: item.itemId,
+        ledger: item.ledger,
+        rawXdr: item.rawXdr ?? undefined,
+        error: err,
+        context: item.context as Record<string, unknown> | undefined,
+      });
+    }
+  }
+}

--- a/src/indexer/indexer.ts
+++ b/src/indexer/indexer.ts
@@ -3,6 +3,7 @@ import { prisma } from '../db';
 import { config } from '../config';
 import { fetchEvents, getLatestLedger, getRpcWebsocketUrl, getTransaction } from './rpc';
 import { decodeTransaction, decodeEvent } from './decoder';
+import { enqueueFailure } from './errorQueue';
 
 const BATCH = config.indexerBatchSize;
 
@@ -35,7 +36,16 @@ async function processLedgerRange(start: number, end: number) {
       const txResult = await getTransaction(event.transactionHash).catch(() => null);
       const rawXdr = (txResult as any)?.envelopeXdr?.toXDR('base64') ?? '';
       const decoded = rawXdr
-        ? await decodeTransaction(rawXdr)
+        ? await decodeTransaction(rawXdr).catch(async (err) => {
+            await enqueueFailure({
+              itemType: 'transaction',
+              itemId: event.transactionHash,
+              ledger: event.ledger,
+              rawXdr,
+              error: err,
+            });
+            return { contractAddress: event.contractId, functionName: null, functionArgs: null, humanReadable: null };
+          })
         : {
             contractAddress: event.contractId,
             functionName: null,
@@ -62,7 +72,20 @@ async function processLedgerRange(start: number, end: number) {
       });
     }
 
-    const { eventType, decoded } = decodeEvent(event.topics, event.data);
+    let eventDecoded: { eventType: string; decoded: Record<string, unknown> };
+    try {
+      eventDecoded = decodeEvent(event.topics, event.data);
+    } catch (err) {
+      await enqueueFailure({
+        itemType: 'event',
+        itemId: `${event.transactionHash}-${event.topics[0] ?? '0'}`,
+        ledger: event.ledger,
+        error: err,
+        context: { topics: event.topics, data: event.data },
+      });
+      eventDecoded = { eventType: 'unknown', decoded: { raw: { topics: event.topics, data: event.data } } };
+    }
+    const { eventType, decoded: decodedEvent } = eventDecoded;
     await prisma.event.upsert({
       where: { id: `${event.transactionHash}-${event.topics[0] ?? '0'}` },
       update: {},
@@ -73,7 +96,7 @@ async function processLedgerRange(start: number, end: number) {
         eventType,
         topics: event.topics,
         data: { raw: event.data },
-        decoded: decoded as object,
+        decoded: decodedEvent as object,
         ledger: event.ledger,
         ledgerCloseTime: event.ledgerCloseTime,
       },


### PR DESCRIPTION
- Add FailedItem model to Prisma schema to persist decode failures
- Add errorQueue.ts with enqueueFailure (idempotent, dead-letter after 3 retries) and retryFailures
- Wrap decodeTransaction and decodeEvent in indexer.ts with error isolation so a single bad item never halts the pipeline
closes #28 