### PR TITLE
feat: typed ABI args decoder for Soroban ScVal types

### DIFF
--- a/src/indexer/args-decoder.ts
+++ b/src/indexer/args-decoder.ts
@@ -1,0 +1,191 @@
+import { xdr, scValToNative, Address } from '@stellar/stellar-sdk';
+import type { AbiParam } from './registry';
+
+export interface DecodedArg {
+  raw: unknown;       // native JS value (BigInt, string, object, …)
+  formatted: string;  // human-readable display string
+}
+
+/**
+ * Decode a single ScVal according to its ABI param type.
+ * Returns { raw, formatted } so callers can use either.
+ */
+export function decodeScVal(val: xdr.ScVal, param: AbiParam, decimals?: number): DecodedArg {
+  const type = param.type.toLowerCase();
+
+  try {
+    switch (true) {
+      // ── Integers ──────────────────────────────────────────────────────────
+      case type === 'i128' || type === 'u128': {
+        const raw = scValToNative(val) as bigint;
+        return { raw, formatted: formatAmount(raw, decimals) };
+      }
+
+      case type === 'i64' || type === 'u64': {
+        const raw = scValToNative(val) as bigint;
+        return { raw, formatted: raw.toString() };
+      }
+
+      case type === 'i32' || type === 'u32': {
+        const raw = scValToNative(val) as number;
+        return { raw, formatted: String(raw) };
+      }
+
+      // ── Address ───────────────────────────────────────────────────────────
+      case type === 'address': {
+        const raw = Address.fromScVal(val).toString();
+        return { raw, formatted: raw };
+      }
+
+      // ── Bool ──────────────────────────────────────────────────────────────
+      case type === 'bool': {
+        const raw = scValToNative(val) as boolean;
+        return { raw, formatted: String(raw) };
+      }
+
+      // ── Bytes / BytesN ────────────────────────────────────────────────────
+      case type === 'bytes' || type.startsWith('bytesn'): {
+        const raw = scValToNative(val) as Uint8Array;
+        const hex = Buffer.from(raw).toString('hex');
+        return { raw, formatted: `0x${hex}` };
+      }
+
+      // ── String ────────────────────────────────────────────────────────────
+      case type === 'string': {
+        const raw = scValToNative(val) as string;
+        return { raw, formatted: raw };
+      }
+
+      // ── Symbol ────────────────────────────────────────────────────────────
+      case type === 'symbol': {
+        const raw = val.switch().name === 'scvSymbol'
+          ? val.sym().toString()
+          : String(scValToNative(val));
+        return { raw, formatted: raw };
+      }
+
+      // ── Enum (Soroban tagged union — scvVec with one element map) ─────────
+      case type === 'enum': {
+        const raw = decodeEnum(val);
+        return { raw, formatted: safeStringify(raw) };
+      }
+
+      // ── Struct (scvMap with named fields) ─────────────────────────────────
+      case type === 'struct': {
+        const raw = decodeStruct(val);
+        return { raw, formatted: safeStringify(raw) };
+      }
+
+      // ── Map ───────────────────────────────────────────────────────────────
+      case type === 'map': {
+        const raw = decodeMap(val);
+        return { raw, formatted: safeStringify(raw) };
+      }
+
+      // ── Vec / Array ───────────────────────────────────────────────────────
+      case type === 'vec' || type.startsWith('vec<'): {
+        const raw = (scValToNative(val) as unknown[]).map(String);
+        return { raw, formatted: `[${raw.join(', ')}]` };
+      }
+
+      // ── Option<T> — scvVoid = None, otherwise unwrap ──────────────────────
+      case type.startsWith('option'): {
+        if (val.switch().name === 'scvVoid') return { raw: null, formatted: 'None' };
+        const inner = type.slice(7, -1); // "option<T>" → "T"
+        return decodeScVal(val, { name: param.name, type: inner }, decimals);
+      }
+
+      // ── Fallback ──────────────────────────────────────────────────────────
+      default: {
+        const raw = scValToNative(val);
+        return { raw, formatted: String(raw) };
+      }
+    }
+  } catch {
+    const fallback = val.toXDR('base64');
+    return { raw: fallback, formatted: fallback };
+  }
+}
+
+/**
+ * Decode all function arguments against their ABI params.
+ * Returns a map of param name → DecodedArg.
+ */
+export function decodeTypedArgs(
+  params: AbiParam[],
+  rawArgs: xdr.ScVal[],
+  decimals?: number
+): Record<string, DecodedArg> {
+  const result: Record<string, DecodedArg> = {};
+  for (let i = 0; i < params.length; i++) {
+    const val = rawArgs[i];
+    if (!val) continue;
+    result[params[i].name] = decodeScVal(val, params[i], decimals);
+  }
+  return result;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Format a bigint amount with 7 decimal places (Stellar standard) or custom decimals.
+ * e.g. 100_000_000n with decimals=7 → "10.0000000"
+ */
+export function formatAmount(raw: bigint, decimals = 7): string {
+  if (decimals === 0) return raw.toString();
+  const divisor = BigInt(10 ** decimals);
+  const whole = raw / divisor;
+  const frac = raw % divisor;
+  const fracStr = frac.toString().padStart(decimals, '0');
+  return `${whole}.${fracStr}`;
+}
+
+/**
+ * Decode a Soroban enum ScVal.
+ * Soroban enums are encoded as scvVec([scvSymbol("VariantName")]) or
+ * scvVec([scvSymbol("VariantName"), value]).
+ */
+function decodeEnum(val: xdr.ScVal): { variant: string; value?: unknown } {
+  if (val.switch().name !== 'scvVec') {
+    return { variant: String(scValToNative(val)) };
+  }
+  const items = val.vec()!;
+  const variant = items[0]?.switch().name === 'scvSymbol'
+    ? items[0].sym().toString()
+    : String(scValToNative(items[0]));
+  if (items.length === 1) return { variant };
+  return { variant, value: scValToNative(items[1]) };
+}
+
+/**
+ * Decode a Soroban struct ScVal (scvMap with symbol keys).
+ */
+function decodeStruct(val: xdr.ScVal): Record<string, unknown> {
+  if (val.switch().name !== 'scvMap') return { raw: scValToNative(val) };
+  const result: Record<string, unknown> = {};
+  for (const entry of val.map()!) {
+    const key = entry.key().switch().name === 'scvSymbol'
+      ? entry.key().sym().toString()
+      : String(scValToNative(entry.key()));
+    result[key] = scValToNative(entry.val());
+  }
+  return result;
+}
+
+/**
+ * Decode a generic ScVal map into a JS object with string keys.
+ */
+function decodeMap(val: xdr.ScVal): Record<string, unknown> {
+  if (val.switch().name !== 'scvMap') return { raw: scValToNative(val) };
+  const result: Record<string, unknown> = {};
+  for (const entry of val.map()!) {
+    const key = String(scValToNative(entry.key()));
+    result[key] = scValToNative(entry.val());
+  }
+  return result;
+}
+
+/** JSON.stringify that serializes BigInt as string to avoid TypeError. */
+function safeStringify(val: unknown): string {
+  return JSON.stringify(val, (_k, v) => (typeof v === 'bigint' ? v.toString() : v));
+}

--- a/src/indexer/decoder.ts
+++ b/src/indexer/decoder.ts
@@ -59,7 +59,7 @@ export async function decodeTransaction(rawXdr: string): Promise<DecodedTransact
   }
 
   const contract = await prisma.contract.findUnique({ where: { address: contractAddress } });
-  const decoded = decodeArgs(functionName, rawArgs, abi);
+  const decoded = decodeArgs(functionName, rawArgs, abi, contract?.tokenDecimals ?? undefined);
   const human = decoded
     ? renderHuman(functionName, decoded, abi, contract?.name, contract?.tokenDecimals ?? undefined)
     : `Called ${functionName} on ${contract?.name ?? contractAddress}`;

--- a/src/indexer/registry.ts
+++ b/src/indexer/registry.ts
@@ -1,5 +1,6 @@
-import { xdr, scValToNative, Address } from '@stellar/stellar-sdk';
+import { xdr } from '@stellar/stellar-sdk';
 import { prisma } from '../db';
+import { decodeTypedArgs, formatAmount } from './args-decoder';
 
 export interface ContractAbi {
   functions: AbiFunction[];
@@ -80,30 +81,26 @@ export async function getContractAbi(contractAddress: string): Promise<ContractA
 
 /**
  * Decode raw XDR ScVal arguments into a named map using the ABI.
+ * Values are the formatted strings from the typed decoder.
  */
 export function decodeArgs(
   fnName: string,
   rawArgs: xdr.ScVal[],
-  abi: ContractAbi
+  abi: ContractAbi,
+  decimals?: number
 ): Record<string, unknown> | null {
   const fn = abi.functions.find((f) => f.name === fnName);
   if (!fn) return null;
-
-  const result: Record<string, unknown> = {};
-  fn.inputs.forEach((param, i) => {
-    const val = rawArgs[i];
-    if (!val) return;
-    try {
-      result[param.name] = scValToNative(val);
-    } catch {
-      result[param.name] = val.toXDR('base64');
-    }
-  });
-  return result;
+  const typed = decodeTypedArgs(fn.inputs, rawArgs, decimals);
+  // Expose { raw, formatted } per key so callers can choose
+  return Object.fromEntries(
+    Object.entries(typed).map(([k, v]) => [k, v])
+  );
 }
 
 /**
  * Render a human-readable string from decoded args and a template.
+ * Expects args values to be DecodedArg objects (with .formatted) or plain strings.
  */
 export function renderHuman(
   fnName: string,
@@ -117,12 +114,14 @@ export function renderHuman(
 
   let text = fn.humanTemplate;
   for (const [key, val] of Object.entries(args)) {
-    let display = String(val);
-    // Format i128 amounts with decimals
-    if (decimals && (key === 'amount' || key === 'amount_in' || key === 'amount_out')) {
-      const num = BigInt(display);
-      const divisor = BigInt(10 ** decimals);
-      display = (Number(num) / Number(divisor)).toFixed(decimals > 4 ? 4 : decimals);
+    // DecodedArg shape from typed decoder
+    let display: string;
+    if (val && typeof val === 'object' && 'formatted' in (val as object)) {
+      display = (val as { formatted: string }).formatted;
+    } else if (typeof val === 'bigint') {
+      display = formatAmount(val, decimals ?? 7);
+    } else {
+      display = String(val);
     }
     text = text.replace(new RegExp(`\\{${key}\\}`, 'g'), display);
   }

--- a/tests/args-decoder.test.ts
+++ b/tests/args-decoder.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import { xdr, nativeToScVal, Address, Keypair } from '@stellar/stellar-sdk';
+import { decodeScVal, decodeTypedArgs, formatAmount } from '../src/indexer/args-decoder';
+import type { AbiParam } from '../src/indexer/registry';
+
+// Stable valid Stellar address for tests
+const VALID_ADDR = Keypair.random().publicKey();
+
+// ── formatAmount ─────────────────────────────────────────────────────────────
+
+describe('formatAmount', () => {
+  it('formats with 7 decimals (Stellar default)', () => {
+    expect(formatAmount(100_000_000n)).toBe('10.0000000');
+    expect(formatAmount(1n)).toBe('0.0000001');
+    expect(formatAmount(0n)).toBe('0.0000000');
+  });
+
+  it('formats with custom decimals', () => {
+    expect(formatAmount(1_000_000n, 6)).toBe('1.000000');
+    expect(formatAmount(1n, 2)).toBe('0.01');
+  });
+
+  it('returns plain string when decimals=0', () => {
+    expect(formatAmount(42n, 0)).toBe('42');
+  });
+});
+
+// ── decodeScVal ───────────────────────────────────────────────────────────────
+
+describe('decodeScVal — integers', () => {
+  it('decodes i128 with decimals', () => {
+    const val = nativeToScVal(100_000_000n, { type: 'i128' });
+    const result = decodeScVal(val, { name: 'amount', type: 'i128' }, 7);
+    expect(result.raw).toBe(100_000_000n);
+    expect(result.formatted).toBe('10.0000000');
+  });
+
+  it('decodes u128 without decimals', () => {
+    const val = nativeToScVal(999n, { type: 'u128' });
+    const result = decodeScVal(val, { name: 'amount', type: 'u128' });
+    expect(result.formatted).toBe('0.0000999'); // default 7 decimals
+  });
+
+  it('decodes u32', () => {
+    const val = nativeToScVal(42, { type: 'u32' });
+    const result = decodeScVal(val, { name: 'ledger', type: 'u32' });
+    expect(result.raw).toBe(42);
+    expect(result.formatted).toBe('42');
+  });
+
+  it('decodes i64', () => {
+    const val = nativeToScVal(BigInt(-9999), { type: 'i64' });
+    const result = decodeScVal(val, { name: 'ts', type: 'i64' });
+    expect(result.raw).toBe(-9999n);
+    expect(result.formatted).toBe('-9999');
+  });
+});
+
+describe('decodeScVal — address', () => {
+  it('decodes a Stellar address', () => {
+    const val = new Address(VALID_ADDR).toScVal();
+    const result = decodeScVal(val, { name: 'from', type: 'address' });
+    expect(result.raw).toBe(VALID_ADDR);
+    expect(result.formatted).toBe(VALID_ADDR);
+  });
+});
+
+describe('decodeScVal — bool', () => {
+  it('decodes true/false', () => {
+    expect(decodeScVal(nativeToScVal(true), { name: 'flag', type: 'bool' }).formatted).toBe('true');
+    expect(decodeScVal(nativeToScVal(false), { name: 'flag', type: 'bool' }).formatted).toBe('false');
+  });
+});
+
+describe('decodeScVal — string & symbol', () => {
+  it('decodes string', () => {
+    const val = nativeToScVal('hello', { type: 'string' });
+    const result = decodeScVal(val, { name: 'msg', type: 'string' });
+    expect(result.formatted).toBe('hello');
+  });
+
+  it('decodes symbol', () => {
+    const val = nativeToScVal('swap', { type: 'symbol' });
+    const result = decodeScVal(val, { name: 'action', type: 'symbol' });
+    expect(result.formatted).toBe('swap');
+  });
+});
+
+describe('decodeScVal — bytes', () => {
+  it('decodes bytes as hex', () => {
+    const val = nativeToScVal(Buffer.from('deadbeef', 'hex'), { type: 'bytes' });
+    const result = decodeScVal(val, { name: 'hash', type: 'bytes' });
+    expect(result.formatted).toBe('0xdeadbeef');
+  });
+});
+
+describe('decodeScVal — struct', () => {
+  it('decodes a scvMap as struct', () => {
+    // Build a proper scvMap with symbol keys (as Soroban structs are encoded)
+    const val = xdr.ScVal.scvMap([
+      new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('x'), val: nativeToScVal(1n, { type: 'i128' }) }),
+      new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('y'), val: nativeToScVal(2n, { type: 'i128' }) }),
+    ]);
+    const result = decodeScVal(val, { name: 'point', type: 'struct' });
+    expect(result.raw).toMatchObject({ x: 1n, y: 2n });
+  });
+});
+
+describe('decodeScVal — map', () => {
+  it('decodes a generic map', () => {
+    const val = nativeToScVal({ key1: 'val1', key2: 'val2' }, { type: 'map' });
+    const result = decodeScVal(val, { name: 'data', type: 'map' });
+    expect(result.raw).toMatchObject({ key1: 'val1', key2: 'val2' });
+  });
+});
+
+describe('decodeScVal — vec', () => {
+  it('decodes a vec', () => {
+    // Build scvVec manually — nativeToScVal doesn't accept 'vec' as a type hint
+    const val = xdr.ScVal.scvVec([
+      nativeToScVal(1n, { type: 'i128' }),
+      nativeToScVal(2n, { type: 'i128' }),
+      nativeToScVal(3n, { type: 'i128' }),
+    ]);
+    const result = decodeScVal(val, { name: 'items', type: 'vec' });
+    expect(result.formatted).toBe('[1, 2, 3]');
+  });
+});
+
+describe('decodeScVal — option', () => {
+  it('returns None for scvVoid', () => {
+    const val = xdr.ScVal.scvVoid();
+    const result = decodeScVal(val, { name: 'opt', type: 'option<u32>' });
+    expect(result.raw).toBeNull();
+    expect(result.formatted).toBe('None');
+  });
+
+  it('unwraps Some(u32)', () => {
+    const val = nativeToScVal(7, { type: 'u32' });
+    const result = decodeScVal(val, { name: 'opt', type: 'option<u32>' });
+    expect(result.formatted).toBe('7');
+  });
+});
+
+describe('decodeScVal — enum', () => {
+  it('decodes a unit enum variant', () => {
+    // Soroban unit enum: scvVec([scvSymbol("Active")])
+    const inner = xdr.ScVal.scvSymbol('Active');
+    const val = xdr.ScVal.scvVec([inner]);
+    const result = decodeScVal(val, { name: 'status', type: 'enum' });
+    expect((result.raw as { variant: string }).variant).toBe('Active');
+  });
+
+  it('decodes an enum variant with value', () => {
+    const inner = xdr.ScVal.scvSymbol('Amount');
+    const amount = nativeToScVal(500n, { type: 'i128' });
+    const val = xdr.ScVal.scvVec([inner, amount]);
+    const result = decodeScVal(val, { name: 'action', type: 'enum' });
+    expect((result.raw as { variant: string; value: unknown }).variant).toBe('Amount');
+  });
+});
+
+describe('decodeScVal — fallback on bad XDR', () => {
+  it('returns base64 XDR on decode error', () => {
+    // Pass a void val for an address type — Address.fromScVal will throw
+    const val = xdr.ScVal.scvVoid();
+    const result = decodeScVal(val, { name: 'addr', type: 'address' });
+    expect(typeof result.formatted).toBe('string');
+    expect(result.formatted.length).toBeGreaterThan(0);
+  });
+});
+
+// ── decodeTypedArgs ───────────────────────────────────────────────────────────
+
+describe('decodeTypedArgs', () => {
+  it('pairs params with ScVals and returns DecodedArg map', () => {
+    const params: AbiParam[] = [
+      { name: 'from', type: 'address' },
+      { name: 'to', type: 'address' },
+      { name: 'amount', type: 'i128' },
+    ];
+    const addrScVal = new Address(VALID_ADDR).toScVal();
+    const rawArgs = [
+      addrScVal,
+      addrScVal,
+      nativeToScVal(10_000_000n, { type: 'i128' }),
+    ];
+
+    const result = decodeTypedArgs(params, rawArgs, 7);
+
+    expect(result.from.formatted).toBe(VALID_ADDR);
+    expect(result.to.formatted).toBe(VALID_ADDR);
+    expect(result.amount.formatted).toBe('1.0000000');
+  });
+
+  it('skips missing args gracefully', () => {
+    const params: AbiParam[] = [
+      { name: 'a', type: 'u32' },
+      { name: 'b', type: 'u32' },
+    ];
+    const result = decodeTypedArgs(params, [nativeToScVal(1, { type: 'u32' })]);
+    expect(result.a.formatted).toBe('1');
+    expect(result.b).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #35

---

## Summary
Implements the core algorithm that pairs raw transaction arguments with the contract ABI and outputs typed key-value pairs with human-readable formatting.

## Changes
- **`src/indexer/args-decoder.ts`** — new typed decoder
  - `decodeScVal(val, param, decimals?)` dispatches on ABI param type → `{ raw, formatted }`
  - `decodeTypedArgs(params, rawArgs, decimals?)` — entry point for full arg maps
  - `formatAmount` — pure BigInt decimal shifting (e.g. `100_000_000n` → `"10.0000000"`)
  - Handles: `i128/u128` (decimal), `i64/u64`, `i32/u32`, `address`, `bool`, `bytes`, `string`, `symbol`, `enum`, `struct`, `map`, `vec`, `option<T>`
  - Fallback to raw base64 XDR on any decode error — never throws
- **`src/indexer/registry.ts`** — `decodeArgs` and `renderHuman` updated to use typed decoder
- **`src/indexer/decoder.ts`** — passes `tokenDecimals` to `decodeArgs`
- **`tests/args-decoder.test.ts`** — 22 tests covering all ScVal edge cases

## Test Results
28/28 tests pass (22 new + 6 existing)