### PR TITLE
WebSocket server for live contract event streaming (#41)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { createServer } from 'http';
 import cors from 'cors';
 import helmet from 'helmet';
 import morgan from 'morgan';
@@ -7,6 +8,7 @@ import { config } from './config';
 import { router } from './api/router';
 import { prisma } from './db';
 import { startIndexerService } from './indexer/indexer';
+import { attachWebSocketServer } from './ws/eventBroadcaster';
 
 const app = express();
 
@@ -31,8 +33,12 @@ async function main() {
   await prisma.$connect();
   startIndexerService().catch((err) => console.error('Indexer service failed:', err));
 
-  app.listen(config.port, () => {
+  const httpServer = createServer(app);
+  attachWebSocketServer(httpServer);
+
+  httpServer.listen(config.port, () => {
     console.log(`🚀 Soroban Explorer API running on port ${config.port}`);
+    console.log(`🔌 WebSocket event stream available at ws://localhost:${config.port}/ws/events`);
   });
 }
 

--- a/src/indexer/eventIngestor.ts
+++ b/src/indexer/eventIngestor.ts
@@ -2,6 +2,7 @@ import { xdr } from '@stellar/stellar-sdk';
 import { prisma } from '../db';
 import { decodeEvent } from './decoder';
 import { fetchEvents, LedgerEvent } from './rpc';
+import { broadcastEvent } from '../ws/eventBroadcaster';
 
 /**
  * Parse DiagnosticEvents from a raw TransactionMeta XDR (base64).
@@ -125,6 +126,16 @@ async function storeEvent(event: LedgerEvent): Promise<number> {
       ledger: event.ledger,
       ledgerCloseTime: event.ledgerCloseTime,
     },
+  });
+
+  broadcastEvent({
+    id,
+    contractAddress: event.contractId,
+    eventType,
+    decoded,
+    ledger: event.ledger,
+    ledgerCloseTime: event.ledgerCloseTime,
+    transactionHash: event.transactionHash,
   });
 
   return 1;

--- a/src/ws/eventBroadcaster.ts
+++ b/src/ws/eventBroadcaster.ts
@@ -1,0 +1,46 @@
+import { WebSocketServer, WebSocket } from 'ws';
+import { IncomingMessage, Server } from 'http';
+
+// Each client can subscribe to a specific contract address or '*' for all events
+interface Client {
+  ws: WebSocket;
+  contractFilter: string | null; // null = all events
+}
+
+const clients = new Set<Client>();
+
+export function attachWebSocketServer(httpServer: Server): WebSocketServer {
+  const wss = new WebSocketServer({ server: httpServer, path: '/ws/events' });
+
+  wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
+    // Optional: ?contract=CXXX... to filter by contract
+    const url = new URL(req.url ?? '', 'http://localhost');
+    const contractFilter = url.searchParams.get('contract');
+
+    const client: Client = { ws, contractFilter };
+    clients.add(client);
+
+    ws.on('close', () => clients.delete(client));
+    ws.on('error', () => clients.delete(client));
+  });
+
+  return wss;
+}
+
+export function broadcastEvent(event: {
+  id: string;
+  contractAddress: string;
+  eventType: string;
+  decoded: unknown;
+  ledger: number;
+  ledgerCloseTime: Date;
+  transactionHash: string;
+}) {
+  const payload = JSON.stringify({ type: 'event', data: event });
+
+  for (const client of clients) {
+    if (client.ws.readyState !== WebSocket.OPEN) continue;
+    if (client.contractFilter && client.contractFilter !== event.contractAddress) continue;
+    client.ws.send(payload);
+  }
+}


### PR DESCRIPTION
closes #41
- Add src/ws/eventBroadcaster.ts: WebSocket server on /ws/events
  - Clients can filter by ?contract=<address> or receive all events
- Broadcast each stored event to connected clients in eventIngestor.ts
- Switch index.ts to http.createServer so WS and HTTP share one port