### PR TITLE
tiered IP and API-key rate limiting middleware (#47)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,11 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import morgan from 'morgan';
-import rateLimit from 'express-rate-limit';
 import { config } from './config';
 import { router } from './api/router';
 import { prisma } from './db';
 import { startIndexerService } from './indexer/indexer';
+import { tieredRateLimit } from './middleware/rateLimit';
 
 const app = express();
 
@@ -14,12 +14,7 @@ app.use(helmet());
 app.use(cors());
 app.use(morgan('dev'));
 app.use(express.json());
-app.use(rateLimit({
-  windowMs: config.rateLimitWindowMs,
-  max: config.rateLimitMax,
-  standardHeaders: true,
-  legacyHeaders: false,
-}));
+app.use(tieredRateLimit);
 
 app.use('/api/v1', router);
 

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -1,0 +1,43 @@
+import rateLimit from 'express-rate-limit';
+import { Request, Response, NextFunction } from 'express';
+
+/**
+ * API-key tiers (set via X-API-Key header).
+ * Keys are loaded from env: API_KEYS_DEVELOPER, API_KEYS_PREMIUM (comma-separated).
+ */
+const developerKeys = new Set(
+  (process.env.API_KEYS_DEVELOPER ?? '').split(',').filter(Boolean)
+);
+const premiumKeys = new Set(
+  (process.env.API_KEYS_PREMIUM ?? '').split(',').filter(Boolean)
+);
+
+// Tier limits (requests per minute)
+const TIERS = {
+  premium: { windowMs: 60_000, max: 1000 },
+  developer: { windowMs: 60_000, max: 300 },
+  public: { windowMs: 60_000, max: 100 },
+};
+
+function getTier(apiKey: string | undefined): keyof typeof TIERS {
+  if (apiKey && premiumKeys.has(apiKey)) return 'premium';
+  if (apiKey && developerKeys.has(apiKey)) return 'developer';
+  return 'public';
+}
+
+// One limiter instance per tier, keyed by IP + tier
+const limiters = {
+  premium: rateLimit({ ...TIERS.premium, standardHeaders: true, legacyHeaders: false, keyGenerator: (req) => `premium:${req.ip}` }),
+  developer: rateLimit({ ...TIERS.developer, standardHeaders: true, legacyHeaders: false, keyGenerator: (req) => `developer:${req.ip}` }),
+  public: rateLimit({ ...TIERS.public, standardHeaders: true, legacyHeaders: false, keyGenerator: (req) => `public:${req.ip}` }),
+};
+
+/**
+ * Middleware: reads X-API-Key, selects the appropriate rate limiter tier,
+ * and delegates to it.
+ */
+export function tieredRateLimit(req: Request, res: Response, next: NextFunction) {
+  const apiKey = req.headers['x-api-key'] as string | undefined;
+  const tier = getTier(apiKey);
+  return limiters[tier](req, res, next);
+}


### PR DESCRIPTION
closes #47
- Add src/middleware/rateLimit.ts with three tiers:
  - public: 100 req/min (default, IP-based)
  - developer: 300 req/min (X-API-Key in API_KEYS_DEVELOPER env)
  - premium: 1000 req/min (X-API-Key in API_KEYS_PREMIUM env)
- Replace flat rateLimit() in index.ts with tieredRateLimit middleware