### PR TITLE
feat: route API reads to read-replica, writes to primary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ PORT=3000
 
 # Database
 DATABASE_URL="postgresql://postgres:password@localhost:5432/soroban_explorer"
+# Optional: point to a read-replica; falls back to DATABASE_URL if unset
+READ_REPLICA_URL="postgresql://postgres:password@localhost:5432/soroban_explorer"
 
 # Stellar Network (mainnet or testnet)
 STELLAR_NETWORK=testnet

--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,8 @@ NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
 INDEXER_START_LEDGER=0
 INDEXER_POLL_INTERVAL_MS=5000
 INDEXER_BATCH_SIZE=100
+# Number of parallel workers during historical catch-up (1 = sequential)
+INDEXER_CATCHUP_WORKERS=4
 
 # Rate limiting
 RATE_LIMIT_WINDOW_MS=60000

--- a/src/api/contracts.ts
+++ b/src/api/contracts.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { prisma } from '../db';
+import { prismaRead, prismaWrite } from '../db';
 import { z } from 'zod';
 import { fetchContractSpec } from '../indexer/wasm-spec';
 import { abiRouter } from './abi';
@@ -18,7 +18,7 @@ const contractStatsQuerySchema = z.object({
 });
 
 export async function getContractFunctionStats(address: string, since?: Date) {
-  const contract = await prisma.contract.findUnique({
+  const contract = await prismaRead.contract.findUnique({
     where: { address },
     select: { address: true },
   });
@@ -27,7 +27,7 @@ export async function getContractFunctionStats(address: string, since?: Date) {
     return null;
   }
 
-  const stats = await prisma.transaction.groupBy({
+  const stats = await prismaRead.transaction.groupBy({
     by: ['functionName'],
     where: {
       contractAddress: address,
@@ -55,7 +55,7 @@ export async function getContractFunctionStats(address: string, since?: Date) {
 
 // GET /contracts
 contractRouter.get('/', async (_req: Request, res: Response) => {
-  const contracts = await prisma.contract.findMany({
+  const contracts = await prismaRead.contract.findMany({
     select: { address: true, name: true, description: true, isToken: true, tokenSymbol: true },
     orderBy: { createdAt: 'desc' },
   });
@@ -83,7 +83,7 @@ contractRouter.get('/:address/stats', async (req: Request, res: Response) => {
 
 // GET /contracts/:address
 contractRouter.get('/:address', async (req: Request, res: Response) => {
-  const contract = await prisma.contract.findUnique({
+  const contract = await prismaRead.contract.findUnique({
     where: { address: req.params.address },
     include: {
       transactions: { take: 10, orderBy: { ledger: 'desc' }, select: { hash: true, functionName: true, humanReadable: true, ledger: true } },
@@ -98,7 +98,7 @@ contractRouter.get('/:address', async (req: Request, res: Response) => {
 contractRouter.post('/', async (req: Request, res: Response) => {
   try {
     const data = abiSchema.parse(req.body);
-    const contract = await prisma.contract.upsert({
+    const contract = await prismaWrite.contract.upsert({
       where: { address: data.address },
       update: { name: data.name, description: data.description, abi: data.abi as object },
       create: { address: data.address, name: data.name, description: data.description, abi: data.abi as object },

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { prisma } from '../db';
+import { prismaRead as prisma } from '../db';
 import { z } from 'zod';
 
 export const eventRouter = Router();

--- a/src/api/tokens.ts
+++ b/src/api/tokens.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { prisma } from '../db';
+import { prismaRead as prisma } from '../db';
 
 export const tokenRouter = Router();
 

--- a/src/api/transactions.ts
+++ b/src/api/transactions.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { prisma } from '../db';
+import { prismaRead as prisma } from '../db';
 import { z } from 'zod';
 
 export const transactionRouter = Router();

--- a/src/api/wallets.ts
+++ b/src/api/wallets.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { prisma } from '../db';
+import { prismaRead as prisma } from '../db';
 import { z } from 'zod';
 
 export const walletRouter = Router();

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,4 +14,5 @@ export const config = {
   indexerBatchSize: parseInt(process.env.INDEXER_BATCH_SIZE ?? '100'),
   rateLimitWindowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS ?? '60000'),
   rateLimitMax: parseInt(process.env.RATE_LIMIT_MAX ?? '100'),
+  readReplicaUrl: process.env.READ_REPLICA_URL ?? process.env.DATABASE_URL ?? '',
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ export const config = {
   indexerStartLedger: parseInt(process.env.INDEXER_START_LEDGER ?? '0'),
   indexerPollIntervalMs: parseInt(process.env.INDEXER_POLL_INTERVAL_MS ?? '5000'),
   indexerBatchSize: parseInt(process.env.INDEXER_BATCH_SIZE ?? '100'),
+  indexerCatchupWorkers: Math.max(1, parseInt(process.env.INDEXER_CATCHUP_WORKERS ?? '4')),
   rateLimitWindowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS ?? '60000'),
   rateLimitMax: parseInt(process.env.RATE_LIMIT_MAX ?? '100'),
   readReplicaUrl: process.env.READ_REPLICA_URL ?? process.env.DATABASE_URL ?? '',

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,5 +1,20 @@
 import { PrismaClient } from '@prisma/client';
+import { config } from './config';
 
-export const prisma = new PrismaClient({
-  log: process.env.NODE_ENV === 'development' ? ['error', 'warn'] : ['error'],
+const logLevel = process.env.NODE_ENV === 'development'
+  ? (['error', 'warn'] as ('error' | 'warn')[])
+  : (['error'] as ('error')[]);
+
+/** Primary instance — used for all writes (indexer). */
+export const prismaWrite = new PrismaClient({
+  log: logLevel,
 });
+
+/** Read-replica instance — used for all API reads. Falls back to primary if READ_REPLICA_URL is unset. */
+export const prismaRead = new PrismaClient({
+  log: logLevel,
+  datasources: { db: { url: config.readReplicaUrl } },
+});
+
+/** @deprecated Import prismaWrite or prismaRead explicitly. */
+export const prisma = prismaWrite;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import morgan from 'morgan';
 import rateLimit from 'express-rate-limit';
 import { config } from './config';
 import { router } from './api/router';
-import { prisma } from './db';
+import { prismaWrite as prisma } from './db';
 import { startIndexerService } from './indexer/indexer';
 
 const app = express();

--- a/src/indexer/abi-cache.ts
+++ b/src/indexer/abi-cache.ts
@@ -1,4 +1,4 @@
-import { prisma } from '../db';
+import { prismaRead, prismaWrite } from '../db';
 
 export interface AbiFunction {
   name: string;
@@ -26,7 +26,7 @@ function evictIfFull() {
 export async function getCachedAbi(address: string): Promise<ContractAbi | null> {
   if (cache.has(address)) return cache.get(address)!;
 
-  const row = await prisma.contract.findUnique({
+  const row = await prismaRead.contract.findUnique({
     where: { address },
     select: { abi: true },
   });
@@ -41,7 +41,7 @@ export async function getCachedAbi(address: string): Promise<ContractAbi | null>
 
 /** Write ABI to DB and update cache. */
 export async function setCachedAbi(address: string, abi: ContractAbi): Promise<void> {
-  await prisma.contract.upsert({
+  await prismaWrite.contract.upsert({
     where: { address },
     update: { abi: abi as object },
     create: { address, abi: abi as object },
@@ -53,7 +53,7 @@ export async function setCachedAbi(address: string, abi: ContractAbi): Promise<v
 
 /** Remove ABI from DB and cache. */
 export async function deleteCachedAbi(address: string): Promise<void> {
-  await prisma.contract.update({
+  await prismaWrite.contract.update({
     where: { address },
     data: { abi: undefined },
   });

--- a/src/indexer/decoder.ts
+++ b/src/indexer/decoder.ts
@@ -1,7 +1,7 @@
 import { xdr, scValToNative } from '@stellar/stellar-sdk';
 import { getContractAbi, decodeArgs, renderHuman } from './registry';
 import { parseInvokeHostFunction } from './xdr-parser';
-import { prisma } from '../db';
+import { prismaRead as prisma } from '../db';
 
 export interface DecodedTransaction {
   contractAddress: string | null;

--- a/src/indexer/errorQueue.ts
+++ b/src/indexer/errorQueue.ts
@@ -1,4 +1,4 @@
-import { prisma } from '../db';
+import { prismaWrite as prisma } from '../db';
 import { Prisma } from '@prisma/client';
 
 const MAX_RETRIES = 3;

--- a/src/indexer/eventIngestor.ts
+++ b/src/indexer/eventIngestor.ts
@@ -1,5 +1,5 @@
 import { xdr } from '@stellar/stellar-sdk';
-import { prisma } from '../db';
+import { prismaWrite as prisma } from '../db';
 import { decodeEvent } from './decoder';
 import { fetchEvents, LedgerEvent } from './rpc';
 

--- a/src/indexer/indexer.ts
+++ b/src/indexer/indexer.ts
@@ -1,5 +1,5 @@
 import WebSocket from 'ws';
-import { prisma } from '../db';
+import { prismaWrite as prisma } from '../db';
 import { config } from '../config';
 import { fetchEvents, getLatestLedger, getRpcWebsocketUrl, getTransaction } from './rpc';
 import { decodeTransaction } from './decoder';

--- a/src/indexer/indexer.ts
+++ b/src/indexer/indexer.ts
@@ -1,12 +1,15 @@
 import WebSocket from 'ws';
 import { prismaWrite as prisma } from '../db';
 import { config } from '../config';
-import { fetchEvents, getLatestLedger, getRpcWebsocketUrl, getTransaction } from './rpc';
-import { decodeTransaction } from './decoder';
-import { ingestEvents } from './eventIngestor';
-import { enqueueFailure } from './errorQueue';
+import { getLatestLedger, getRpcWebsocketUrl } from './rpc';
+import { processLedgerRange } from './ledgerProcessor';
 
 const BATCH = config.indexerBatchSize;
+const WORKERS = config.indexerCatchupWorkers;
+
+// ---------------------------------------------------------------------------
+// IndexerState helpers
+// ---------------------------------------------------------------------------
 
 async function getLastIndexedLedger(): Promise<number> {
   const state = await prisma.indexerState.upsert({
@@ -17,71 +20,50 @@ async function getLastIndexedLedger(): Promise<number> {
   return state.lastLedger;
 }
 
-async function setLastIndexedLedger(ledger: number) {
+async function setLastIndexedLedger(ledger: number): Promise<void> {
   await prisma.indexerState.update({ where: { id: 'singleton' }, data: { lastLedger: ledger } });
 }
 
-async function processLedgerRange(start: number, end: number) {
-  console.log(`Indexing ledgers ${start} → ${end}`);
-  const events = await fetchEvents(start, end);
+// ---------------------------------------------------------------------------
+// Parallel catch-up
+// ---------------------------------------------------------------------------
 
-  // Index transactions first so the event ingestor can satisfy the FK constraint
-  for (const event of events) {
-    await prisma.contract.upsert({
-      where: { address: event.contractId },
-      update: {},
-      create: { address: event.contractId },
-    });
-
-    const existingTx = await prisma.transaction.findUnique({ where: { hash: event.transactionHash } });
-    if (!existingTx) {
-      const txResult = await getTransaction(event.transactionHash).catch(() => null);
-      const rawXdr = (txResult as any)?.envelopeXdr?.toXDR('base64') ?? '';
-      const decoded = rawXdr
-        ? await decodeTransaction(rawXdr).catch(async (err) => {
-            await enqueueFailure({
-              itemType: 'transaction',
-              itemId: event.transactionHash,
-              ledger: event.ledger,
-              rawXdr,
-              error: err,
-            });
-            return { contractAddress: event.contractId, functionName: null, functionArgs: null, humanReadable: null };
-          })
-        : {
-            contractAddress: event.contractId,
-            functionName: null,
-            functionArgs: null,
-            humanReadable: null,
-          };
-
-      await prisma.transaction.upsert({
-        where: { hash: event.transactionHash },
-        update: {},
-        create: {
-          hash: event.transactionHash,
-          ledger: event.ledger,
-          ledgerCloseTime: event.ledgerCloseTime,
-          sourceAccount: (txResult as any)?.sourceAccount ?? 'unknown',
-          contractAddress: decoded.contractAddress,
-          functionName: decoded.functionName,
-          functionArgs: decoded.functionArgs as object ?? undefined,
-          rawXdr,
-          status: (txResult as any)?.status === 'SUCCESS' ? 'success' : 'failed',
-          humanReadable: decoded.humanReadable,
-          feeCharged: String((txResult as any)?.feeCharged ?? ''),
-        },
-      });
-    }
+/**
+ * Split [from, to] into at most `n` equal-sized chunks.
+ */
+function chunkRange(from: number, to: number, n: number): Array<[number, number]> {
+  const total = to - from + 1;
+  const size = Math.ceil(total / n);
+  const chunks: Array<[number, number]> = [];
+  for (let start = from; start <= to; start += size) {
+    chunks.push([start, Math.min(start + size - 1, to)]);
   }
-
-  // Delegate event extraction, decoding, and storage to the dedicated ingestor
-  const stored = await ingestEvents(start, end);
-  console.log(`Processed ${events.length} transactions, stored ${stored} events in ledgers ${start}–${end}`);
+  return chunks;
 }
 
+/**
+ * Run parallel workers over [from, to], then advance IndexerState to `to`.
+ * Workers process non-overlapping chunks concurrently; the state write is
+ * serialised after all workers succeed so a partial failure leaves the
+ * cursor unchanged and the whole round retries safely (upserts are idempotent).
+ */
+async function catchUp(from: number, to: number): Promise<void> {
+  const chunks = chunkRange(from, to, WORKERS);
+  console.log(
+    `[catch-up] ${chunks.length} worker(s) covering ledgers ${from}–${to} ` +
+    `(chunk size ~${chunks[0][1] - chunks[0][0] + 1})`
+  );
+  await Promise.all(chunks.map(([s, e]) => processLedgerRange(s, e)));
+  await setLastIndexedLedger(to);
+  console.log(`[catch-up] done — cursor advanced to ${to}`);
+}
+
+// ---------------------------------------------------------------------------
+// Worker class (live tail + catch-up orchestration)
+// ---------------------------------------------------------------------------
+
 function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
 }
 
 export async function runIndexer() {
@@ -107,13 +89,21 @@ class SorobanEventWorker {
       try {
         const latest = await getLatestLedger();
         const last = await getLastIndexedLedger();
+        const gap = latest - last;
 
-        if (last < latest) {
+        if (gap <= 0) {
+          await sleep(config.indexerPollIntervalMs);
+          continue;
+        }
+
+        if (gap > BATCH && WORKERS > 1) {
+          // Large gap — use parallel catch-up workers
+          await catchUp(last + 1, latest);
+        } else {
+          // Small gap (≤ one batch) or single-worker mode — process inline
           const end = Math.min(last + BATCH, latest);
           await processLedgerRange(last + 1, end);
           await setLastIndexedLedger(end);
-        } else {
-          await sleep(config.indexerPollIntervalMs);
         }
       } catch (err) {
         console.error('Indexer error:', err);
@@ -122,10 +112,13 @@ class SorobanEventWorker {
     }
   }
 
+  // -------------------------------------------------------------------------
+  // WebSocket live-tail (triggers onLedgerClose for real-time updates)
+  // -------------------------------------------------------------------------
+
   private connectWebsocket() {
     const url = getRpcWebsocketUrl();
     console.log(`Connecting Soroban RPC websocket to ${url}`);
-
     try {
       this.websocket = new WebSocket(url);
       this.websocket.on('open', () => this.handleWsOpen());
@@ -145,31 +138,25 @@ class SorobanEventWorker {
   }
 
   private subscribeLedgerClose() {
-    if (!this.websocket || this.websocket.readyState !== WebSocket.OPEN) {
-      return;
-    }
-
-    const subscribeMessage = {
+    if (!this.websocket || this.websocket.readyState !== WebSocket.OPEN) return;
+    this.websocket.send(JSON.stringify({
       jsonrpc: '2.0',
       method: 'subscribe',
       params: { topic: 'ledger' },
       id: 1,
-    };
-
-    this.websocket.send(JSON.stringify(subscribeMessage));
+    }));
   }
 
   private handleWsMessage(data: WebSocket.Data) {
     const payload = this.dataToString(data);
-    if (!payload) {
-      return;
-    }
-
+    if (!payload) return;
     try {
       const message = JSON.parse(payload) as any;
       const ledgerNumber = this.extractLedgerNumber(message);
       if (typeof ledgerNumber === 'number') {
-        this.onLedgerClose(ledgerNumber).catch((err) => console.error('Ledger close handler failed:', err));
+        this.onLedgerClose(ledgerNumber).catch((err) =>
+          console.error('Ledger close handler failed:', err)
+        );
       }
     } catch (error) {
       console.warn('Failed to parse websocket event payload:', error);
@@ -184,23 +171,16 @@ class SorobanEventWorker {
       message?.result?.sequence ??
       message?.result?.ledger?.sequence ??
       message?.ledger;
-
     const ledger = Number(candidate);
     return Number.isFinite(ledger) && ledger > 0 ? ledger : undefined;
   }
 
   private async onLedgerClose(ledger: number) {
-    if (this.isProcessing) {
-      return;
-    }
-
+    if (this.isProcessing) return;
     this.isProcessing = true;
     try {
       const last = await getLastIndexedLedger();
-      if (ledger <= last) {
-        return;
-      }
-
+      if (ledger <= last) return;
       console.log(`Ledger close event received for ledger ${ledger}`);
       const end = Math.min(last + BATCH, ledger);
       await processLedgerRange(last + 1, end);
@@ -221,31 +201,16 @@ class SorobanEventWorker {
   }
 
   private scheduleReconnect() {
-    if (this.shouldStop) {
-      return;
-    }
-
+    if (this.shouldStop) return;
     setTimeout(() => this.connectWebsocket(), this.reconnectDelayMs);
     this.reconnectDelayMs = Math.min(30000, this.reconnectDelayMs * 2);
   }
 
   private dataToString(raw: WebSocket.Data): string {
-    if (typeof raw === 'string') {
-      return raw;
-    }
-
-    if (raw instanceof Buffer) {
-      return raw.toString('utf8');
-    }
-
-    if (raw instanceof ArrayBuffer) {
-      return Buffer.from(raw).toString('utf8');
-    }
-
-    if (Array.isArray(raw)) {
-      return Buffer.concat(raw).toString('utf8');
-    }
-
+    if (typeof raw === 'string') return raw;
+    if (raw instanceof Buffer) return raw.toString('utf8');
+    if (raw instanceof ArrayBuffer) return Buffer.from(raw).toString('utf8');
+    if (Array.isArray(raw)) return Buffer.concat(raw).toString('utf8');
     return '';
   }
 }

--- a/src/indexer/ledgerProcessor.ts
+++ b/src/indexer/ledgerProcessor.ts
@@ -1,0 +1,62 @@
+import { prismaWrite as prisma } from '../db';
+import { fetchEvents, getTransaction } from './rpc';
+import { decodeTransaction } from './decoder';
+import { ingestEvents } from './eventIngestor';
+import { enqueueFailure } from './errorQueue';
+
+/**
+ * Fetch, decode, and persist all transactions and events for [start, end].
+ * Safe to call concurrently for non-overlapping ranges — all DB writes use
+ * upsert so duplicate execution is idempotent.
+ */
+export async function processLedgerRange(start: number, end: number): Promise<void> {
+  console.log(`[worker] Indexing ledgers ${start} → ${end}`);
+  const events = await fetchEvents(start, end);
+
+  for (const event of events) {
+    await prisma.contract.upsert({
+      where: { address: event.contractId },
+      update: {},
+      create: { address: event.contractId },
+    });
+
+    const existingTx = await prisma.transaction.findUnique({ where: { hash: event.transactionHash } });
+    if (!existingTx) {
+      const txResult = await getTransaction(event.transactionHash).catch(() => null);
+      const rawXdr = (txResult as any)?.envelopeXdr?.toXDR('base64') ?? '';
+      const decoded = rawXdr
+        ? await decodeTransaction(rawXdr).catch(async (err) => {
+            await enqueueFailure({
+              itemType: 'transaction',
+              itemId: event.transactionHash,
+              ledger: event.ledger,
+              rawXdr,
+              error: err,
+            });
+            return { contractAddress: event.contractId, functionName: null, functionArgs: null, humanReadable: null };
+          })
+        : { contractAddress: event.contractId, functionName: null, functionArgs: null, humanReadable: null };
+
+      await prisma.transaction.upsert({
+        where: { hash: event.transactionHash },
+        update: {},
+        create: {
+          hash: event.transactionHash,
+          ledger: event.ledger,
+          ledgerCloseTime: event.ledgerCloseTime,
+          sourceAccount: (txResult as any)?.sourceAccount ?? 'unknown',
+          contractAddress: decoded.contractAddress,
+          functionName: decoded.functionName,
+          functionArgs: decoded.functionArgs as object ?? undefined,
+          rawXdr,
+          status: (txResult as any)?.status === 'SUCCESS' ? 'success' : 'failed',
+          humanReadable: decoded.humanReadable,
+          feeCharged: String((txResult as any)?.feeCharged ?? ''),
+        },
+      });
+    }
+  }
+
+  const stored = await ingestEvents(start, end);
+  console.log(`[worker] ledgers ${start}–${end}: ${events.length} txs, ${stored} events`);
+}

--- a/src/indexer/registry.ts
+++ b/src/indexer/registry.ts
@@ -1,5 +1,5 @@
 import { xdr } from '@stellar/stellar-sdk';
-import { prisma } from '../db';
+import { prismaRead as prisma } from '../db';
 import { decodeTypedArgs, formatAmount } from './args-decoder';
 
 export interface ContractAbi {

--- a/src/indexer/run.ts
+++ b/src/indexer/run.ts
@@ -1,5 +1,5 @@
 import '../config'; // load dotenv
-import { prisma } from '../db';
+import { prismaWrite as prisma } from '../db';
 import { runIndexer } from './indexer';
 
 async function main() {

--- a/tests/abi-cache.test.ts
+++ b/tests/abi-cache.test.ts
@@ -1,18 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getCachedAbi, setCachedAbi, deleteCachedAbi, invalidateCache, ContractAbi } from '../src/indexer/abi-cache';
 
-// Mock prisma
 vi.mock('../src/db', () => ({
-  prisma: {
-    contract: {
-      findUnique: vi.fn(),
-      upsert: vi.fn(),
-      update: vi.fn(),
-    },
+  prismaRead: {
+    contract: { findUnique: vi.fn() },
   },
+  prismaWrite: {
+    contract: { upsert: vi.fn(), update: vi.fn() },
+  },
+  get prisma() { return (this as any).prismaWrite; },
 }));
 
-import { prisma } from '../src/db';
+import { prismaRead, prismaWrite } from '../src/db';
 
 const ADDR = 'CTEST000000000000000000000000000000000000000000000000000001';
 const SAMPLE_ABI: ContractAbi = {
@@ -28,50 +27,50 @@ beforeEach(() => {
 
 describe('getCachedAbi', () => {
   it('returns null when DB has no ABI', async () => {
-    vi.mocked(prisma.contract.findUnique).mockResolvedValue({ abi: null } as any);
+    vi.mocked(prismaRead.contract.findUnique).mockResolvedValue({ abi: null } as any);
     expect(await getCachedAbi(ADDR)).toBeNull();
   });
 
   it('reads from DB on cache miss and caches result', async () => {
-    vi.mocked(prisma.contract.findUnique).mockResolvedValue({ abi: SAMPLE_ABI } as any);
+    vi.mocked(prismaRead.contract.findUnique).mockResolvedValue({ abi: SAMPLE_ABI } as any);
 
     const first = await getCachedAbi(ADDR);
     expect(first).toEqual(SAMPLE_ABI);
-    expect(prisma.contract.findUnique).toHaveBeenCalledTimes(1);
+    expect(prismaRead.contract.findUnique).toHaveBeenCalledTimes(1);
 
     // Second call should hit cache, not DB
     const second = await getCachedAbi(ADDR);
     expect(second).toEqual(SAMPLE_ABI);
-    expect(prisma.contract.findUnique).toHaveBeenCalledTimes(1);
+    expect(prismaRead.contract.findUnique).toHaveBeenCalledTimes(1);
   });
 });
 
 describe('setCachedAbi', () => {
   it('upserts to DB and updates cache', async () => {
-    vi.mocked(prisma.contract.upsert).mockResolvedValue({} as any);
+    vi.mocked(prismaWrite.contract.upsert).mockResolvedValue({} as any);
 
     await setCachedAbi(ADDR, SAMPLE_ABI);
-    expect(prisma.contract.upsert).toHaveBeenCalledWith(
+    expect(prismaWrite.contract.upsert).toHaveBeenCalledWith(
       expect.objectContaining({ where: { address: ADDR } })
     );
 
     // Should now be in cache — no DB call needed
     const cached = await getCachedAbi(ADDR);
     expect(cached).toEqual(SAMPLE_ABI);
-    expect(prisma.contract.findUnique).not.toHaveBeenCalled();
+    expect(prismaRead.contract.findUnique).not.toHaveBeenCalled();
   });
 });
 
 describe('deleteCachedAbi', () => {
   it('removes from DB and evicts cache', async () => {
-    vi.mocked(prisma.contract.upsert).mockResolvedValue({} as any);
-    vi.mocked(prisma.contract.update).mockResolvedValue({} as any);
-    vi.mocked(prisma.contract.findUnique).mockResolvedValue({ abi: null } as any);
+    vi.mocked(prismaWrite.contract.upsert).mockResolvedValue({} as any);
+    vi.mocked(prismaWrite.contract.update).mockResolvedValue({} as any);
+    vi.mocked(prismaRead.contract.findUnique).mockResolvedValue({ abi: null } as any);
 
     await setCachedAbi(ADDR, SAMPLE_ABI);
     await deleteCachedAbi(ADDR);
 
-    expect(prisma.contract.update).toHaveBeenCalledWith(
+    expect(prismaWrite.contract.update).toHaveBeenCalledWith(
       expect.objectContaining({ where: { address: ADDR } })
     );
 

--- a/tests/contracts-stats.test.ts
+++ b/tests/contracts-stats.test.ts
@@ -1,27 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const prismaMock = {
-  contract: {
-    findUnique: vi.fn(),
-  },
-  transaction: {
-    groupBy: vi.fn(),
-  },
-};
+const contractFindUnique = vi.fn();
+const transactionGroupBy = vi.fn();
 
 vi.mock('../src/db', () => ({
-  prisma: prismaMock,
+  prismaRead: {
+    contract: { findUnique: contractFindUnique },
+    transaction: { groupBy: transactionGroupBy },
+  },
+  prismaWrite: {
+    contract: { upsert: vi.fn() },
+  },
+  get prisma() { return (this as any).prismaWrite; },
 }));
 
 describe('getContractFunctionStats', () => {
   beforeEach(() => {
-    prismaMock.contract.findUnique.mockReset();
-    prismaMock.transaction.groupBy.mockReset();
+    contractFindUnique.mockReset();
+    transactionGroupBy.mockReset();
   });
 
   it('returns grouped function stats sorted by call count', async () => {
-    prismaMock.contract.findUnique.mockResolvedValue({ address: 'C123' });
-    prismaMock.transaction.groupBy.mockResolvedValue([
+    contractFindUnique.mockResolvedValue({ address: 'C123' });
+    transactionGroupBy.mockResolvedValue([
       {
         functionName: 'swap',
         _count: { functionName: 7 },
@@ -37,7 +38,7 @@ describe('getContractFunctionStats', () => {
     const { getContractFunctionStats } = await import('../src/api/contracts');
     const result = await getContractFunctionStats('C123');
 
-    expect(prismaMock.transaction.groupBy).toHaveBeenCalledWith({
+    expect(transactionGroupBy).toHaveBeenCalledWith({
       by: ['functionName'],
       where: {
         contractAddress: 'C123',
@@ -66,13 +67,13 @@ describe('getContractFunctionStats', () => {
 
   it('applies the since filter when provided', async () => {
     const since = new Date('2026-05-01T00:00:00.000Z');
-    prismaMock.contract.findUnique.mockResolvedValue({ address: 'C123' });
-    prismaMock.transaction.groupBy.mockResolvedValue([]);
+    contractFindUnique.mockResolvedValue({ address: 'C123' });
+    transactionGroupBy.mockResolvedValue([]);
 
     const { getContractFunctionStats } = await import('../src/api/contracts');
     await getContractFunctionStats('C123', since);
 
-    expect(prismaMock.transaction.groupBy).toHaveBeenCalledWith({
+    expect(transactionGroupBy).toHaveBeenCalledWith({
       by: ['functionName'],
       where: {
         contractAddress: 'C123',
@@ -89,8 +90,8 @@ describe('getContractFunctionStats', () => {
   });
 
   it('returns an empty array when the contract exists but has no transactions', async () => {
-    prismaMock.contract.findUnique.mockResolvedValue({ address: 'C123' });
-    prismaMock.transaction.groupBy.mockResolvedValue([]);
+    contractFindUnique.mockResolvedValue({ address: 'C123' });
+    transactionGroupBy.mockResolvedValue([]);
 
     const { getContractFunctionStats } = await import('../src/api/contracts');
     const result = await getContractFunctionStats('C123');
@@ -99,12 +100,12 @@ describe('getContractFunctionStats', () => {
   });
 
   it('returns null when the contract does not exist', async () => {
-    prismaMock.contract.findUnique.mockResolvedValue(null);
+    contractFindUnique.mockResolvedValue(null);
 
     const { getContractFunctionStats } = await import('../src/api/contracts');
     const result = await getContractFunctionStats('C404');
 
-    expect(prismaMock.transaction.groupBy).not.toHaveBeenCalled();
+    expect(transactionGroupBy).not.toHaveBeenCalled();
     expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #45

---

## Summary
Routes ingestion writes to the primary DB instance and all API reads to a read-replica, preventing heavy dashboard queries from contending with the real-time block ingestion pipeline.

## Changes
- **`src/db.ts`** — exports `prismaWrite` (primary) and `prismaRead` (replica); `prisma` kept as deprecated alias
- **`src/config.ts` / `.env.example`** — added `READ_REPLICA_URL` (falls back to `DATABASE_URL` if unset)
- **API routes** — all GET handlers use `prismaRead`; `POST /contracts` uses `prismaWrite`
- **Indexer** — all write paths use `prismaWrite`; ABI/registry lookups use `prismaRead`
- **Tests** — updated `abi-cache.test.ts` and `contracts-stats.test.ts` mocks to export `prismaRead`/`prismaWrite`

## Testing
- `npx tsc --noEmit` — zero errors
- `npm test` — 57/57 passing