### PR TITLE
feat: cross contract call stack visualizer

### DIFF
--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -5,6 +5,7 @@ import { contractRouter } from './contracts';
 import { walletRouter } from './wallets';
 import { tokenRouter } from './tokens';
 import { renderRouter } from './render';
+import { simulateRouter } from './simulate';
 
 export const router = Router();
 
@@ -14,3 +15,4 @@ router.use('/contracts', contractRouter);
 router.use('/wallets', walletRouter);
 router.use('/tokens', tokenRouter);
 router.use('/render', renderRouter);
+router.use('/simulate', simulateRouter);

--- a/src/api/simulate.ts
+++ b/src/api/simulate.ts
@@ -1,0 +1,165 @@
+import { Router, Request, Response } from 'express';
+import { xdr, Transaction, FeeBumpTransaction, SorobanRpc } from '@stellar/stellar-sdk';
+import { rpc } from '../indexer/rpc';
+import { config } from '../config';
+import { parseInvokeHostFunction } from '../indexer/xdr-parser';
+import { getContractAbi } from '../indexer/registry';
+import { decodeScVal } from '../indexer/args-decoder';
+import { formatFootprint } from '../indexer/footprint-formatter';
+import { generateAuthSnapshots } from '../indexer/auth-snippet-gen';
+import { parseCallTrace } from '../indexer/call-trace';
+import { prisma } from '../db';
+
+export const simulateRouter = Router();
+
+// ── Param diagnostics ─────────────────────────────────────────────────────────
+
+interface ParamDiagnostic {
+  index: number; name: string; expectedType: string;
+  providedType: string; value: unknown; issue: string;
+}
+
+const XDR_TYPE_MAP: Record<string, string[]> = {
+  address: ['scvAddress'], bool: ['scvBool'],
+  i128: ['scvI128'], u128: ['scvU128'], i64: ['scvI64'], u64: ['scvU64'],
+  i32: ['scvI32'], u32: ['scvU32'], string: ['scvString'],
+  symbol: ['scvSymbol'], bytes: ['scvBytes'], void: ['scvVoid'],
+};
+
+function detectTypeMismatch(abiType: string, xdrType: string, value: unknown): string | null {
+  const allowed = XDR_TYPE_MAP[abiType.toLowerCase()];
+  if (!allowed) return null;
+  if (!allowed.includes(xdrType))
+    return `Type mismatch: expected ${abiType} (${allowed.join('|')}) but got ${xdrType}`;
+  if (['u32','u64','u128'].includes(abiType) && typeof value === 'bigint' && value < 0n)
+    return `Value ${value} is negative but ${abiType} must be ≥ 0`;
+  return null;
+}
+
+function diagnoseArgs(
+  fnName: string, rawArgs: xdr.ScVal[],
+  abi: Awaited<ReturnType<typeof getContractAbi>>, decimals?: number,
+): ParamDiagnostic[] {
+  if (!abi) return [];
+  const fn = abi.functions.find((f) => f.name === fnName);
+  if (!fn) return [];
+  const issues: ParamDiagnostic[] = [];
+  for (let i = 0; i < fn.inputs.length; i++) {
+    const param = fn.inputs[i];
+    const val = rawArgs[i];
+    if (!val) {
+      issues.push({ index: i, name: param.name, expectedType: param.type,
+        providedType: 'missing', value: undefined,
+        issue: `Missing required argument "${param.name}" (expected ${param.type})` });
+      continue;
+    }
+    const decoded = decodeScVal(val, param, decimals);
+    const mismatch = detectTypeMismatch(param.type, val.switch().name, decoded.raw);
+    if (mismatch)
+      issues.push({ index: i, name: param.name, expectedType: param.type,
+        providedType: val.switch().name, value: decoded.formatted, issue: mismatch });
+  }
+  if (rawArgs.length > fn.inputs.length)
+    issues.push({ index: fn.inputs.length, name: '(extra)', expectedType: 'none',
+      providedType: 'extra', value: null,
+      issue: `${rawArgs.length - fn.inputs.length} unexpected extra argument(s) passed to "${fnName}"` });
+  return issues;
+}
+
+// ── Route ─────────────────────────────────────────────────────────────────────
+
+/**
+ * POST /api/v1/simulate
+ * Body: { transaction: "<base64 XDR>" }
+ *
+ * Proxies to Soroban RPC simulateTransaction and overlays:
+ *   - Resource footprint with % of protocol limits
+ *   - Chronological call-stack trace with per-event resource deltas
+ *   - Recording-mode auth snapshots with JS/Rust signing snippets
+ *   - On failure: ABI-aware per-param diagnostics
+ */
+simulateRouter.post('/', async (req: Request, res: Response) => {
+  const { transaction } = req.body as { transaction?: string };
+  if (!transaction || typeof transaction !== 'string')
+    return res.status(400).json({ error: 'Body must include a base64 XDR "transaction" field.' });
+
+  const parsed = parseInvokeHostFunction(transaction);
+
+  let txObj: Transaction | FeeBumpTransaction;
+  try {
+    try { txObj = new Transaction(transaction, config.networkPassphrase); }
+    catch { txObj = new FeeBumpTransaction(transaction, config.networkPassphrase); }
+  } catch (err) {
+    return res.status(400).json({ error: 'Invalid transaction XDR', detail: String(err) });
+  }
+
+  let rpcResult: SorobanRpc.Api.SimulateTransactionResponse;
+  try {
+    rpcResult = await rpc.simulateTransaction(txObj);
+  } catch (err) {
+    return res.status(502).json({ error: 'RPC request failed', detail: String(err) });
+  }
+
+  // ── Success ───────────────────────────────────────────────────────────────
+  if (SorobanRpc.Api.isSimulationSuccess(rpcResult) || SorobanRpc.Api.isSimulationRestore(rpcResult)) {
+    const footprint = formatFootprint(rpcResult);
+    const authSnapshots = rpcResult.result?.auth
+      ? generateAuthSnapshots(rpcResult.result.auth) : [];
+
+    // Build call trace from diagnostic events
+    const cpuInsns = Number((rpcResult.cost as SorobanRpc.Api.Cost)?.cpuInsns ?? 0);
+    const memBytes = Number((rpcResult.cost as SorobanRpc.Api.Cost)?.memBytes ?? 0);
+    const callTrace = parseCallTrace(
+      rpcResult.events as xdr.DiagnosticEvent[],
+      cpuInsns || undefined,
+      memBytes || undefined,
+    );
+
+    return res.json({ status: 'success', simulation: rpcResult, footprint, callTrace, authSnapshots, parsed });
+  }
+
+  // ── Failure — diagnostic overlay ──────────────────────────────────────────
+  const rpcError = (rpcResult as SorobanRpc.Api.SimulateTransactionErrorResponse).error;
+
+  // Still parse call trace from diagnostic events on failure (partial trace)
+  const callTrace = parseCallTrace(
+    (rpcResult as SorobanRpc.Api.SimulateTransactionErrorResponse).events as xdr.DiagnosticEvent[],
+  );
+
+  let paramIssues: ParamDiagnostic[] = [];
+  let humanSummary = rpcError;
+
+  if (parsed) {
+    const { contractId, functionName } = parsed;
+    let rawArgs: xdr.ScVal[] = [];
+    try {
+      const envelope = xdr.TransactionEnvelope.fromXDR(transaction, 'base64');
+      const ops = envelope.switch().name === 'envelopeTypeTx'
+        ? envelope.v1().tx().operations() : envelope.v0().tx().operations();
+      const invokeOp = ops.find((op) => op.body().switch().name === 'invokeHostFunction');
+      if (invokeOp)
+        rawArgs = invokeOp.body().invokeHostFunctionOp().hostFunction().invokeContract().args();
+    } catch { /* leave empty */ }
+
+    const [abi, contract] = await Promise.all([
+      getContractAbi(contractId),
+      prisma.contract.findUnique({ where: { address: contractId } }),
+    ]);
+
+    paramIssues = diagnoseArgs(functionName, rawArgs, abi, contract?.tokenDecimals ?? undefined);
+    humanSummary = paramIssues.length > 0
+      ? `Call to "${functionName}" on ${contract?.name ?? contractId} will fail:\n` +
+        paramIssues.map((p) => `  • [arg ${p.index}] ${p.name}: ${p.issue}`).join('\n')
+      : abi
+        ? `Simulation failed for "${functionName}" on ${contract?.name ?? contractId}. ` +
+          `Arguments look structurally valid — likely a contract assertion or missing auth. RPC: ${rpcError}`
+        : rpcError;
+  }
+
+  return res.status(422).json({
+    status: 'failed',
+    callTrace,
+    diagnostics: { rpcError, contract: parsed?.contractId ?? null,
+      function: parsed?.functionName ?? null, paramIssues, humanSummary },
+  });
+});

--- a/src/indexer/auth-snippet-gen.ts
+++ b/src/indexer/auth-snippet-gen.ts
@@ -1,0 +1,85 @@
+import { xdr, StrKey } from '@stellar/stellar-sdk';
+
+export interface AuthSnapshot {
+  entryXdr: string;
+  signerAddress: string;
+  nonce: string | null;
+  contractId: string;
+  functionName: string;
+  jsSnippet: string;
+  rustSnippet: string;
+}
+
+function scAddressToString(addr: xdr.ScAddress): string {
+  return addr.switch().name === 'scAddressTypeAccount'
+    ? StrKey.encodeEd25519PublicKey(addr.accountId().ed25519())
+    : StrKey.encodeContract(addr.contractId());
+}
+
+function buildJsSnippet(xdrStr: string, signer: string, nonce: string | null, contractId: string, fn: string): string {
+  return `\
+// Auth snippet (JS / @stellar/stellar-sdk) — signer: ${signer}  contract: ${contractId}  fn: ${fn}
+import { xdr, Keypair, hash } from '@stellar/stellar-sdk';
+const entry = xdr.SorobanAuthorizationEntry.fromXDR('${xdrStr}', 'base64');
+entry.credentials().address().signatureExpirationLedger(CURRENT_LEDGER + 100);${nonce !== null ? `  // nonce: ${nonce}` : ''}
+const keypair = Keypair.fromSecret('YOUR_SECRET_KEY');
+const preimage = xdr.HashIdPreimage.fromXDR(xdr.HashIdPreimageSorobanAuthorization.toXDR(
+  new xdr.HashIdPreimageSorobanAuthorization({
+    networkId: hash(Buffer.from(NETWORK_PASSPHRASE)),
+    nonce: entry.credentials().address().nonce(),
+    signatureExpirationLedger: entry.credentials().address().signatureExpirationLedger(),
+    invocation: entry.rootInvocation(),
+  })
+));
+const sig = keypair.sign(hash(preimage));
+entry.credentials().address().signature(xdr.ScVal.scvMap([
+  new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('public_key'), val: xdr.ScVal.scvBytes(keypair.rawPublicKey()) }),
+  new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('signature'),  val: xdr.ScVal.scvBytes(sig) }),
+]));
+op.body().invokeHostFunctionOp().auth([entry]);`;
+}
+
+function buildRustSnippet(xdrStr: string, signer: string, nonce: string | null, contractId: string, fn: string): string {
+  return `\
+// Auth snippet (Rust / soroban-sdk) — signer: ${signer}  contract: ${contractId}  fn: ${fn}
+let mut entry = SorobanAuthorizationEntry::from_xdr_base64("${xdrStr}", Limits::none()).unwrap();
+if let SorobanCredentials::Address(ref mut creds) = entry.credentials {
+    creds.signature_expiration_ledger = current_ledger + 100;${nonce !== null ? `  // nonce: ${nonce}` : ''}
+    let preimage = HashIdPreimage::SorobanAuthorization(HashIdPreimageSorobanAuthorization {
+        network_id: Hash(env.ledger().network_id().to_array()),
+        nonce: creds.nonce,
+        signature_expiration_ledger: creds.signature_expiration_ledger,
+        invocation: entry.root_invocation.clone(),
+    });
+    let payload = Sha256::digest(preimage.to_xdr(Limits::none()).unwrap());
+    let sig = keypair.sign(&payload);
+    creds.signature = ScVal::Map(Some(ScMap(vec![
+        ScMapEntry { key: ScVal::Symbol("public_key".into()), val: ScVal::Bytes(keypair.public.to_bytes().to_vec().try_into().unwrap()) },
+        ScMapEntry { key: ScVal::Symbol("signature".into()),  val: ScVal::Bytes(sig.to_bytes().to_vec().try_into().unwrap()) },
+    ].try_into().unwrap())));
+}`;
+}
+
+export function generateAuthSnapshots(authEntries: xdr.SorobanAuthorizationEntry[]): AuthSnapshot[] {
+  return authEntries.map((entry) => {
+    const entryXdr = entry.toXDR('base64');
+    const creds = entry.credentials();
+    let signerAddress = 'source';
+    let nonce: string | null = null;
+    if (creds.switch().name === 'sorobanCredentialsAddress') {
+      signerAddress = scAddressToString(creds.address().address());
+      nonce = creds.address().nonce().toString();
+    }
+    const rootFn = entry.rootInvocation().function();
+    let contractId = 'unknown', functionName = 'unknown';
+    if (rootFn.switch().name === 'sorobanAuthorizedFunctionTypeContractFn') {
+      contractId = StrKey.encodeContract(rootFn.contractFn().contractAddress().contractId());
+      functionName = rootFn.contractFn().functionName().toString();
+    }
+    return {
+      entryXdr, signerAddress, nonce, contractId, functionName,
+      jsSnippet: buildJsSnippet(entryXdr, signerAddress, nonce, contractId, functionName),
+      rustSnippet: buildRustSnippet(entryXdr, signerAddress, nonce, contractId, functionName),
+    };
+  });
+}

--- a/src/indexer/call-trace.ts
+++ b/src/indexer/call-trace.ts
@@ -1,0 +1,152 @@
+import { xdr, StrKey, scValToNative } from '@stellar/stellar-sdk';
+
+export interface CallTraceNode {
+  /** Chronological sequence index (0-based) */
+  seq: number;
+  /** Nesting depth — 0 = root call, 1 = first cross-contract call, etc. */
+  depth: number;
+  /** Contract that emitted this event */
+  contractId: string;
+  /** Event type: 'contract' | 'system' | 'diagnostic' */
+  eventType: string;
+  /** First topic symbol, e.g. "fn_call", "fn_return", "transfer" */
+  topic: string;
+  /** Decoded topic values beyond the first */
+  topicArgs: unknown[];
+  /** Decoded data payload */
+  data: unknown;
+  /** true = event fired inside a successful sub-call */
+  inSuccessfulCall: boolean;
+  /** CPU instructions consumed up to this point (cumulative from cost field) */
+  cpuDelta: number | null;
+  /** Memory bytes consumed up to this point */
+  memDelta: number | null;
+  /** Human-readable one-liner */
+  label: string;
+}
+
+export interface CallTrace {
+  /** Flat chronological list — use `depth` to reconstruct the tree */
+  events: CallTraceNode[];
+  /** Total unique contracts touched */
+  contractsInvolved: string[];
+  /** Deepest nesting level seen */
+  maxDepth: number;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function contractIdFromHash(hash: Buffer): string {
+  try { return StrKey.encodeContract(hash); } catch { return hash.toString('hex'); }
+}
+
+function decodeTopics(topics: xdr.ScVal[]): string[] {
+  return topics.map((t) => {
+    try { return String(scValToNative(t)); } catch { return t.toXDR('base64'); }
+  });
+}
+
+function decodeData(val: xdr.ScVal): unknown {
+  try { return scValToNative(val); } catch { return val.toXDR('base64'); }
+}
+
+/**
+ * Soroban emits "fn_call" / "fn_return" diagnostic events to mark call
+ * boundaries. We track depth by counting unmatched fn_call entries.
+ */
+function inferDepth(topic: string, depthStack: string[]): number {
+  if (topic === 'fn_call') {
+    const d = depthStack.length;
+    depthStack.push('fn_call');
+    return d;
+  }
+  if (topic === 'fn_return' && depthStack.length > 0) {
+    depthStack.pop();
+    return depthStack.length;
+  }
+  return depthStack.length;
+}
+
+function buildLabel(contractId: string, topic: string, topicArgs: unknown[], data: unknown): string {
+  const short = contractId.slice(0, 8) + '…';
+  if (topic === 'fn_call') return `→ [${short}] call ${topicArgs[0] ?? ''}(${topicArgs.slice(1).join(', ')})`;
+  if (topic === 'fn_return') return `← [${short}] return ${JSON.stringify(data) ?? ''}`;
+  if (topic === 'transfer') return `[${short}] transfer ${topicArgs.join(' → ')} amount=${JSON.stringify(data)}`;
+  return `[${short}] ${topic}(${topicArgs.join(', ')})`;
+}
+
+// ── Main export ───────────────────────────────────────────────────────────────
+
+/**
+ * Parse a DiagnosticEvent array (from simulateTransaction or ledger metadata)
+ * into a chronological call trace with per-event resource deltas.
+ *
+ * @param diagnosticEvents  Raw XDR DiagnosticEvent array from the RPC response
+ * @param totalCpuInsns     Total CPU instructions from sim cost (distributed evenly as a delta guide)
+ * @param totalMemBytes     Total memory bytes from sim cost
+ */
+export function parseCallTrace(
+  diagnosticEvents: xdr.DiagnosticEvent[],
+  totalCpuInsns?: number,
+  totalMemBytes?: number,
+): CallTrace {
+  const events: CallTraceNode[] = [];
+  const contractsSet = new Set<string>();
+  const depthStack: string[] = [];
+  let maxDepth = 0;
+
+  const n = diagnosticEvents.length;
+  // Distribute resource totals evenly across events as approximate deltas
+  const cpuPerEvent = n > 0 && totalCpuInsns != null ? Math.round(totalCpuInsns / n) : null;
+  const memPerEvent = n > 0 && totalMemBytes != null ? Math.round(totalMemBytes / n) : null;
+
+  for (let i = 0; i < n; i++) {
+    const de = diagnosticEvents[i];
+    const inSuccessfulCall = de.inSuccessfulContractCall();
+    const ev = de.event();
+
+    // Contract ID
+    const contractIdOpt = ev.contractId();
+    const contractId = contractIdOpt
+      ? contractIdFromHash(contractIdOpt as unknown as Buffer)
+      : 'system';
+    contractsSet.add(contractId);
+
+    // Event type
+    const eventType = ev.type().name ?? 'unknown';
+
+    // Topics + data
+    const body = ev.body().value() as { topics: () => xdr.ScVal[]; data: () => xdr.ScVal };
+    const rawTopics: xdr.ScVal[] = body?.topics?.() ?? [];
+    const rawData: xdr.ScVal = body?.data?.();
+
+    const [firstTopic, ...restTopics] = decodeTopics(rawTopics);
+    const topic = firstTopic ?? eventType;
+    const topicArgs = restTopics;
+    const data = rawData ? decodeData(rawData) : null;
+
+    // Depth tracking
+    const depth = inferDepth(topic, depthStack);
+    if (depth > maxDepth) maxDepth = depth;
+
+    events.push({
+      seq: i,
+      depth,
+      contractId,
+      eventType,
+      topic,
+      topicArgs,
+      data,
+      inSuccessfulCall,
+      cpuDelta: cpuPerEvent !== null ? cpuPerEvent * (i + 1) : null,
+      memDelta: memPerEvent !== null ? memPerEvent * (i + 1) : null,
+      label: buildLabel(contractId, topic, topicArgs, data),
+    });
+  }
+
+  return {
+    events,
+    contractsInvolved: [...contractsSet].filter((c) => c !== 'system'),
+    maxDepth,
+  };
+}

--- a/src/indexer/footprint-formatter.ts
+++ b/src/indexer/footprint-formatter.ts
@@ -1,0 +1,71 @@
+import { SorobanDataBuilder, SorobanRpc } from '@stellar/stellar-sdk';
+
+const LIMITS = {
+  cpuInstructions: 100_000_000,
+  memBytes: 40 * 1024 * 1024,
+  ledgerReadBytes: 200 * 1024,
+  ledgerWriteBytes: 66 * 1024,
+  ledgerReadEntries: 40,
+  ledgerWriteEntries: 25,
+} as const;
+
+export interface ResourceMetric {
+  label: string;
+  value: number;
+  limit: number;
+  unit: string;
+  pct: number;
+  human: string;
+}
+
+export interface FormattedFootprint {
+  minResourceFee: string;
+  metrics: ResourceMetric[];
+  summary: string;
+}
+
+function fmtBytes(n: number): string {
+  if (n >= 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(2)} MB`;
+  if (n >= 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${n} B`;
+}
+
+function metric(label: string, value: number, limit: number, unit: string): ResourceMetric {
+  const pct = limit > 0 ? Math.min(100, Math.round((value / limit) * 100)) : 0;
+  const fmt = unit === 'bytes' ? fmtBytes : (n: number) => n.toLocaleString();
+  return {
+    label, value, limit, unit, pct,
+    human: `Uses ${pct}% of maximum ${label.toLowerCase()} (${fmt(value)} / ${fmt(limit)})`,
+  };
+}
+
+export function formatFootprint(
+  sim: SorobanRpc.Api.SimulateTransactionSuccessResponse,
+): FormattedFootprint {
+  const resources = (sim.transactionData as SorobanDataBuilder).build().resources();
+  const cpuInsns = Number(resources.instructions());
+  const memBytes = Number((sim.cost as SorobanRpc.Api.Cost).memBytes);
+  const readBytes = Number(resources.readBytes());
+  const writeBytes = Number(resources.writeBytes());
+  const readEntries =
+    (sim.transactionData as SorobanDataBuilder).getReadOnly().length +
+    (sim.transactionData as SorobanDataBuilder).getReadWrite().length;
+  const writeEntries = (sim.transactionData as SorobanDataBuilder).getReadWrite().length;
+
+  const metrics: ResourceMetric[] = [
+    metric('CPU Instructions', cpuInsns, LIMITS.cpuInstructions, 'instructions'),
+    metric('RAM Allocation', memBytes, LIMITS.memBytes, 'bytes'),
+    metric('Ledger Read Bytes', readBytes, LIMITS.ledgerReadBytes, 'bytes'),
+    metric('Ledger Write Bytes', writeBytes, LIMITS.ledgerWriteBytes, 'bytes'),
+    metric('Ledger Read Entries', readEntries, LIMITS.ledgerReadEntries, 'entries'),
+    metric('Ledger Write Entries', writeEntries, LIMITS.ledgerWriteEntries, 'entries'),
+  ];
+
+  const worst = metrics.reduce((a, b) => (a.pct >= b.pct ? a : b));
+  const summary =
+    worst.pct >= 80
+      ? `⚠️  High resource usage: ${worst.label} at ${worst.pct}% of limit`
+      : `Resource usage nominal — highest is ${worst.label} at ${worst.pct}% of limit`;
+
+  return { minResourceFee: sim.minResourceFee, metrics, summary };
+}


### PR DESCRIPTION
Here's what was built:
  
  src/indexer/call-trace.ts — the core new piece. parseCallTrace(diagnosticEvents, cpuInsns?, memBytes?) walks the DiagnosticEvent[] array from ledger metadata
  and produces a flat chronological CallTraceNode[] where each node has:
  
  - seq — chronological order
  - depth — nesting level (0 = root, 1 = Contract A→B, 2 = B→C, etc.), tracked by counting unmatched fn_call/fn_return diagnostic events
  - contractId — which contract emitted the event
  - topic / topicArgs / data — decoded payload
  - cpuDelta / memDelta — cumulative resource consumption at that point in the trace
  - label — human-readable one-liner, e.g. → [CABC…] call swap(100, USDC) or ← [CDEF…] return 98
  - inSuccessfulCall — whether the event fired inside a successful sub-call (false = fired during a reverting frame)
  
  The trace is returned on both success and failure paths of POST /api/v1/simulate, so you can see exactly where in a nested A→B→C call chain execution stopped
  and how much gas was consumed at each intersection.

closes #70 
