### PR TITLE
feat: add Ledger model and rename ledger field to ledgerSequence

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,18 +9,34 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+// Ledger (block) — one row per closed ledger.
+// sequence is the natural PK; closeTime enables timestamp-range queries.
+model Ledger {
+  sequence     Int      @id                // ledger sequence number (block number)
+  hash         String   @unique            // ledger hash
+  closeTime    DateTime                    // ledger close timestamp
+  txCount      Int      @default(0)        // number of transactions in this ledger
+  createdAt    DateTime @default(now())
+
+  transactions Transaction[]
+  events       Event[]
+
+  @@index([sequence])                      // sub-second lookup by ledger number
+  @@index([closeTime])                     // range queries by timestamp
+}
+
 model Contract {
-  id          String   @id @default(cuid())
-  address     String   @unique
-  name        String?
-  description String?
-  abi         Json?    // ABI-like metadata: functions, events, types
-  isToken     Boolean  @default(false)
-  tokenSymbol String?
-  tokenName   String?
+  id            String   @id @default(cuid())
+  address       String   @unique
+  name          String?
+  description   String?
+  abi           Json?    // ABI-like metadata: functions, events, types
+  isToken       Boolean  @default(false)
+  tokenSymbol   String?
+  tokenName     String?
   tokenDecimals Int?
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
 
   transactions Transaction[]
   events       Event[]
@@ -31,7 +47,7 @@ model Contract {
 model Transaction {
   id              String   @id @default(cuid())
   hash            String   @unique
-  ledger          Int
+  ledgerSequence  Int                      // FK → Ledger.sequence
   ledgerCloseTime DateTime
   sourceAccount   String
   contractAddress String?
@@ -43,18 +59,20 @@ model Transaction {
   feeCharged      String?
   createdAt       DateTime @default(now())
 
+  ledger   Ledger    @relation(fields: [ledgerSequence], references: [sequence])
   contract Contract? @relation(fields: [contractAddress], references: [address])
   events   Event[]
 
-  @@index([hash])
+  @@index([hash])                          // sub-second lookup by tx hash
+  @@index([ledgerSequence])               // sub-second lookup by ledger number
   @@index([sourceAccount])
   @@index([contractAddress])
-  @@index([ledger])
-  // Composite indexes for cursor-based pagination (ledger DESC, id DESC)
-  @@index([contractAddress, ledger, id])
-  @@index([sourceAccount, ledger, id])
-  @@index([status, ledger, id])
-  @@index([ledger, id])
+  @@index([status])
+  // Composite indexes for cursor-based pagination (ledgerSequence DESC, id DESC)
+  @@index([contractAddress, ledgerSequence, id])
+  @@index([sourceAccount, ledgerSequence, id])
+  @@index([status, ledgerSequence, id])
+  @@index([ledgerSequence, id])
 }
 
 model Event {
@@ -65,23 +83,25 @@ model Event {
   topics          Json     // raw topics
   data            Json     // raw data
   decoded         Json?    // human-readable decoded event
-  ledger          Int
+  ledgerSequence  Int                      // FK → Ledger.sequence
   ledgerCloseTime DateTime
   createdAt       DateTime @default(now())
 
+  ledger      Ledger      @relation(fields: [ledgerSequence], references: [sequence])
   transaction Transaction @relation(fields: [transactionHash], references: [hash])
   contract    Contract    @relation(fields: [contractAddress], references: [address])
 
   @@index([transactionHash])
   @@index([contractAddress])
   @@index([eventType])
-  @@index([ledger])
+  @@index([ledgerSequence])               // sub-second lookup by ledger number
+  @@index([contractAddress, ledgerSequence])
 }
 
 model IndexerState {
-  id            String   @id @default("singleton")
-  lastLedger    Int      @default(0)
-  updatedAt     DateTime @updatedAt
+  id         String   @id @default("singleton")
+  lastLedger Int      @default(0)
+  updatedAt  DateTime @updatedAt
 }
 
 model FailedItem {

--- a/src/api/contracts.ts
+++ b/src/api/contracts.ts
@@ -86,8 +86,8 @@ contractRouter.get('/:address', async (req: Request, res: Response) => {
   const contract = await prismaRead.contract.findUnique({
     where: { address: req.params.address },
     include: {
-      transactions: { take: 10, orderBy: { ledger: 'desc' }, select: { hash: true, functionName: true, humanReadable: true, ledger: true } },
-      events: { take: 10, orderBy: { ledger: 'desc' }, select: { id: true, eventType: true, decoded: true, ledger: true } },
+      transactions: { take: 10, orderBy: { ledgerSequence: 'desc' }, select: { hash: true, functionName: true, humanReadable: true, ledgerSequence: true } },
+      events: { take: 10, orderBy: { ledgerSequence: 'desc' }, select: { id: true, eventType: true, decoded: true, ledgerSequence: true } },
     },
   });
   if (!contract) return res.status(404).json({ error: 'Contract not found' });

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -24,7 +24,7 @@ eventRouter.get('/', async (req: Request, res: Response) => {
     const [events, total] = await Promise.all([
       prisma.event.findMany({
         where,
-        orderBy: { ledger: 'desc' },
+        orderBy: { ledgerSequence: 'desc' },
         skip,
         take: limit,
         select: {
@@ -33,7 +33,7 @@ eventRouter.get('/', async (req: Request, res: Response) => {
           contractAddress: true,
           eventType: true,
           decoded: true,
-          ledger: true,
+          ledgerSequence: true,
           ledgerCloseTime: true,
         },
       }),

--- a/src/api/tokens.ts
+++ b/src/api/tokens.ts
@@ -31,9 +31,9 @@ tokenRouter.get('/:address', async (req: Request, res: Response) => {
 tokenRouter.get('/:address/transfers', async (req: Request, res: Response) => {
   const events = await prisma.event.findMany({
     where: { contractAddress: req.params.address, eventType: 'transfer' },
-    orderBy: { ledger: 'desc' },
+    orderBy: { ledgerSequence: 'desc' },
     take: 50,
-    select: { id: true, transactionHash: true, decoded: true, ledger: true, ledgerCloseTime: true },
+    select: { id: true, transactionHash: true, decoded: true, ledgerSequence: true, ledgerCloseTime: true },
   });
   res.json(events);
 });

--- a/src/api/transactions.ts
+++ b/src/api/transactions.ts
@@ -6,7 +6,7 @@ export const transactionRouter = Router();
 
 const TX_SELECT = {
   hash: true,
-  ledger: true,
+  ledgerSequence: true,
   ledgerCloseTime: true,
   sourceAccount: true,
   contractAddress: true,
@@ -42,7 +42,7 @@ transactionRouter.get('/', async (req: Request, res: Response) => {
       ...(q.account   && { sourceAccount: q.account }),
       ...(q.status    && { status: q.status }),
       ...((q.ledgerMin !== undefined || q.ledgerMax !== undefined) && {
-        ledger: {
+        ledgerSequence: {
           ...(q.ledgerMin !== undefined && { gte: q.ledgerMin }),
           ...(q.ledgerMax !== undefined && { lte: q.ledgerMax }),
         },
@@ -53,7 +53,7 @@ transactionRouter.get('/', async (req: Request, res: Response) => {
       // Cursor-based: fetch limit+1 to determine if there's a next page
       const rows = await prisma.transaction.findMany({
         where,
-        orderBy: [{ ledger: 'desc' }, { id: 'desc' }],
+        orderBy: [{ ledgerSequence: 'desc' }, { id: 'desc' }],
         cursor: { id: q.cursor },
         skip: 1,           // skip the cursor row itself
         take: q.limit + 1,
@@ -82,7 +82,7 @@ transactionRouter.get('/', async (req: Request, res: Response) => {
     const [data, total] = await Promise.all([
       prisma.transaction.findMany({
         where,
-        orderBy: [{ ledger: 'desc' }, { id: 'desc' }],
+        orderBy: [{ ledgerSequence: 'desc' }, { id: 'desc' }],
         skip,
         take: q.limit,
         select: TX_SELECT,

--- a/src/api/wallets.ts
+++ b/src/api/wallets.ts
@@ -18,12 +18,12 @@ walletRouter.get('/:address/transactions', async (req: Request, res: Response) =
     const [transactions, total] = await Promise.all([
       prisma.transaction.findMany({
         where: { sourceAccount: req.params.address },
-        orderBy: { ledger: 'desc' },
+        orderBy: { ledgerSequence: 'desc' },
         skip,
         take: limit,
         select: {
           hash: true,
-          ledger: true,
+          ledgerSequence: true,
           ledgerCloseTime: true,
           contractAddress: true,
           functionName: true,
@@ -56,7 +56,7 @@ walletRouter.get('/:address/events', async (req: Request, res: Response) => {
             { decoded: { path: ['to'], equals: address } },
           ],
         },
-        orderBy: { ledger: 'desc' },
+        orderBy: { ledgerSequence: 'desc' },
         skip,
         take: limit,
       }),

--- a/src/indexer/eventIngestor.ts
+++ b/src/indexer/eventIngestor.ts
@@ -67,7 +67,7 @@ export async function ingestEvents(startLedger: number, endLedger: number): Prom
  */
 export async function ingestEventsFromMeta(
   txHash: string,
-  ledger: number,
+  ledgerSequence: number,
   ledgerCloseTime: Date,
   metaXdr: string
 ): Promise<number> {
@@ -78,7 +78,7 @@ export async function ingestEventsFromMeta(
     const ledgerEvent: LedgerEvent = {
       contractId: ev.contractId,
       transactionHash: txHash,
-      ledger,
+      ledgerSequence,
       ledgerCloseTime,
       topics: ev.topics,
       data: ev.data,
@@ -122,7 +122,7 @@ async function storeEvent(event: LedgerEvent): Promise<number> {
       topics: event.topics,
       data: { raw: event.data },
       decoded: decoded as object,
-      ledger: event.ledger,
+      ledgerSequence: event.ledgerSequence,
       ledgerCloseTime: event.ledgerCloseTime,
     },
   });

--- a/src/indexer/ledgerProcessor.ts
+++ b/src/indexer/ledgerProcessor.ts
@@ -14,6 +14,17 @@ export async function processLedgerRange(start: number, end: number): Promise<vo
   const events = await fetchEvents(start, end);
 
   for (const event of events) {
+    // Upsert the Ledger row before writing transactions/events (FK constraint)
+    await prisma.ledger.upsert({
+      where: { sequence: event.ledgerSequence },
+      update: {},
+      create: {
+        sequence: event.ledgerSequence,
+        hash: '',               // hash not available from event stream; filled in if known
+        closeTime: event.ledgerCloseTime,
+      },
+    });
+
     await prisma.contract.upsert({
       where: { address: event.contractId },
       update: {},
@@ -29,7 +40,7 @@ export async function processLedgerRange(start: number, end: number): Promise<vo
             await enqueueFailure({
               itemType: 'transaction',
               itemId: event.transactionHash,
-              ledger: event.ledger,
+              ledger: event.ledgerSequence,
               rawXdr,
               error: err,
             });
@@ -42,7 +53,7 @@ export async function processLedgerRange(start: number, end: number): Promise<vo
         update: {},
         create: {
           hash: event.transactionHash,
-          ledger: event.ledger,
+          ledgerSequence: event.ledgerSequence,
           ledgerCloseTime: event.ledgerCloseTime,
           sourceAccount: (txResult as any)?.sourceAccount ?? 'unknown',
           contractAddress: decoded.contractAddress,

--- a/src/indexer/rpc.ts
+++ b/src/indexer/rpc.ts
@@ -7,7 +7,7 @@ export const rpc = new SorobanRpc.Server(config.stellarRpcUrl, { allowHttp: true
 export interface LedgerEvent {
   contractId: string;
   transactionHash: string;
-  ledger: number;
+  ledgerSequence: number;
   ledgerCloseTime: Date;
   topics: string[];
   data: string;
@@ -76,7 +76,7 @@ export async function fetchEvents(startLedger: number, endLedger: number): Promi
       .map((e) => ({
         contractId: String(e.contractId ?? ''),
         transactionHash: String(e.txHash ?? ''),
-        ledger: Number(e.ledger),
+        ledgerSequence: Number(e.ledger),
         ledgerCloseTime: new Date(e.ledgerClosedAt ?? Date.now()),
         topics: Array.isArray(e.topic) ? e.topic.map((t: any) => t.toXDR('base64')) : [],
         data: e.value?.toXDR ? e.value.toXDR('base64') : String(e.value ?? ''),


### PR DESCRIPTION
close #29 

- Add Ledger model (sequence PK, hash, closeTime, txCount) with indexes on sequence and closeTime for sub-second block/timestamp queries
- Rename Transaction.ledger → ledgerSequence and Event.ledger → ledgerSequence; add FK relations to Ledger
- Add composite index on Event(contractAddress, ledgerSequence) for contract+range queries
- Upsert Ledger row in ledgerProcessor before writing transactions/events
- Update all API handlers and indexer code to use ledgerSequence