### PR TITLE
feat: multi network cluster router

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,19 +1,39 @@
 import dotenv from 'dotenv';
-dotenv.config();
+import { getProfile, type NetworkProfile } from './profiles';
+
+// Load the profile-specific env file first, then fall back to .env
+const network = process.env.STELLAR_NETWORK ?? 'testnet';
+dotenv.config({ path: `.env.${network}` });
+dotenv.config(); // base .env fills any remaining gaps
+
+const profile: NetworkProfile = getProfile(network);
 
 export const config = {
-  port: parseInt(process.env.PORT ?? '3000'),
+  // ── Server ───────────────────────────────────────────────────────────────
+  port:    parseInt(process.env.PORT ?? '3000'),
   nodeEnv: process.env.NODE_ENV ?? 'development',
-  stellarNetwork: process.env.STELLAR_NETWORK ?? 'testnet',
-  stellarRpcUrl: process.env.STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org',
-  stellarRpcWsUrl: process.env.STELLAR_RPC_WS_URL ?? process.env.STELLAR_RPC_URL?.replace(/^http/, 'ws') ?? 'wss://soroban-testnet.stellar.org',
-  horizonUrl: process.env.HORIZON_URL ?? 'https://horizon-testnet.stellar.org',
-  networkPassphrase: process.env.NETWORK_PASSPHRASE ?? 'Test SDF Network ; September 2015',
-  indexerStartLedger: parseInt(process.env.INDEXER_START_LEDGER ?? '0'),
+
+  // ── Active network profile ────────────────────────────────────────────────
+  profile,
+  stellarNetwork:    profile.name,
+  stellarRpcUrl:     profile.rpcUrl,
+  stellarRpcWsUrl:   profile.rpcWsUrl,
+  horizonUrl:        profile.horizonUrl,
+  networkPassphrase: profile.networkPassphrase,
+  apiSubdomain:      profile.apiSubdomain,
+  cacheUrl:          profile.cacheUrl,
+
+  // ── Database (resolved from profile) ─────────────────────────────────────
+  databaseUrl:    profile.databaseUrl,
+  readReplicaUrl: profile.readReplicaUrl,
+
+  // ── Indexer ───────────────────────────────────────────────────────────────
+  indexerStartLedger:    parseInt(process.env.INDEXER_START_LEDGER    ?? '0'),
   indexerPollIntervalMs: parseInt(process.env.INDEXER_POLL_INTERVAL_MS ?? '5000'),
-  indexerBatchSize: parseInt(process.env.INDEXER_BATCH_SIZE ?? '100'),
+  indexerBatchSize:      parseInt(process.env.INDEXER_BATCH_SIZE       ?? '100'),
   indexerCatchupWorkers: Math.max(1, parseInt(process.env.INDEXER_CATCHUP_WORKERS ?? '4')),
+
+  // ── Rate limiting ─────────────────────────────────────────────────────────
   rateLimitWindowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS ?? '60000'),
-  rateLimitMax: parseInt(process.env.RATE_LIMIT_MAX ?? '100'),
-  readReplicaUrl: process.env.READ_REPLICA_URL ?? process.env.DATABASE_URL ?? '',
+  rateLimitMax:      parseInt(process.env.RATE_LIMIT_MAX        ?? '100'),
 };

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,20 +1,21 @@
 import { PrismaClient } from '@prisma/client';
 import { config } from './config';
 
-const logLevel = process.env.NODE_ENV === 'development'
-  ? (['error', 'warn'] as ('error' | 'warn')[])
-  : (['error'] as ('error')[]);
+const logLevel = config.nodeEnv === 'development'
+  ? (['error', 'warn'] as const)
+  : (['error'] as const);
 
-/** Primary instance — used for all writes (indexer). */
+/** Primary write client — uses the active profile's database cluster. */
 export const prismaWrite = new PrismaClient({
   log: logLevel,
+  datasources: { db: { url: config.databaseUrl } },
 });
 
-/** Read-replica instance — used for all API reads. Falls back to primary if READ_REPLICA_URL is unset. */
+/** Read-replica client — uses the active profile's replica (falls back to primary). */
 export const prismaRead = new PrismaClient({
   log: logLevel,
   datasources: { db: { url: config.readReplicaUrl } },
 });
 
-/** @deprecated Import prismaWrite or prismaRead explicitly. */
+/** @deprecated Use prismaWrite or prismaRead explicitly. */
 export const prisma = prismaWrite;

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -1,0 +1,85 @@
+/**
+ * Network profiles — one per Stellar environment.
+ *
+ * Each profile is fully self-contained: its own DB cluster, read-replica,
+ * RPC endpoint, Horizon URL, network passphrase, API subdomain, and cache DSN.
+ * The engine code (indexer, API, decoders) is shared across all profiles.
+ *
+ * Active profile is selected by STELLAR_NETWORK at startup.
+ */
+
+export type NetworkName = 'testnet' | 'mainnet' | 'devnet';
+
+export interface NetworkProfile {
+  name: NetworkName;
+
+  // ── Stellar RPC ──────────────────────────────────────────────────────────
+  rpcUrl: string;
+  rpcWsUrl: string;
+  horizonUrl: string;
+  networkPassphrase: string;
+
+  // ── Database cluster ─────────────────────────────────────────────────────
+  databaseUrl: string;       // primary (write)
+  readReplicaUrl: string;    // read replica (falls back to primary)
+
+  // ── API subdomain ────────────────────────────────────────────────────────
+  apiSubdomain: string;      // e.g. "testnet-api.example.com"
+
+  // ── Cache node ───────────────────────────────────────────────────────────
+  cacheUrl: string;          // Redis DSN or in-process sentinel "memory://"
+}
+
+// ─── Profile registry ─────────────────────────────────────────────────────────
+
+const PROFILES: Record<NetworkName, NetworkProfile> = {
+  testnet: {
+    name: 'testnet',
+    rpcUrl:           process.env.TESTNET_RPC_URL      ?? 'https://soroban-testnet.stellar.org',
+    rpcWsUrl:         process.env.TESTNET_RPC_WS_URL   ?? 'wss://soroban-testnet.stellar.org',
+    horizonUrl:       process.env.TESTNET_HORIZON_URL  ?? 'https://horizon-testnet.stellar.org',
+    networkPassphrase: process.env.TESTNET_PASSPHRASE  ?? 'Test SDF Network ; September 2015',
+    databaseUrl:      process.env.TESTNET_DATABASE_URL ?? process.env.DATABASE_URL ?? '',
+    readReplicaUrl:   process.env.TESTNET_READ_REPLICA_URL ?? process.env.TESTNET_DATABASE_URL ?? process.env.DATABASE_URL ?? '',
+    apiSubdomain:     process.env.TESTNET_API_SUBDOMAIN ?? 'testnet-api.localhost',
+    cacheUrl:         process.env.TESTNET_CACHE_URL    ?? 'memory://',
+  },
+
+  mainnet: {
+    name: 'mainnet',
+    rpcUrl:           process.env.MAINNET_RPC_URL      ?? 'https://mainnet.stellar.validationcloud.io/v1/placeholder',
+    rpcWsUrl:         process.env.MAINNET_RPC_WS_URL   ?? 'wss://mainnet.stellar.validationcloud.io/v1/placeholder',
+    horizonUrl:       process.env.MAINNET_HORIZON_URL  ?? 'https://horizon.stellar.org',
+    networkPassphrase: process.env.MAINNET_PASSPHRASE  ?? 'Public Global Stellar Network ; September 2015',
+    databaseUrl:      process.env.MAINNET_DATABASE_URL ?? '',
+    readReplicaUrl:   process.env.MAINNET_READ_REPLICA_URL ?? process.env.MAINNET_DATABASE_URL ?? '',
+    apiSubdomain:     process.env.MAINNET_API_SUBDOMAIN ?? 'api.localhost',
+    cacheUrl:         process.env.MAINNET_CACHE_URL    ?? 'memory://',
+  },
+
+  devnet: {
+    name: 'devnet',
+    rpcUrl:           process.env.DEVNET_RPC_URL       ?? 'http://localhost:8000/soroban/rpc',
+    rpcWsUrl:         process.env.DEVNET_RPC_WS_URL    ?? 'ws://localhost:8000/soroban/rpc',
+    horizonUrl:       process.env.DEVNET_HORIZON_URL   ?? 'http://localhost:8000',
+    networkPassphrase: process.env.DEVNET_PASSPHRASE   ?? 'Standalone Network ; February 2017',
+    databaseUrl:      process.env.DEVNET_DATABASE_URL  ?? 'postgresql://postgres:password@localhost:5433/soroban_devnet',
+    readReplicaUrl:   process.env.DEVNET_READ_REPLICA_URL ?? process.env.DEVNET_DATABASE_URL ?? 'postgresql://postgres:password@localhost:5433/soroban_devnet',
+    apiSubdomain:     process.env.DEVNET_API_SUBDOMAIN ?? 'devnet-api.localhost',
+    cacheUrl:         process.env.DEVNET_CACHE_URL     ?? 'memory://',
+  },
+};
+
+/** Return the profile for `name`, throwing if unknown. */
+export function getProfile(name: string): NetworkProfile {
+  const profile = PROFILES[name as NetworkName];
+  if (!profile) {
+    throw new Error(
+      `Unknown STELLAR_NETWORK "${name}". Valid values: ${Object.keys(PROFILES).join(', ')}`
+    );
+  }
+  return profile;
+}
+
+/** All registered profiles (useful for multi-network tooling). */
+export const allProfiles = PROFILES;


### PR DESCRIPTION
Description:
  
  Centralized all environment-specific configuration into src/profiles.ts as typed NetworkProfile objects. Each profile carries its own independent DB cluster URLs, read-replica, RPC endpoint, Horizon URL,
  API subdomain, and cache node DSN.
  
  - src/profiles.ts — NetworkProfile type + PROFILES registry for testnet, mainnet, devnet
  - src/config.ts — loads .env.{network} then .env, resolves the active profile via STELLAR_NETWORK, exposes all profile fields on the shared config object
  - src/db.ts — prismaWrite and prismaRead now instantiate against the active profile's DB URLs instead of raw env vars
  - .env.testnet / .env.mainnet / .env.devnet — per-profile env files with isolated DB, RPC, and cache values
  - docker-compose.yml — separate service stacks per profile using env_file, independent Postgres volumes and Redis nodes per environment
  
  The engine code (indexer, API, decoders) is fully shared — only the infrastructure bindings change per profile.

closes #73