### PR TITLE
feat: diff enginefor unverified contracts

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,8 @@ model Contract {
   tokenSymbol String?
   tokenName   String?
   tokenDecimals Int?
+  wasmHash    String?  // fuzzy hash of compiled Wasm bytecode for similarity detection
+  isVerified  Boolean  @default(false)
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 


### PR DESCRIPTION
  What was added:
  
  - src/indexer/wasm-similarity.ts — Pure TypeScript ssdeep-like fuzzy hashing (CTPH) on raw Wasm bytecode. Computes rolling Adler-32 chunk boundaries, FNV-1a chunk hashes, and a normalised edit-distance
  similarity score (0–100).
  - src/api/similarity.ts — GET /contracts/:address/similarity endpoint that fetches the target contract's Wasm hash (computing and persisting it on first call), compares it against all verified contracts
  in the DB, and returns ranked matches with human-readable labels.
  - prisma/schema.prisma — Added wasmHash String? and isVerified Boolean fields to the Contract model.
  - src/api/router.ts — Registered the similarity router.
  - Prisma migration for the new fields.
closes #64 