### PR TITLE
feat: erc20 / sac liquidity pool

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -84,6 +84,47 @@ model IndexerState {
   updatedAt     DateTime @updatedAt
 }
 
+// Bidirectional mapping: classic Stellar asset ↔ SAC contract address
+model SacMapping {
+  id           String   @id @default(cuid())
+  // Classic asset fields
+  assetCode    String   // e.g. "USDC"
+  assetIssuer  String?  // null for XLM (native)
+  assetType    String   // "native" | "credit_alphanum4" | "credit_alphanum12"
+  // Soroban side
+  sacAddress   String   @unique  // derived C-address of the SAC contract
+  // Metadata
+  firstSeenLedger Int?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  ammPools     AmmPool[]
+
+  @@unique([assetCode, assetIssuer])
+  @@index([sacAddress])
+  @@index([assetCode])
+}
+
+// AMM pool that uses one or more SAC-wrapped assets
+model AmmPool {
+  id              String   @id @default(cuid())
+  poolAddress     String   @unique  // Soroban contract address of the pool
+  poolType        String   @default("constant_product")  // constant_product | stable
+  // The two assets in the pool (at least one is a SAC)
+  assetAAddress   String   // SAC address or native token address
+  assetBAddress   String
+  // Reverse links to SacMapping (nullable — one side may be a non-SAC token)
+  sacMappingAId   String?
+  sacMappingBId   String?
+  sacMappingA     SacMapping? @relation(fields: [sacMappingAId], references: [id])
+  firstSeenLedger Int?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  @@index([assetAAddress])
+  @@index([assetBAddress])
+}
+
 model FailedItem {
   id          String   @id @default(cuid())
   itemType    String   // "transaction" | "event"


### PR DESCRIPTION
 What's added:
  
  - SacMapping model — a persistent index keyed on (assetCode, assetIssuer) that stores the deterministically-derived SAC contract address (sacAddress). Lookups work in both directions: given a classic
  asset, find its SAC address; given a SAC address, resolve back to the classic asset.
  - AmmPool model — tracks AMM liquidity pools whose asset pairs include one or more SAC-wrapped tokens, linking pool contracts back to their underlying classic assets.
  - src/indexer/sac-registry.ts — derives SAC addresses from classic assets using the Stellar SDK's deterministic preimage hash (no RPC call needed), maintains an in-memory live dictionary for hot-path
  lookups, and persists new mappings to the database on first encounter.
  - src/api/sac.ts — REST endpoints to query the mapping:
    - GET /sac/asset/:code/:issuer → resolve classic asset to SAC address
    - GET /sac/contract/:address → resolve SAC address back to classic asset
    - GET /sac/pools → list AMM pools with their SAC asset pairs
  
  Net effect: Any component in the indexer or API that encounters a SAC contract address can instantly resolve it to a human-readable classic asset (e.g.
  USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN), and vice versa — closing the mutation gap between classic Stellar liquidity and Soroban-native AMM interfaces.

closes #65 