### PR TITLE
feat: event schema registry

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,6 +78,23 @@ model Event {
   @@index([ledger])
 }
 
+// Custom event symbol → template bindings submitted by verified project creators
+model EventDefinition {
+  id              String   @id @default(cuid())
+  contractAddress String
+  // The event topic symbol this binding applies to, e.g. "mint_pass"
+  topicSymbol     String
+  // Mustache-style template, e.g. "Minted pass #{{data.id}} to {{data.owner}}"
+  humanTemplate   String
+  // Who submitted this definition (API key or creator identifier)
+  submittedBy     String?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  @@unique([contractAddress, topicSymbol])
+  @@index([contractAddress])
+}
+
 model IndexerState {
   id            String   @id @default("singleton")
   lastLedger    Int      @default(0)

--- a/src/api/event-definitions.ts
+++ b/src/api/event-definitions.ts
@@ -1,0 +1,83 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { prismaRead, prismaWrite } from '../db';
+
+export const eventDefinitionRouter = Router();
+
+// Verified creators must supply a developer or premium API key (X-API-Key header).
+// The key is stored as `submittedBy` for audit purposes; actual key validation
+// is handled by the tieredRateLimit middleware mounted in router.ts.
+function requireApiKey(req: Request, res: Response): string | null {
+  const key = req.headers['x-api-key'] as string | undefined;
+  if (!key) {
+    res.status(401).json({ error: 'X-API-Key header required to submit event definitions' });
+    return null;
+  }
+  return key;
+}
+
+const definitionSchema = z.object({
+  topicSymbol: z.string().min(1).max(64),
+  humanTemplate: z.string().min(1).max(512),
+});
+
+const bulkSchema = z.object({
+  definitions: z.array(definitionSchema).min(1).max(50),
+});
+
+// GET /contracts/:address/event-definitions
+// List all custom event definitions for a contract.
+eventDefinitionRouter.get('/', async (req: Request, res: Response) => {
+  const { address } = req.params;
+  const defs = await prismaRead.eventDefinition.findMany({
+    where: { contractAddress: address },
+    select: { id: true, topicSymbol: true, humanTemplate: true, submittedBy: true, updatedAt: true },
+    orderBy: { topicSymbol: 'asc' },
+  });
+  res.json(defs);
+});
+
+// POST /contracts/:address/event-definitions
+// Submit one or more event symbol → template bindings.
+// Body: { definitions: [{ topicSymbol, humanTemplate }] }
+eventDefinitionRouter.post('/', async (req: Request, res: Response) => {
+  const key = requireApiKey(req, res);
+  if (!key) return;
+
+  const parsed = bulkSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+
+  const { address } = req.params;
+  const { definitions } = parsed.data;
+
+  // Upsert each binding — idempotent so re-submissions update the template.
+  const results = await Promise.all(
+    definitions.map((d) =>
+      prismaWrite.eventDefinition.upsert({
+        where: { contractAddress_topicSymbol: { contractAddress: address, topicSymbol: d.topicSymbol } },
+        update: { humanTemplate: d.humanTemplate, submittedBy: key },
+        create: { contractAddress: address, topicSymbol: d.topicSymbol, humanTemplate: d.humanTemplate, submittedBy: key },
+        select: { id: true, topicSymbol: true, humanTemplate: true },
+      })
+    )
+  );
+
+  res.status(201).json(results);
+});
+
+// DELETE /contracts/:address/event-definitions/:topicSymbol
+// Remove a single binding.
+eventDefinitionRouter.delete('/:topicSymbol', async (req: Request, res: Response) => {
+  const key = requireApiKey(req, res);
+  if (!key) return;
+
+  const { address, topicSymbol } = req.params;
+  try {
+    await prismaWrite.eventDefinition.delete({
+      where: { contractAddress_topicSymbol: { contractAddress: address, topicSymbol } },
+    });
+    res.status(204).send();
+  } catch {
+    res.status(404).json({ error: 'Event definition not found' });
+  }
+});

--- a/src/indexer/decoder.ts
+++ b/src/indexer/decoder.ts
@@ -3,6 +3,45 @@ import { getContractAbi, decodeArgs, renderHuman } from './registry';
 import { parseInvokeHostFunction } from './xdr-parser';
 import { prismaRead as prisma } from '../db';
 
+/**
+ * Look up a custom EventDefinition for a given contract + topic symbol.
+ * Returns the humanTemplate string if found, otherwise null.
+ */
+export async function lookupCustomEventTemplate(
+  contractAddress: string,
+  topicSymbol: string
+): Promise<string | null> {
+  const def = await prisma.eventDefinition.findUnique({
+    where: { contractAddress_topicSymbol: { contractAddress, topicSymbol } },
+    select: { humanTemplate: true },
+  });
+  return def?.humanTemplate ?? null;
+}
+
+/**
+ * Render a custom template by substituting {{data.key}} and {{topics.N}} placeholders.
+ * Supports: {{data.key}}, {{topics.0}}, {{topics.1}}, etc.
+ */
+export function renderCustomTemplate(
+  template: string,
+  topicValues: unknown[],
+  dataValue: unknown
+): string {
+  return template.replace(/\{\{([\w.]+)\}\}/g, (_match, path: string) => {
+    const parts = path.split('.');
+    if (parts[0] === 'topics' && parts[1] !== undefined) {
+      return String(topicValues[Number(parts[1])] ?? '');
+    }
+    if (parts[0] === 'data') {
+      const val = parts[1] !== undefined && typeof dataValue === 'object' && dataValue !== null
+        ? (dataValue as Record<string, unknown>)[parts[1]]
+        : dataValue;
+      return String(val ?? '');
+    }
+    return _match;
+  });
+}
+
 export interface DecodedTransaction {
   contractAddress: string | null;
   functionName: string | null;


### PR DESCRIPTION
  What's added:
  
  - EventDefinition model in the database — stores the binding between a contractAddress, a topicSymbol (e.g. "mint_pass"), and a humanTemplate (e.g. "Minted pass #{{data.id}} to {{data.owner}}"). Unique
  per (contractAddress, topicSymbol) pair. Tracks submittedBy for audit.
  - POST /api/v1/contracts/:address/event-definitions — accepts a batch of { topicSymbol, humanTemplate } pairs. Requires X-API-Key header (developer or premium tier). Upserts are idempotent, so
  re-submitting updates the template without creating duplicates.
  - GET /api/v1/contracts/:address/event-definitions — lists all custom bindings for a contract.
  - DELETE /api/v1/contracts/:address/event-definitions/:topicSymbol — removes a single binding (requires API key).
  - lookupCustomEventTemplate + renderCustomTemplate in the decoder — when the indexer processes an event, it first checks for a custom EventDefinition matching the contract address and topic symbol. If
  found, the {{data.key}} / {{topics.N}} placeholders in the template are interpolated with the decoded event values, producing a custom human-readable string instead of the generic fallback.
  
  Net effect: A project creator whose contract emits a "mint_pass" event can register the template "Minted pass #{{data.id}} to {{data.owner}}" once via the API, and every subsequent occurrence of that
  event in the explorer will render with their custom description rather than the raw decoded dump.

closes #66