### PR TITLE
feat: add contract verification snippet endpoint (#43)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -177,6 +177,7 @@ model VerificationJob {
   matched         Boolean?
   errorMsg        String?
   logs            String?  // compiler stdout/stderr
+  sourceFiles     Json?    // extracted source files: [{ path, content }]
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 

--- a/src/api/compiler.ts
+++ b/src/api/compiler.ts
@@ -112,6 +112,46 @@ export function hashFile(filePath: string): string {
   return crypto.createHash('sha256').update(bytes).digest('hex');
 }
 
+export interface SourceFile {
+  path: string;
+  content: string;
+}
+
+/**
+ * Recursively collects .rs source files from a project directory.
+ * Returns at most 50 files, each capped at 64 KB.
+ */
+export async function extractSourceFiles(projectDir: string): Promise<SourceFile[]> {
+  const results: SourceFile[] = [];
+  const MAX_FILES = 50;
+  const MAX_BYTES = 64 * 1024;
+
+  async function walk(dir: string, base: string): Promise<void> {
+    if (results.length >= MAX_FILES) return;
+    const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (results.length >= MAX_FILES) break;
+      const full = path.join(dir, entry.name);
+      const rel = path.join(base, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'target' || entry.name === '.git') continue;
+        await walk(full, rel);
+      } else if (entry.isFile() && entry.name.endsWith('.rs')) {
+        const stat = await fs.promises.stat(full);
+        const size = Math.min(stat.size, MAX_BYTES);
+        const buf = Buffer.alloc(size);
+        const fd = await fs.promises.open(full, 'r');
+        await fd.read(buf, 0, size, 0);
+        await fd.close();
+        results.push({ path: rel, content: buf.toString('utf8') });
+      }
+    }
+  }
+
+  await walk(projectDir, '');
+  return results;
+}
+
 /**
  * Cleans up a temp directory, ignoring errors.
  */

--- a/src/api/verify.ts
+++ b/src/api/verify.ts
@@ -3,7 +3,7 @@ import multer from 'multer';
 import * as path from 'path';
 import * as os from 'os';
 import { prisma } from '../db';
-import { extractArchive, compileSandboxed, hashFile, cleanupDir } from './compiler';
+import { extractArchive, compileSandboxed, hashFile, cleanupDir, extractSourceFiles } from './compiler';
 
 export const verifyRouter = Router();
 
@@ -56,6 +56,23 @@ verifyRouter.get('/:id', async (req: Request, res: Response) => {
   res.json(job);
 });
 
+// GET /verify/:id/snippet — return extracted source code files for a verification job
+verifyRouter.get('/:id/snippet', async (req: Request, res: Response) => {
+  const job = await prisma.verificationJob.findUnique({
+    where: { id: req.params.id },
+    select: { id: true, status: true, sourceFiles: true },
+  });
+  if (!job) {
+    res.status(404).json({ error: 'Job not found' });
+    return;
+  }
+  if (!job.sourceFiles) {
+    res.status(404).json({ error: 'Source files not available. Job may still be pending or failed before extraction.' });
+    return;
+  }
+  res.json({ jobId: job.id, status: job.status, files: job.sourceFiles });
+});
+
 // ── async worker ─────────────────────────────────────────────────────────────
 
 async function runVerification(
@@ -71,6 +88,13 @@ async function runVerification(
     await prisma.verificationJob.update({ where: { id: jobId }, data: { status: 'compiling' } });
 
     extractedDir = await extractArchive(archivePath, mimeType);
+
+    // Capture source files before compilation (they get cleaned up after)
+    const sourceFiles = await extractSourceFiles(extractedDir).catch(() => []);
+    if (sourceFiles.length > 0) {
+      await prisma.verificationJob.update({ where: { id: jobId }, data: { sourceFiles } });
+    }
+
     const { wasmHash, logs } = await compileSandboxed(extractedDir, toolchain);
 
     // Optionally fetch on-chain Wasm hash via RPC


### PR DESCRIPTION
- Add GET /verify/:id/snippet endpoint returning extracted Rust source files
- Add extractSourceFiles() helper to compiler.ts (collects .rs files, max 50, 64KB each)
- Store source files as JSON in VerificationJob.sourceFiles during verification
- Add sourceFiles Json? field to VerificationJob model in schema.prisma

closes #43