### PR TITLE
feat: add account history aggregator endpoint (#42)

### DIFF
--- a/src/api/wallets.ts
+++ b/src/api/wallets.ts
@@ -1,6 +1,8 @@
 import { Router, Request, Response } from 'express';
 import { prismaRead as prisma } from '../db';
 import { z } from 'zod';
+import axios from 'axios';
+import { config } from '../config';
 
 export const walletRouter = Router();
 
@@ -75,3 +77,91 @@ walletRouter.get('/:address/events', async (req: Request, res: Response) => {
     res.status(400).json({ error: String(e) });
   }
 });
+
+// GET /wallets/:address/history — unified Soroban + classic Stellar history
+walletRouter.get('/:address/history', async (req: Request, res: Response) => {
+  try {
+    const { page, limit } = paginationSchema.parse(req.query);
+    const address = req.params.address;
+
+    // Fetch Soroban transactions and classic Horizon operations in parallel
+    const [sorobanTxs, horizonOps] = await Promise.all([
+      prisma.transaction.findMany({
+        where: { sourceAccount: address },
+        orderBy: { ledgerCloseTime: 'desc' },
+        take: limit * 2, // over-fetch to allow merged sort
+        select: {
+          hash: true,
+          ledgerSequence: true,
+          ledgerCloseTime: true,
+          contractAddress: true,
+          functionName: true,
+          status: true,
+          humanReadable: true,
+        },
+      }),
+      fetchHorizonOperations(address, limit * 2),
+    ]);
+
+    // Normalise into a unified shape
+    const sorobanItems = sorobanTxs.map(tx => ({
+      type: 'soroban' as const,
+      timestamp: tx.ledgerCloseTime,
+      hash: tx.hash,
+      ledgerSequence: tx.ledgerSequence,
+      status: tx.status,
+      contractAddress: tx.contractAddress ?? null,
+      functionName: tx.functionName ?? null,
+      humanReadable: tx.humanReadable ?? null,
+      // classic fields not applicable
+      operationType: null,
+      amount: null,
+      asset: null,
+      from: null,
+      to: null,
+    }));
+
+    const classicItems = horizonOps.map((op: any) => ({
+      type: 'classic' as const,
+      timestamp: new Date(op.created_at),
+      hash: op.transaction_hash,
+      ledgerSequence: null,
+      status: op.transaction_successful ? 'success' : 'failed',
+      contractAddress: null,
+      functionName: null,
+      humanReadable: null,
+      operationType: op.type,
+      amount: op.amount ?? op.starting_balance ?? null,
+      asset: op.asset_type === 'native' ? 'XLM' : (op.asset_code ?? null),
+      from: op.from ?? op.funder ?? null,
+      to: op.to ?? op.account ?? null,
+    }));
+
+    // Merge and sort descending by timestamp
+    const merged = [...sorobanItems, ...classicItems].sort(
+      (a, b) => b.timestamp.getTime() - a.timestamp.getTime(),
+    );
+
+    // Apply pagination on merged result
+    const skip = (page - 1) * limit;
+    const paginated = merged.slice(skip, skip + limit);
+
+    res.json({ data: paginated, total: merged.length, page, limit });
+  } catch (e) {
+    res.status(400).json({ error: String(e) });
+  }
+});
+
+async function fetchHorizonOperations(address: string, limit: number): Promise<any[]> {
+  try {
+    const url = `${config.horizonUrl}/accounts/${encodeURIComponent(address)}/operations`;
+    const resp = await axios.get(url, {
+      params: { limit, order: 'desc' },
+      timeout: 10_000,
+    });
+    return resp.data?._embedded?.records ?? [];
+  } catch {
+    // Horizon unavailable or account not found — return empty rather than failing the whole request
+    return [];
+  }
+}


### PR DESCRIPTION
- Add GET /wallets/:address/history endpoint
- Fetches Soroban transactions from DB and classic Stellar operations from Horizon API in parallel
- Normalises both sources into a unified history item shape
- Merges and sorts by timestamp descending
- Supports page/limit pagination

closes #42 