### PR TITLE
feat: contract state & event storage schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2285,6 +2285,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,21 +26,20 @@ model Ledger {
 }
 
 model Contract {
-  id            String   @id @default(cuid())
-  address       String   @unique
-  name          String?
-  description   String?
-  abi           Json?    // ABI-like metadata: functions, events, types
-  isToken       Boolean  @default(false)
-  tokenSymbol   String?
-  tokenName     String?
-  tokenDecimals Int?
-  wasmHash    String?  // fuzzy hash of compiled Wasm bytecode for similarity detection
-  isVerified  Boolean  @default(false)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  id                 String   @id @default(cuid())
+  address            String   @unique
+  name               String?
+  description        String?
+  abi                Json?    // ABI-like metadata: functions, events, types
+  functionSignatures Json?    // decoded function signatures: [{ name, inputs, outputs }]
+  isToken            Boolean  @default(false)
+  tokenSymbol        String?
+  tokenName          String?
+  tokenDecimals      Int?
+  wasmHash           String?  // fuzzy hash of compiled Wasm bytecode for similarity detection
+  isVerified         Boolean  @default(false)
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
 
   transactions Transaction[]
   events       Event[]
@@ -84,8 +83,9 @@ model Event {
   transactionHash String
   contractAddress String
   eventType       String   // transfer | swap | mint | burn | custom
-  topics          Json     // raw topics
-  data            Json     // raw data
+  topicSymbol     String?  // first topic decoded as symbol (e.g. "transfer", "mint_pass")
+  topics          Json     // raw topics (base64 XDR array)
+  data            Json     // raw data (base64 XDR)
   decoded         Json?    // human-readable decoded event
   ledgerSequence  Int                      // FK → Ledger.sequence
   ledgerCloseTime DateTime
@@ -98,8 +98,14 @@ model Event {
   @@index([transactionHash])
   @@index([contractAddress])
   @@index([eventType])
-  @@index([ledgerSequence])               // sub-second lookup by ledger number
-  @@index([contractAddress, ledgerSequence])
+  @@index([topicSymbol])
+  @@index([ledgerSequence])
+  // Heavy-use composite: filter by contract + topic symbol (event name)
+  @@index([contractAddress, topicSymbol])
+  // Cursor-based pagination: contract + ledger desc
+  @@index([contractAddress, ledgerSequence, id])
+  // Filter by contract + event type + ledger for time-range queries
+  @@index([contractAddress, eventType, ledgerSequence])
 }
 
 // Custom event symbol → template bindings submitted by verified project creators

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -9,16 +9,17 @@ const paginationSchema = z.object({
   limit: z.coerce.number().min(1).max(100).default(20),
 });
 
-// GET /events?contract=&type=&page=1
+// GET /events?contract=&type=&topic=&page=1
 eventRouter.get('/', async (req: Request, res: Response) => {
   try {
     const { page, limit } = paginationSchema.parse(req.query);
-    const { contract, type } = req.query as Record<string, string>;
+    const { contract, type, topic } = req.query as Record<string, string>;
     const skip = (page - 1) * limit;
 
     const where = {
       ...(contract && { contractAddress: contract }),
       ...(type && { eventType: type }),
+      ...(topic && { topicSymbol: topic }),
     };
 
     const [events, total] = await Promise.all([
@@ -32,6 +33,7 @@ eventRouter.get('/', async (req: Request, res: Response) => {
           transactionHash: true,
           contractAddress: true,
           eventType: true,
+          topicSymbol: true,
           decoded: true,
           ledgerSequence: true,
           ledgerCloseTime: true,

--- a/src/indexer/decoder.ts
+++ b/src/indexer/decoder.ts
@@ -94,27 +94,27 @@ export function decodeEvent(
   topics: string[],
   data: string,
   contractName?: string | null
-): { eventType: string; decoded: Record<string, unknown> } {
+): { eventType: string; topicSymbol: string | null; decoded: Record<string, unknown> } {
   try {
     const topicVals = topics.map((t) => xdr.ScVal.fromXDR(t, 'base64'));
     const dataVal = xdr.ScVal.fromXDR(data, 'base64');
 
     // First topic is usually the event name symbol
-    const eventType = topicVals[0]
+    const rawSymbol = topicVals[0]
       ? String(scValToNative(topicVals[0]))
       : 'unknown';
 
-    const decoded: Record<string, unknown> = { event: eventType };
+    const decoded: Record<string, unknown> = { event: rawSymbol };
 
     // SEP-41 transfer event: topics = [Symbol("transfer"), from, to], data = amount
-    if (eventType === 'transfer' && topicVals.length >= 3) {
+    if (rawSymbol === 'transfer' && topicVals.length >= 3) {
       decoded.from = String(scValToNative(topicVals[1]));
       decoded.to = String(scValToNative(topicVals[2]));
       decoded.amount = String(scValToNative(dataVal));
-    } else if (eventType === 'mint' && topicVals.length >= 2) {
+    } else if (rawSymbol === 'mint' && topicVals.length >= 2) {
       decoded.to = String(scValToNative(topicVals[1]));
       decoded.amount = String(scValToNative(dataVal));
-    } else if (eventType === 'burn' && topicVals.length >= 2) {
+    } else if (rawSymbol === 'burn' && topicVals.length >= 2) {
       decoded.from = String(scValToNative(topicVals[1]));
       decoded.amount = String(scValToNative(dataVal));
     } else {
@@ -123,9 +123,9 @@ export function decodeEvent(
       decoded.data = scValToNative(dataVal);
     }
 
-    return { eventType: normalizeEventType(eventType), decoded };
+    return { eventType: normalizeEventType(rawSymbol), topicSymbol: rawSymbol, decoded };
   } catch {
-    return { eventType: 'unknown', decoded: { raw: { topics, data } } };
+    return { eventType: 'unknown', topicSymbol: null, decoded: { raw: { topics, data } } };
   }
 }
 

--- a/src/indexer/eventIngestor.ts
+++ b/src/indexer/eventIngestor.ts
@@ -107,7 +107,7 @@ async function storeEvent(event: LedgerEvent): Promise<number> {
   });
   if (!txExists) return 0; // transaction not yet indexed; skip
 
-  const { eventType, decoded } = decodeEvent(event.topics, event.data);
+  const { eventType, topicSymbol, decoded } = decodeEvent(event.topics, event.data);
 
   // Stable dedup key: hash + first topic (mirrors existing indexer logic)
   const id = `${event.transactionHash}-${event.topics[0] ?? '0'}`;
@@ -120,6 +120,7 @@ async function storeEvent(event: LedgerEvent): Promise<number> {
       transactionHash: event.transactionHash,
       contractAddress: event.contractId,
       eventType,
+      topicSymbol,
       topics: event.topics,
       data: { raw: event.data },
       decoded: decoded as object,


### PR DESCRIPTION
Closes #30

---

- Fix duplicate createdAt/updatedAt fields on Contract model (schema was invalid)
- Add functionSignatures Json? field to Contract for storing decoded function signatures
- Add topicSymbol String? column to Event for the first decoded topic (event name)
- Add indexes on Event: topicSymbol, (contractAddress, topicSymbol), (contractAddress, ledgerSequence, id), (contractAddress, eventType, ledgerSequence)
- Populate topicSymbol in eventIngestor when storing events
- Expose topicSymbol from decodeEvent() return value
- Support ?topic= filter on GET /events and include topicSymbol in list response


Files changed:
- prisma/schema.prisma — schema fixes + new field + indexes
- src/indexer/decoder.ts — return topicSymbol from decodeEvent
- src/indexer/eventIngestor.ts — persist topicSymbol on upsert
- src/api/events.ts — ?topic= filter + expose topicSymbol in response