### PR TITLE
feat: protocol upgrade fork invariant verifier

### DIFF
--- a/src/api/protocol.ts
+++ b/src/api/protocol.ts
@@ -1,10 +1,13 @@
 /**
- * GET /api/v1/protocol — current protocol version status (#51)
- * GET /api/v1/protocol/reconciliation — trigger/view reconciliation report (#50)
+ * GET  /api/v1/protocol                    — current protocol version status (#51)
+ * GET  /api/v1/protocol/reconciliation     — trigger/view reconciliation report (#50)
+ * POST /api/v1/protocol/validate-upgrade   — pre-validate XDR invariants for an upcoming protocol version
  */
 import { Router, Request, Response } from 'express';
+import { z } from 'zod';
 import { getProtocolStatus } from '../indexer/protocol-guard';
 import { runReconciliation } from '../indexer/reconciliation';
+import { verifyUpgradeInvariants } from '../indexer/upgrade-invariant';
 
 export const protocolRouter = Router();
 
@@ -27,4 +30,26 @@ protocolRouter.get('/reconciliation', async (req: Request, res: Response) => {
   } catch (err) {
     res.status(500).json({ error: String(err) });
   }
+});
+
+const validateUpgradeSchema = z.object({
+  protocolVersion: z.number().int().min(1),
+  candidates: z.object({
+    envelopeXdr:   z.string().optional(),
+    resultXdr:     z.string().optional(),
+    resultMetaXdr: z.string().optional(),
+    ledgerEntryXdr: z.string().optional(),
+  }),
+});
+
+// POST /protocol/validate-upgrade — pre-validate XDR invariants before a protocol upgrade goes live
+protocolRouter.post('/validate-upgrade', (req: Request, res: Response) => {
+  const parsed = validateUpgradeSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Invalid request', details: parsed.error.flatten() });
+    return;
+  }
+  const { protocolVersion, candidates } = parsed.data;
+  const result = verifyUpgradeInvariants(candidates, protocolVersion);
+  res.status(result.safe ? 200 : 422).json(result);
 });

--- a/src/indexer/upgrade-invariant.ts
+++ b/src/indexer/upgrade-invariant.ts
@@ -1,0 +1,316 @@
+/**
+ * Protocol Upgrade Fork Invariant Verifier
+ *
+ * Pre-validation gating engine that screens incoming protocol upgrades for
+ * structural ledger changes. Validates XDR definitions dynamically against
+ * upcoming schema adaptations before new rules go live, so parser engines
+ * are never exposed to breaking structures at runtime.
+ *
+ * Usage:
+ *   const result = await verifyUpgradeInvariants(candidateXdrs, nextProtocolVersion);
+ *   if (!result.safe) throw new Error(result.violations.join('; '));
+ */
+
+import { xdr } from '@stellar/stellar-sdk';
+
+// ── Invariant definitions ────────────────────────────────────────────────────
+
+export interface XdrInvariant {
+  /** Human-readable name for this invariant */
+  name: string;
+  /**
+   * Probe function: receives a raw base64 XDR blob and returns true if the
+   * structural invariant holds. Must not throw — return false on any error.
+   */
+  probe: (xdrBase64: string) => boolean;
+}
+
+export interface CandidateXdrs {
+  /** A sample transaction envelope XDR (base64) to probe */
+  envelopeXdr?: string;
+  /** A sample transaction result XDR (base64) to probe */
+  resultXdr?: string;
+  /** A sample transaction result meta XDR (base64) to probe */
+  resultMetaXdr?: string;
+  /** A sample ledger entry XDR (base64) to probe */
+  ledgerEntryXdr?: string;
+}
+
+export interface InvariantViolation {
+  invariant: string;
+  reason: string;
+}
+
+export interface UpgradeValidationResult {
+  /** True only when all invariants pass */
+  safe: boolean;
+  protocolVersion: number;
+  violations: InvariantViolation[];
+  /** Invariants that passed */
+  passed: string[];
+  /** Invariants that were skipped (no sample XDR provided for their category) */
+  skipped: string[];
+}
+
+// ── Core invariants ──────────────────────────────────────────────────────────
+
+/**
+ * Invariants keyed by the XDR category they require.
+ * Each invariant probes one structural property of the XDR type.
+ */
+const ENVELOPE_INVARIANTS: XdrInvariant[] = [
+  {
+    name: 'envelope:decodable',
+    probe: (b64) => {
+      try { xdr.TransactionEnvelope.fromXDR(b64, 'base64'); return true; }
+      catch { return false; }
+    },
+  },
+  {
+    name: 'envelope:known-switch',
+    probe: (b64) => {
+      try {
+        const env = xdr.TransactionEnvelope.fromXDR(b64, 'base64');
+        const name = env.switch().name;
+        return name === 'envelopeTypeTx' || name === 'envelopeTypeTxV0' || name === 'envelopeTypeTxFeeBump';
+      } catch { return false; }
+    },
+  },
+  {
+    name: 'envelope:has-operations',
+    probe: (b64) => {
+      try {
+        const env = xdr.TransactionEnvelope.fromXDR(b64, 'base64');
+        const ops = env.switch().name === 'envelopeTypeTx'
+          ? env.v1().tx().operations()
+          : env.switch().name === 'envelopeTypeTxV0'
+            ? env.v0().tx().operations()
+            : null;
+        return ops !== null;
+      } catch { return false; }
+    },
+  },
+];
+
+const RESULT_INVARIANTS: XdrInvariant[] = [
+  {
+    name: 'result:decodable',
+    probe: (b64) => {
+      try { xdr.TransactionResult.fromXDR(b64, 'base64'); return true; }
+      catch { return false; }
+    },
+  },
+  {
+    name: 'result:has-result-union',
+    probe: (b64) => {
+      try {
+        const r = xdr.TransactionResult.fromXDR(b64, 'base64');
+        // result() must return a union with a switch
+        const res = r.result();
+        return typeof res.switch === 'function';
+      } catch { return false; }
+    },
+  },
+];
+
+const RESULT_META_INVARIANTS: XdrInvariant[] = [
+  {
+    name: 'resultMeta:decodable',
+    probe: (b64) => {
+      try { xdr.TransactionResultMeta.fromXDR(b64, 'base64'); return true; }
+      catch { return false; }
+    },
+  },
+];
+
+const LEDGER_ENTRY_INVARIANTS: XdrInvariant[] = [
+  {
+    name: 'ledgerEntry:decodable',
+    probe: (b64) => {
+      try { xdr.LedgerEntry.fromXDR(b64, 'base64'); return true; }
+      catch { return false; }
+    },
+  },
+  {
+    name: 'ledgerEntry:known-type',
+    probe: (b64) => {
+      try {
+        const entry = xdr.LedgerEntry.fromXDR(b64, 'base64');
+        const typeName = entry.data().switch().name;
+        const known = ['account', 'trustline', 'offer', 'data', 'claimableBalance', 'liquidityPool', 'contractData', 'contractCode', 'configSetting', 'ttl'];
+        return known.includes(typeName);
+      } catch { return false; }
+    },
+  },
+];
+
+// ── Version-specific structural rules ────────────────────────────────────────
+
+/**
+ * Additional invariants that only apply at or above a given protocol version.
+ * These encode "if we're on protocol N+, this structure MUST exist."
+ */
+const VERSION_INVARIANTS: Array<{ minVersion: number; invariant: XdrInvariant; category: keyof CandidateXdrs }> = [
+  {
+    minVersion: 20,
+    category: 'envelopeXdr',
+    invariant: {
+      name: 'envelope:soroban-v1-invoke-host-function-arm',
+      probe: (b64) => {
+        try {
+          const env = xdr.TransactionEnvelope.fromXDR(b64, 'base64');
+          if (env.switch().name !== 'envelopeTypeTx') return true; // not a v1 tx, skip
+          const ops = env.v1().tx().operations();
+          // If any op is invokeHostFunction, the arm must be parseable
+          for (const op of ops) {
+            if (op.body().switch().name === 'invokeHostFunction') {
+              op.body().invokeHostFunctionOp(); // throws if arm is broken
+            }
+          }
+          return true;
+        } catch { return false; }
+      },
+    },
+  },
+  {
+    minVersion: 21,
+    category: 'resultMetaXdr',
+    invariant: {
+      name: 'resultMeta:v3-soroban-meta-accessible',
+      probe: (b64) => {
+        try {
+          const meta = xdr.TransactionResultMeta.fromXDR(b64, 'base64');
+          // v3 meta must have a txApplyProcessing field accessible without throwing
+          const result = meta.result();
+          return typeof result !== 'undefined';
+        } catch { return false; }
+      },
+    },
+  },
+];
+
+// ── Engine ───────────────────────────────────────────────────────────────────
+
+function runInvariants(
+  invariants: XdrInvariant[],
+  xdrBlob: string,
+  violations: InvariantViolation[],
+  passed: string[],
+): void {
+  for (const inv of invariants) {
+    try {
+      if (inv.probe(xdrBlob)) {
+        passed.push(inv.name);
+      } else {
+        violations.push({ invariant: inv.name, reason: 'probe returned false' });
+      }
+    } catch (err) {
+      violations.push({
+        invariant: inv.name,
+        reason: `probe threw: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  }
+}
+
+/**
+ * Verify structural invariants against candidate XDR samples for a given
+ * upcoming protocol version. Call this before allowing the indexer to process
+ * ledgers under the new protocol.
+ *
+ * @param candidates  Sample XDR blobs from the first ledger(s) of the new protocol
+ * @param nextVersion The protocol version being gated
+ */
+export function verifyUpgradeInvariants(
+  candidates: CandidateXdrs,
+  nextVersion: number,
+): UpgradeValidationResult {
+  const violations: InvariantViolation[] = [];
+  const passed: string[] = [];
+  const skipped: string[] = [];
+
+  // Run category invariants only when a sample is provided
+  if (candidates.envelopeXdr) {
+    runInvariants(ENVELOPE_INVARIANTS, candidates.envelopeXdr, violations, passed);
+  } else {
+    skipped.push(...ENVELOPE_INVARIANTS.map((i) => i.name));
+  }
+
+  if (candidates.resultXdr) {
+    runInvariants(RESULT_INVARIANTS, candidates.resultXdr, violations, passed);
+  } else {
+    skipped.push(...RESULT_INVARIANTS.map((i) => i.name));
+  }
+
+  if (candidates.resultMetaXdr) {
+    runInvariants(RESULT_META_INVARIANTS, candidates.resultMetaXdr, violations, passed);
+  } else {
+    skipped.push(...RESULT_META_INVARIANTS.map((i) => i.name));
+  }
+
+  if (candidates.ledgerEntryXdr) {
+    runInvariants(LEDGER_ENTRY_INVARIANTS, candidates.ledgerEntryXdr, violations, passed);
+  } else {
+    skipped.push(...LEDGER_ENTRY_INVARIANTS.map((i) => i.name));
+  }
+
+  // Version-specific invariants
+  for (const { minVersion, category, invariant } of VERSION_INVARIANTS) {
+    if (nextVersion < minVersion) {
+      skipped.push(invariant.name);
+      continue;
+    }
+    const blob = candidates[category];
+    if (!blob) {
+      skipped.push(invariant.name);
+      continue;
+    }
+    try {
+      if (invariant.probe(blob)) {
+        passed.push(invariant.name);
+      } else {
+        violations.push({ invariant: invariant.name, reason: 'probe returned false' });
+      }
+    } catch (err) {
+      violations.push({
+        invariant: invariant.name,
+        reason: `probe threw: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  }
+
+  return {
+    safe: violations.length === 0,
+    protocolVersion: nextVersion,
+    violations,
+    passed,
+    skipped,
+  };
+}
+
+/**
+ * Gate function for the indexer: call before processing the first ledger of a
+ * new protocol version. Logs a structured warning if any invariant fails and
+ * returns false, signalling the caller to hold off or fall back to safe mode.
+ */
+export function gateUpgrade(
+  candidates: CandidateXdrs,
+  nextVersion: number,
+): boolean {
+  const result = verifyUpgradeInvariants(candidates, nextVersion);
+
+  if (!result.safe) {
+    console.warn(
+      `[upgrade-invariant] ⛔ Protocol ${nextVersion} failed pre-validation. ` +
+      `${result.violations.length} violation(s):`,
+      result.violations.map((v) => `${v.invariant}: ${v.reason}`).join(' | '),
+    );
+    return false;
+  }
+
+  console.log(
+    `[upgrade-invariant] ✅ Protocol ${nextVersion} passed pre-validation. ` +
+    `${result.passed.length} invariant(s) checked, ${result.skipped.length} skipped.`,
+  );
+  return true;
+}

--- a/tests/upgrade-invariant.test.ts
+++ b/tests/upgrade-invariant.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import {
+  xdr,
+  Keypair,
+  Account,
+  TransactionBuilder,
+  Networks,
+  Operation,
+  Address,
+  nativeToScVal,
+} from '@stellar/stellar-sdk';
+import { verifyUpgradeInvariants, gateUpgrade, CandidateXdrs } from '../src/indexer/upgrade-invariant';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const FAKE_CONTRACT_ID = Buffer.alloc(32, 0xab);
+
+function buildEnvelopeXdr(): string {
+  const source = Keypair.random();
+  const account = new Account(source.publicKey(), '100');
+  const contractAddress = xdr.ScAddress.scAddressTypeContract(FAKE_CONTRACT_ID);
+  const invokeArgs = new xdr.InvokeContractArgs({
+    contractAddress,
+    functionName: Buffer.from('swap'),
+    args: [nativeToScVal(100n, { type: 'i128' })],
+  });
+  const hostFn = xdr.HostFunction.hostFunctionTypeInvokeContract(invokeArgs);
+  const op = Operation.invokeHostFunction({ func: hostFn, auth: [] });
+  const tx = new TransactionBuilder(account, { fee: '100', networkPassphrase: Networks.TESTNET })
+    .addOperation(op)
+    .setTimeout(30)
+    .build();
+  return tx.toEnvelope().toXDR('base64');
+}
+
+function buildResultXdr(): string {
+  const result = new xdr.TransactionResult({
+    feeCharged: xdr.Int64.fromString('100'),
+    result: xdr.TransactionResultResult.txSuccess([]),
+    ext: xdr.TransactionResultExt.fromXDR('AAAAAA==', 'base64'),
+  });
+  return result.toXDR('base64');
+}
+
+// ── verifyUpgradeInvariants ───────────────────────────────────────────────────
+
+describe('verifyUpgradeInvariants', () => {
+  it('returns safe=true with all passed when valid envelope is provided', () => {
+    const candidates: CandidateXdrs = { envelopeXdr: buildEnvelopeXdr() };
+    const result = verifyUpgradeInvariants(candidates, 21);
+
+    expect(result.safe).toBe(true);
+    expect(result.protocolVersion).toBe(21);
+    expect(result.violations).toHaveLength(0);
+    expect(result.passed).toContain('envelope:decodable');
+    expect(result.passed).toContain('envelope:known-switch');
+    expect(result.passed).toContain('envelope:has-operations');
+  });
+
+  it('returns safe=true with valid result XDR', () => {
+    const candidates: CandidateXdrs = { resultXdr: buildResultXdr() };
+    const result = verifyUpgradeInvariants(candidates, 20);
+
+    expect(result.safe).toBe(true);
+    expect(result.passed).toContain('result:decodable');
+    expect(result.passed).toContain('result:has-result-union');
+  });
+
+  it('skips all invariants when no candidates are provided', () => {
+    const result = verifyUpgradeInvariants({}, 21);
+
+    expect(result.safe).toBe(true);
+    expect(result.passed).toHaveLength(0);
+    expect(result.skipped.length).toBeGreaterThan(0);
+  });
+
+  it('reports violation for a corrupt envelope XDR', () => {
+    const candidates: CandidateXdrs = { envelopeXdr: 'not-valid-base64-xdr==' };
+    const result = verifyUpgradeInvariants(candidates, 21);
+
+    expect(result.safe).toBe(false);
+    expect(result.violations.length).toBeGreaterThan(0);
+    expect(result.violations[0].invariant).toBe('envelope:decodable');
+  });
+
+  it('reports violation for a corrupt result XDR', () => {
+    const candidates: CandidateXdrs = { resultXdr: 'AAAA' };
+    const result = verifyUpgradeInvariants(candidates, 20);
+
+    expect(result.safe).toBe(false);
+    expect(result.violations.some((v) => v.invariant.startsWith('result:'))).toBe(true);
+  });
+
+  it('skips version-specific invariants below their minimum version', () => {
+    // envelope:soroban-v1-invoke-host-function-arm requires minVersion 20
+    const candidates: CandidateXdrs = { envelopeXdr: buildEnvelopeXdr() };
+    const result = verifyUpgradeInvariants(candidates, 19);
+
+    expect(result.skipped).toContain('envelope:soroban-v1-invoke-host-function-arm');
+  });
+
+  it('runs version-specific invariants at or above their minimum version', () => {
+    const candidates: CandidateXdrs = { envelopeXdr: buildEnvelopeXdr() };
+    const result = verifyUpgradeInvariants(candidates, 20);
+
+    // Should be checked (not skipped) and should pass for a valid envelope
+    expect(result.skipped).not.toContain('envelope:soroban-v1-invoke-host-function-arm');
+    expect(result.passed).toContain('envelope:soroban-v1-invoke-host-function-arm');
+  });
+
+  it('includes both passed and skipped in the result', () => {
+    const candidates: CandidateXdrs = { envelopeXdr: buildEnvelopeXdr() };
+    const result = verifyUpgradeInvariants(candidates, 21);
+
+    // result/resultMeta/ledgerEntry invariants should be skipped (no samples)
+    expect(result.skipped).toContain('result:decodable');
+    expect(result.skipped).toContain('resultMeta:decodable');
+    expect(result.skipped).toContain('ledgerEntry:decodable');
+  });
+});
+
+// ── gateUpgrade ───────────────────────────────────────────────────────────────
+
+describe('gateUpgrade', () => {
+  it('returns true when all provided invariants pass', () => {
+    const candidates: CandidateXdrs = { envelopeXdr: buildEnvelopeXdr() };
+    expect(gateUpgrade(candidates, 21)).toBe(true);
+  });
+
+  it('returns false when an invariant fails', () => {
+    const candidates: CandidateXdrs = { envelopeXdr: 'garbage-xdr' };
+    expect(gateUpgrade(candidates, 21)).toBe(false);
+  });
+
+  it('returns true when no candidates are provided (nothing to fail)', () => {
+    expect(gateUpgrade({}, 21)).toBe(true);
+  });
+});


### PR DESCRIPTION
closes #104 
What was implemented:

src/indexer/upgrade-invariant.ts — The core engine. Defines structural XDR invariants grouped by category (envelope, result, resultMeta, ledgerEntry) plus version-gated invariants (e.g. the invokeHostFunction arm only checked at protocol ≥ 20). 
verifyUpgradeInvariants() probes candidate XDR blobs against all applicable invariants and returns a structured UpgradeValidationResult with safe, violations, passed, and skipped. gateUpgrade() wraps it with structured logging and returns a boolean 
for the indexer to act on.
 stash. do not commit, after completing the task, write me the commit message and i'll do the rest my self(commit 422 with the violation list if 
not.

tests/upgrade-invariant.test.ts — 11 tests covering: valid envelope passes, valid result passes, empty candidates skips all, corrupt XDR produces violations, version-gated invariants are skipped below their minimum version and run above it, 
gateUpgrade returns correct booleans.

All 68 tests pass (68 up from 57).