### PR TITLE
feat: add read replica lag-mitigation engine

### DIFF
--- a/src/db/replicaGateway.ts
+++ b/src/db/replicaGateway.ts
@@ -1,0 +1,58 @@
+import { PrismaClient } from '@prisma/client';
+import { prismaRead, prismaWrite } from '../db';
+
+/** Ledgers behind primary before we fall back to the write node (~10 s). */
+export const LAG_THRESHOLD_LEDGERS = 2;
+
+/** How long (ms) to cache a lag measurement before re-checking. */
+const CACHE_TTL_MS = 5_000;
+
+let cachedLag: number | null = null;
+let cacheExpiresAt = 0;
+
+/**
+ * Query the replica for its latest indexed ledger and compare to the primary.
+ * Returns the lag in ledgers (primary − replica). Returns 0 on any error so
+ * we don't unnecessarily fall back when the check itself fails.
+ */
+export async function measureReplicaLag(
+  read: PrismaClient = prismaRead,
+  write: PrismaClient = prismaWrite,
+): Promise<number> {
+  const now = Date.now();
+  if (cachedLag !== null && now < cacheExpiresAt) return cachedLag;
+
+  try {
+    const [primaryState, replicaState] = await Promise.all([
+      write.indexerState.findUnique({ where: { id: 'singleton' }, select: { lastLedger: true } }),
+      read.indexerState.findUnique({ where: { id: 'singleton' }, select: { lastLedger: true } }),
+    ]);
+
+    const primaryLedger = primaryState?.lastLedger ?? 0;
+    const replicaLedger = replicaState?.lastLedger ?? 0;
+    cachedLag = Math.max(0, primaryLedger - replicaLedger);
+  } catch {
+    cachedLag = 0; // fail-open: don't force primary on measurement error
+  }
+
+  cacheExpiresAt = now + CACHE_TTL_MS;
+  return cachedLag;
+}
+
+/**
+ * Returns `prismaRead` when the replica is within the acceptable lag window,
+ * otherwise falls back to `prismaWrite` (primary).
+ */
+export async function getReadClient(
+  read: PrismaClient = prismaRead,
+  write: PrismaClient = prismaWrite,
+): Promise<PrismaClient> {
+  const lag = await measureReplicaLag(read, write);
+  return lag > LAG_THRESHOLD_LEDGERS ? write : read;
+}
+
+/** Expose cache-busting for tests. */
+export function _resetLagCache(): void {
+  cachedLag = null;
+  cacheExpiresAt = 0;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { router } from './api/router';
 import { prismaWrite as prisma } from './db';
 import { startIndexerService } from './indexer/indexer';
 import { tieredRateLimit } from './middleware/rateLimit';
+import { replicaGuard } from './middleware/replicaGuard';
 import { swaggerSpec } from './indexer/swaggerSpec';
 
 const app = express();
@@ -18,6 +19,7 @@ app.use(cors());
 app.use(morgan('dev'));
 app.use(express.json());
 app.use(tieredRateLimit);
+app.use(replicaGuard);
 
 // Interactive API docs
 app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));

--- a/src/middleware/replicaGuard.ts
+++ b/src/middleware/replicaGuard.ts
@@ -1,0 +1,23 @@
+import { Request, Response, NextFunction } from 'express';
+import { getReadClient, measureReplicaLag, LAG_THRESHOLD_LEDGERS } from '../db/replicaGateway';
+
+/**
+ * Attaches the appropriate Prisma read client to `res.locals.db`.
+ *
+ * If the replica lags the primary by more than LAG_THRESHOLD_LEDGERS ledgers
+ * (~10 s), `res.locals.db` is set to the primary write client so that
+ * critical frontend reads are never served stale data.
+ */
+export async function replicaGuard(req: Request, res: Response, next: NextFunction) {
+  try {
+    res.locals.db = await getReadClient();
+    const lag = await measureReplicaLag();
+    if (lag > LAG_THRESHOLD_LEDGERS) {
+      res.setHeader('X-Replica-Fallback', 'true');
+      res.setHeader('X-Replica-Lag-Ledgers', String(lag));
+    }
+  } catch {
+    // Never block a request due to lag-check failure
+  }
+  next();
+}

--- a/tests/replica-gateway.test.ts
+++ b/tests/replica-gateway.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { measureReplicaLag, getReadClient, LAG_THRESHOLD_LEDGERS, _resetLagCache } from '../src/db/replicaGateway';
+import type { PrismaClient } from '@prisma/client';
+
+function makeClient(lastLedger: number | null) {
+  return {
+    indexerState: {
+      findUnique: vi.fn().mockResolvedValue(lastLedger !== null ? { lastLedger } : null),
+    },
+  } as unknown as PrismaClient;
+}
+
+beforeEach(() => _resetLagCache());
+
+describe('measureReplicaLag', () => {
+  it('returns 0 when replica is in sync', async () => {
+    const lag = await measureReplicaLag(makeClient(100), makeClient(100));
+    expect(lag).toBe(0);
+  });
+
+  it('returns positive lag when replica is behind', async () => {
+    const lag = await measureReplicaLag(makeClient(98), makeClient(100));
+    expect(lag).toBe(2);
+  });
+
+  it('never returns negative lag', async () => {
+    const lag = await measureReplicaLag(makeClient(105), makeClient(100));
+    expect(lag).toBe(0);
+  });
+
+  it('returns 0 (fail-open) when the DB throws', async () => {
+    const broken = {
+      indexerState: { findUnique: vi.fn().mockRejectedValue(new Error('db down')) },
+    } as unknown as PrismaClient;
+    const lag = await measureReplicaLag(broken, broken);
+    expect(lag).toBe(0);
+  });
+
+  it('caches the result within TTL', async () => {
+    const read = makeClient(98);
+    const write = makeClient(100);
+    await measureReplicaLag(read, write);
+    await measureReplicaLag(read, write);
+    expect(read.indexerState.findUnique).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getReadClient', () => {
+  it('returns the read client when lag is within threshold', async () => {
+    const read = makeClient(99);
+    const write = makeClient(100);
+    const client = await getReadClient(read, write);
+    expect(client).toBe(read);
+  });
+
+  it(`falls back to write client when lag exceeds ${LAG_THRESHOLD_LEDGERS} ledgers`, async () => {
+    const read = makeClient(90);
+    const write = makeClient(100);
+    const client = await getReadClient(read, write);
+    expect(client).toBe(write);
+  });
+
+  it('returns read client when lag equals threshold exactly', async () => {
+    const read = makeClient(100 - LAG_THRESHOLD_LEDGERS);
+    const write = makeClient(100);
+    const client = await getReadClient(read, write);
+    expect(client).toBe(read);
+  });
+});


### PR DESCRIPTION
closes #105 

Branch: feat/Read-Replicas-Lag-Mitigation-Engine

Files created/modified:

- src/db/replicaGateway.ts — core engine: queries indexerState on both primary and replica, computes lag in ledgers, caches the result for 5s, and returns the appropriate Prisma client (prismaRead if lag ≤ 2,
prismaWrite as fallback)
- src/middleware/replicaGuard.ts — Express middleware that calls getReadClient() and attaches it to res.locals.db; sets X-Replica-Fallback: true and X-Replica-Lag-Ledgers: N headers when falling back
- src/index.ts — wired replicaGuard middleware in after tieredRateLimit
- tests/replica-gateway.test.ts — 8 unit tests covering: in-sync, lagging, negative-lag guard, DB error fail-open, cache TTL, threshold boundary, and fallback trigger

All 65 tests pass. Build errors are pre-existing in simulate.ts and footprint-formatter.ts (confirmed by stash test — identical errors exist on the base branch before any of our changes).