### PR TITLE
feat: add SEP-41 token standard parser

### DIFF
--- a/src/indexer/decoder.ts
+++ b/src/indexer/decoder.ts
@@ -1,6 +1,7 @@
 import { xdr, scValToNative } from '@stellar/stellar-sdk';
 import { getContractAbi, decodeArgs, renderHuman } from './registry';
 import { parseInvokeHostFunction } from './xdr-parser';
+import { parseSep41Event, isSep41Event } from './sep41-parser';
 import { prismaRead as prisma } from '../db';
 
 /**
@@ -97,31 +98,36 @@ export function decodeEvent(
 ): { eventType: string; topicSymbol: string | null; decoded: Record<string, unknown> } {
   try {
     const topicVals = topics.map((t) => xdr.ScVal.fromXDR(t, 'base64'));
-    const dataVal = xdr.ScVal.fromXDR(data, 'base64');
 
     // First topic is usually the event name symbol
     const rawSymbol = topicVals[0]
       ? String(scValToNative(topicVals[0]))
       : 'unknown';
 
-    const decoded: Record<string, unknown> = { event: rawSymbol };
-
-    // SEP-41 transfer event: topics = [Symbol("transfer"), from, to], data = amount
-    if (rawSymbol === 'transfer' && topicVals.length >= 3) {
-      decoded.from = String(scValToNative(topicVals[1]));
-      decoded.to = String(scValToNative(topicVals[2]));
-      decoded.amount = String(scValToNative(dataVal));
-    } else if (rawSymbol === 'mint' && topicVals.length >= 2) {
-      decoded.to = String(scValToNative(topicVals[1]));
-      decoded.amount = String(scValToNative(dataVal));
-    } else if (rawSymbol === 'burn' && topicVals.length >= 2) {
-      decoded.from = String(scValToNative(topicVals[1]));
-      decoded.amount = String(scValToNative(dataVal));
-    } else {
-      // Generic: decode all topics and data
-      decoded.topics = topicVals.map((t) => scValToNative(t));
-      decoded.data = scValToNative(dataVal);
+    // ── SEP-41 fast path ────────────────────────────────────────────────────
+    if (isSep41Event(rawSymbol)) {
+      const parsed = parseSep41Event(topics, data);
+      if (parsed) {
+        // Flatten { raw, formatted } entries to their formatted strings for
+        // storage compatibility, and keep the full structured fields too.
+        const decoded: Record<string, unknown> = {
+          event: rawSymbol,
+          humanReadable: parsed.humanReadable,
+          ...Object.fromEntries(
+            Object.entries(parsed.fields).map(([k, v]) => [k, v.formatted])
+          ),
+        };
+        return { eventType: normalizeEventType(rawSymbol), topicSymbol: rawSymbol, decoded };
+      }
     }
+
+    // ── Generic fallback ────────────────────────────────────────────────────
+    const dataVal = xdr.ScVal.fromXDR(data, 'base64');
+    const decoded: Record<string, unknown> = {
+      event: rawSymbol,
+      topics: topicVals.map((t) => scValToNative(t)),
+      data: scValToNative(dataVal),
+    };
 
     return { eventType: normalizeEventType(rawSymbol), topicSymbol: rawSymbol, decoded };
   } catch {
@@ -136,6 +142,8 @@ function normalizeEventType(raw: string): string {
     'burn',
     'swap',
     'approve',
+    'clawback',
+    'set_admin',
     'add_liquidity',
     'remove_liquidity',
     'session_authorization',

--- a/src/indexer/registry.ts
+++ b/src/indexer/registry.ts
@@ -2,6 +2,7 @@ import { xdr } from '@stellar/stellar-sdk';
 import { prismaRead as prisma } from '../db';
 import { decodeTypedArgs, formatAmount } from './args-decoder';
 import { renderTemplate } from './template-engine';
+import { getSep41Abi } from './sep41-parser';
 
 export interface ContractAbi {
   functions: AbiFunction[];
@@ -18,56 +19,13 @@ export interface AbiParam {
   type: string;
 }
 
-// Built-in ABI for SEP-41 token standard
-export const SEP41_ABI: ContractAbi = {
-  functions: [
-    {
-      name: 'transfer',
-      inputs: [
-        { name: 'from', type: 'address' },
-        { name: 'to', type: 'address' },
-        { name: 'amount', type: 'i128' },
-      ],
-      humanTemplate: '{from} transferred {amount} tokens to {to}',
-    },
-    {
-      name: 'transfer_from',
-      inputs: [
-        { name: 'spender', type: 'address' },
-        { name: 'from', type: 'address' },
-        { name: 'to', type: 'address' },
-        { name: 'amount', type: 'i128' },
-      ],
-      humanTemplate: '{spender} transferred {amount} tokens from {from} to {to}',
-    },
-    {
-      name: 'mint',
-      inputs: [
-        { name: 'to', type: 'address' },
-        { name: 'amount', type: 'i128' },
-      ],
-      humanTemplate: 'Minted {amount} tokens to {to}',
-    },
-    {
-      name: 'burn',
-      inputs: [
-        { name: 'from', type: 'address' },
-        { name: 'amount', type: 'i128' },
-      ],
-      humanTemplate: '{from} burned {amount} tokens',
-    },
-    {
-      name: 'approve',
-      inputs: [
-        { name: 'from', type: 'address' },
-        { name: 'spender', type: 'address' },
-        { name: 'amount', type: 'i128' },
-        { name: 'expiration_ledger', type: 'u32' },
-      ],
-      humanTemplate: '{from} approved {spender} to spend {amount} tokens',
-    },
-  ],
-};
+/**
+ * Full SEP-41 ABI — single source of truth lives in sep41-parser.ts.
+ * Covers all 14 standard functions: transfer, transfer_from, approve,
+ * balance_of, allowance, decimals, name, symbol, mint, burn, burn_from,
+ * clawback, set_admin, admin.
+ */
+export const SEP41_ABI: ContractAbi = getSep41Abi();
 
 /**
  * Get ABI for a contract address. Falls back to SEP-41 for token contracts.

--- a/src/indexer/sep41-parser.ts
+++ b/src/indexer/sep41-parser.ts
@@ -1,0 +1,375 @@
+/**
+ * SEP-41 Token Standard Parser
+ *
+ * Soroban's ERC-20 equivalent. Spec:
+ * https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0041.md
+ *
+ * All function and event signatures are hardcoded here so they can be decoded
+ * and formatted instantly — no custom ABI upload required.
+ *
+ * Functions  : transfer, transfer_from, approve, balance_of, allowance,
+ *              decimals, name, symbol, mint, burn, burn_from,
+ *              clawback, set_admin, admin
+ * Events     : transfer, mint, burn, approve, clawback, set_admin
+ */
+
+import { xdr, scValToNative, Address } from '@stellar/stellar-sdk';
+import { decodeTypedArgs, formatAmount } from './args-decoder';
+import type { AbiParam } from './registry';
+
+// ─── Canonical function signatures ───────────────────────────────────────────
+
+export interface Sep41FunctionDef {
+  name: string;
+  inputs: AbiParam[];
+  /** Human-readable template using {param} placeholders. */
+  humanTemplate: string;
+}
+
+/**
+ * Complete SEP-41 function table.
+ * Keyed by function name for O(1) lookup.
+ */
+export const SEP41_FUNCTIONS: Record<string, Sep41FunctionDef> = {
+  transfer: {
+    name: 'transfer',
+    inputs: [
+      { name: 'from', type: 'address' },
+      { name: 'to', type: 'address' },
+      { name: 'amount', type: 'i128' },
+    ],
+    humanTemplate: '{from|truncate} transferred {amount} {token} to {to|truncate}',
+  },
+  transfer_from: {
+    name: 'transfer_from',
+    inputs: [
+      { name: 'spender', type: 'address' },
+      { name: 'from', type: 'address' },
+      { name: 'to', type: 'address' },
+      { name: 'amount', type: 'i128' },
+    ],
+    humanTemplate: '{spender|truncate} transferred {amount} {token} from {from|truncate} to {to|truncate}',
+  },
+  approve: {
+    name: 'approve',
+    inputs: [
+      { name: 'from', type: 'address' },
+      { name: 'spender', type: 'address' },
+      { name: 'amount', type: 'i128' },
+      { name: 'expiration_ledger', type: 'u32' },
+    ],
+    humanTemplate: '{from|truncate} approved {spender|truncate} to spend {amount} {token} (expires ledger {expiration_ledger})',
+  },
+  balance_of: {
+    name: 'balance_of',
+    inputs: [{ name: 'id', type: 'address' }],
+    humanTemplate: 'Balance query for {id|truncate}',
+  },
+  allowance: {
+    name: 'allowance',
+    inputs: [
+      { name: 'from', type: 'address' },
+      { name: 'spender', type: 'address' },
+    ],
+    humanTemplate: 'Allowance query: {from|truncate} → {spender|truncate}',
+  },
+  decimals: {
+    name: 'decimals',
+    inputs: [],
+    humanTemplate: 'Query token decimals',
+  },
+  name: {
+    name: 'name',
+    inputs: [],
+    humanTemplate: 'Query token name',
+  },
+  symbol: {
+    name: 'symbol',
+    inputs: [],
+    humanTemplate: 'Query token symbol',
+  },
+  mint: {
+    name: 'mint',
+    inputs: [
+      { name: 'to', type: 'address' },
+      { name: 'amount', type: 'i128' },
+    ],
+    humanTemplate: 'Minted {amount} {token} to {to|truncate}',
+  },
+  burn: {
+    name: 'burn',
+    inputs: [
+      { name: 'from', type: 'address' },
+      { name: 'amount', type: 'i128' },
+    ],
+    humanTemplate: '{from|truncate} burned {amount} {token}',
+  },
+  burn_from: {
+    name: 'burn_from',
+    inputs: [
+      { name: 'spender', type: 'address' },
+      { name: 'from', type: 'address' },
+      { name: 'amount', type: 'i128' },
+    ],
+    humanTemplate: '{spender|truncate} burned {amount} {token} from {from|truncate}',
+  },
+  clawback: {
+    name: 'clawback',
+    inputs: [
+      { name: 'from', type: 'address' },
+      { name: 'amount', type: 'i128' },
+    ],
+    humanTemplate: 'Admin clawed back {amount} {token} from {from|truncate}',
+  },
+  set_admin: {
+    name: 'set_admin',
+    inputs: [{ name: 'new_admin', type: 'address' }],
+    humanTemplate: 'Admin changed to {new_admin|truncate}',
+  },
+  admin: {
+    name: 'admin',
+    inputs: [],
+    humanTemplate: 'Query token admin',
+  },
+};
+
+/** Fast O(1) check — is this function name part of the SEP-41 standard? */
+const SEP41_FUNCTION_NAMES = new Set(Object.keys(SEP41_FUNCTIONS));
+
+export function isSep41Function(fnName: string): boolean {
+  return SEP41_FUNCTION_NAMES.has(fnName);
+}
+
+// ─── Canonical event signatures ───────────────────────────────────────────────
+
+export interface Sep41EventDef {
+  /** Symbol emitted as the first topic. */
+  symbol: string;
+  /**
+   * Expected topic layout (index 0 is the symbol itself).
+   * Describes topics[1], topics[2], … in order.
+   */
+  topicParams: AbiParam[];
+  /** Data field type (single value). */
+  dataParam: AbiParam;
+  humanTemplate: string;
+}
+
+/**
+ * SEP-41 event table.
+ * Keyed by the raw symbol string emitted as topics[0].
+ */
+export const SEP41_EVENTS: Record<string, Sep41EventDef> = {
+  transfer: {
+    symbol: 'transfer',
+    topicParams: [
+      { name: 'from', type: 'address' },
+      { name: 'to', type: 'address' },
+    ],
+    dataParam: { name: 'amount', type: 'i128' },
+    humanTemplate: '{from|truncate} → {to|truncate}: {amount} {token}',
+  },
+  mint: {
+    symbol: 'mint',
+    topicParams: [
+      { name: 'admin', type: 'address' },
+      { name: 'to', type: 'address' },
+    ],
+    dataParam: { name: 'amount', type: 'i128' },
+    humanTemplate: 'Minted {amount} {token} to {to|truncate}',
+  },
+  burn: {
+    symbol: 'burn',
+    topicParams: [{ name: 'from', type: 'address' }],
+    dataParam: { name: 'amount', type: 'i128' },
+    humanTemplate: '{from|truncate} burned {amount} {token}',
+  },
+  approve: {
+    symbol: 'approve',
+    topicParams: [
+      { name: 'from', type: 'address' },
+      { name: 'spender', type: 'address' },
+    ],
+    dataParam: { name: 'amount', type: 'i128' },
+    humanTemplate: '{from|truncate} approved {spender|truncate} for {amount} {token}',
+  },
+  clawback: {
+    symbol: 'clawback',
+    topicParams: [
+      { name: 'admin', type: 'address' },
+      { name: 'from', type: 'address' },
+    ],
+    dataParam: { name: 'amount', type: 'i128' },
+    humanTemplate: 'Admin clawed back {amount} {token} from {from|truncate}',
+  },
+  set_admin: {
+    symbol: 'set_admin',
+    topicParams: [{ name: 'new_admin', type: 'address' }],
+    dataParam: { name: 'new_admin', type: 'address' },
+    humanTemplate: 'Token admin changed to {new_admin|truncate}',
+  },
+};
+
+/** Fast O(1) check — is this event symbol a known SEP-41 event? */
+const SEP41_EVENT_SYMBOLS = new Set(Object.keys(SEP41_EVENTS));
+
+export function isSep41Event(symbol: string): boolean {
+  return SEP41_EVENT_SYMBOLS.has(symbol);
+}
+
+// ─── Parsed result types ──────────────────────────────────────────────────────
+
+export interface Sep41ParsedCall {
+  functionName: string;
+  /** Named decoded args, each with { raw, formatted }. */
+  args: Record<string, { raw: unknown; formatted: string }>;
+  /** Pre-rendered human-readable string. */
+  humanReadable: string;
+}
+
+export interface Sep41ParsedEvent {
+  symbol: string;
+  /** Named decoded fields from topics + data. */
+  fields: Record<string, { raw: unknown; formatted: string }>;
+  /** Pre-rendered human-readable string. */
+  humanReadable: string;
+}
+
+// ─── Call parser ─────────────────────────────────────────────────────────────
+
+/**
+ * Parse a SEP-41 function call from raw XDR ScVal arguments.
+ *
+ * Returns null if `fnName` is not a known SEP-41 function.
+ * Never throws — falls back to raw XDR strings on individual arg decode errors.
+ *
+ * @param fnName   - The invoked function name (e.g. "transfer")
+ * @param rawArgs  - The ScVal argument array from the transaction envelope
+ * @param decimals - Token decimal places (default 7, Stellar standard)
+ * @param tokenSymbol - Token symbol for display (e.g. "USDC")
+ */
+export function parseSep41Call(
+  fnName: string,
+  rawArgs: xdr.ScVal[],
+  decimals = 7,
+  tokenSymbol = '',
+): Sep41ParsedCall | null {
+  const def = SEP41_FUNCTIONS[fnName];
+  if (!def) return null;
+
+  const decoded = decodeTypedArgs(def.inputs, rawArgs, decimals);
+  const human = renderSep41Template(def.humanTemplate, decoded, decimals, tokenSymbol);
+
+  return { functionName: fnName, args: decoded, humanReadable: human };
+}
+
+// ─── Event parser ─────────────────────────────────────────────────────────────
+
+/**
+ * Parse a SEP-41 event from raw base64-encoded XDR topics and data.
+ *
+ * topics[0] must be a Symbol ScVal matching a known SEP-41 event name.
+ * Returns null if the symbol is not a known SEP-41 event.
+ * Never throws.
+ *
+ * @param topics      - Array of base64-encoded XDR ScVal strings (topics)
+ * @param data        - Base64-encoded XDR ScVal string (event data)
+ * @param decimals    - Token decimal places (default 7)
+ * @param tokenSymbol - Token symbol for display
+ */
+export function parseSep41Event(
+  topics: string[],
+  data: string,
+  decimals = 7,
+  tokenSymbol = '',
+): Sep41ParsedEvent | null {
+  if (topics.length === 0) return null;
+
+  let symbol: string;
+  try {
+    const symbolVal = xdr.ScVal.fromXDR(topics[0], 'base64');
+    symbol = symbolVal.switch().name === 'scvSymbol'
+      ? symbolVal.sym().toString()
+      : String(scValToNative(symbolVal));
+  } catch {
+    return null;
+  }
+
+  const def = SEP41_EVENTS[symbol];
+  if (!def) return null;
+
+  const fields: Record<string, { raw: unknown; formatted: string }> = {};
+
+  // Decode topic params (topics[1], topics[2], …)
+  for (let i = 0; i < def.topicParams.length; i++) {
+    const topicXdr = topics[i + 1];
+    if (!topicXdr) continue;
+    try {
+      const val = xdr.ScVal.fromXDR(topicXdr, 'base64');
+      const [decoded] = Object.values(decodeTypedArgs([def.topicParams[i]], [val], decimals));
+      if (decoded) fields[def.topicParams[i].name] = decoded;
+    } catch {
+      fields[def.topicParams[i].name] = { raw: topicXdr, formatted: topicXdr };
+    }
+  }
+
+  // Decode data field
+  try {
+    const dataVal = xdr.ScVal.fromXDR(data, 'base64');
+    const [decoded] = Object.values(decodeTypedArgs([def.dataParam], [dataVal], decimals));
+    if (decoded) fields[def.dataParam.name] = decoded;
+  } catch {
+    fields[def.dataParam.name] = { raw: data, formatted: data };
+  }
+
+  const human = renderSep41Template(def.humanTemplate, fields, decimals, tokenSymbol);
+
+  return { symbol, fields, humanReadable: human };
+}
+
+// ─── Template renderer ────────────────────────────────────────────────────────
+
+/**
+ * Render a SEP-41 template string.
+ *
+ * Placeholders:
+ *   {key}          — resolved display value
+ *   {key|truncate} — address truncated to first 6 + "…" + last 4 chars
+ *   {token}        — tokenSymbol (empty string if not provided)
+ */
+export function renderSep41Template(
+  template: string,
+  args: Record<string, { raw: unknown; formatted: string }>,
+  decimals = 7,
+  tokenSymbol = '',
+): string {
+  return template.replace(/\{(\w+)(?:\|(\w+))?\}/g, (_match, key: string, modifier?: string) => {
+    if (key === 'token') return tokenSymbol;
+
+    const entry = args[key];
+    if (!entry) return '';
+
+    const display = entry.formatted;
+
+    if (modifier === 'truncate' && display.length > 12) {
+      return `${display.slice(0, 6)}…${display.slice(-4)}`;
+    }
+    return display;
+  });
+}
+
+// ─── ABI export (for registry integration) ────────────────────────────────────
+
+/**
+ * Returns the full SEP-41 ABI in the ContractAbi shape used by registry.ts.
+ * This is the single source of truth — registry.ts imports from here.
+ */
+export function getSep41Abi() {
+  return {
+    functions: Object.values(SEP41_FUNCTIONS).map((def) => ({
+      name: def.name,
+      inputs: def.inputs,
+      humanTemplate: def.humanTemplate,
+    })),
+  };
+}

--- a/tests/sep41-parser.test.ts
+++ b/tests/sep41-parser.test.ts
@@ -1,0 +1,475 @@
+/**
+ * Tests for the SEP-41 token standard parser.
+ *
+ * Covers:
+ *  - isSep41Function / isSep41Event guards
+ *  - parseSep41Call for every standard function
+ *  - parseSep41Event for every standard event
+ *  - renderSep41Template (truncation, {token} placeholder)
+ *  - getSep41Abi shape
+ *  - Edge cases: unknown names, missing args, malformed XDR
+ */
+
+import { describe, it, expect } from 'vitest';
+import { xdr, nativeToScVal, Address, Keypair } from '@stellar/stellar-sdk';
+import {
+  isSep41Function,
+  isSep41Event,
+  parseSep41Call,
+  parseSep41Event,
+  renderSep41Template,
+  getSep41Abi,
+  SEP41_FUNCTIONS,
+  SEP41_EVENTS,
+} from '../src/indexer/sep41-parser';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const ADDR_A = Keypair.random().publicKey();
+const ADDR_B = Keypair.random().publicKey();
+const ADDR_C = Keypair.random().publicKey();
+
+/** Encode a Stellar address as a base64 XDR ScVal. */
+function addrXdr(addr: string): string {
+  return new Address(addr).toScVal().toXDR('base64');
+}
+
+/** Encode a symbol as a base64 XDR ScVal. */
+function symXdr(sym: string): string {
+  return xdr.ScVal.scvSymbol(sym).toXDR('base64');
+}
+
+/** Encode an i128 bigint as a base64 XDR ScVal. */
+function i128Xdr(val: bigint): string {
+  return nativeToScVal(val, { type: 'i128' }).toXDR('base64');
+}
+
+/** Encode a u32 number as a base64 XDR ScVal. */
+function u32Xdr(val: number): string {
+  return nativeToScVal(val, { type: 'u32' }).toXDR('base64');
+}
+
+// ─── isSep41Function ──────────────────────────────────────────────────────────
+
+describe('isSep41Function', () => {
+  it('returns true for all standard SEP-41 functions', () => {
+    const expected = [
+      'transfer', 'transfer_from', 'approve', 'balance_of', 'allowance',
+      'decimals', 'name', 'symbol', 'mint', 'burn', 'burn_from',
+      'clawback', 'set_admin', 'admin',
+    ];
+    for (const fn of expected) {
+      expect(isSep41Function(fn), `expected ${fn} to be SEP-41`).toBe(true);
+    }
+  });
+
+  it('returns false for non-SEP-41 names', () => {
+    expect(isSep41Function('swap')).toBe(false);
+    expect(isSep41Function('deposit')).toBe(false);
+    expect(isSep41Function('')).toBe(false);
+    expect(isSep41Function('TRANSFER')).toBe(false); // case-sensitive
+  });
+});
+
+// ─── isSep41Event ─────────────────────────────────────────────────────────────
+
+describe('isSep41Event', () => {
+  it('returns true for all standard SEP-41 events', () => {
+    for (const sym of ['transfer', 'mint', 'burn', 'approve', 'clawback', 'set_admin']) {
+      expect(isSep41Event(sym), `expected ${sym} to be SEP-41 event`).toBe(true);
+    }
+  });
+
+  it('returns false for unknown symbols', () => {
+    expect(isSep41Event('swap')).toBe(false);
+    expect(isSep41Event('Transfer')).toBe(false);
+    expect(isSep41Event('')).toBe(false);
+  });
+});
+
+// ─── parseSep41Call ───────────────────────────────────────────────────────────
+
+describe('parseSep41Call — transfer', () => {
+  it('decodes args and renders human-readable string', () => {
+    const rawArgs = [
+      new Address(ADDR_A).toScVal(),
+      new Address(ADDR_B).toScVal(),
+      nativeToScVal(10_000_000n, { type: 'i128' }),
+    ];
+    const result = parseSep41Call('transfer', rawArgs, 7, 'USDC');
+    expect(result).not.toBeNull();
+    expect(result!.functionName).toBe('transfer');
+    expect(result!.args.from.formatted).toBe(ADDR_A);
+    expect(result!.args.to.formatted).toBe(ADDR_B);
+    expect(result!.args.amount.formatted).toBe('1.0000000');
+    expect(result!.humanReadable).toContain('USDC');
+    expect(result!.humanReadable).toContain('1.0000000');
+  });
+});
+
+describe('parseSep41Call — transfer_from', () => {
+  it('decodes spender, from, to, amount', () => {
+    const rawArgs = [
+      new Address(ADDR_C).toScVal(),
+      new Address(ADDR_A).toScVal(),
+      new Address(ADDR_B).toScVal(),
+      nativeToScVal(5_000_000n, { type: 'i128' }),
+    ];
+    const result = parseSep41Call('transfer_from', rawArgs, 7, 'XLM');
+    expect(result).not.toBeNull();
+    expect(result!.args.spender.formatted).toBe(ADDR_C);
+    expect(result!.args.from.formatted).toBe(ADDR_A);
+    expect(result!.args.to.formatted).toBe(ADDR_B);
+    expect(result!.args.amount.formatted).toBe('0.5000000');
+    expect(result!.humanReadable).toContain('XLM');
+  });
+});
+
+describe('parseSep41Call — approve', () => {
+  it('decodes from, spender, amount, expiration_ledger', () => {
+    const rawArgs = [
+      new Address(ADDR_A).toScVal(),
+      new Address(ADDR_B).toScVal(),
+      nativeToScVal(100_000_000n, { type: 'i128' }),
+      nativeToScVal(5000000, { type: 'u32' }),
+    ];
+    const result = parseSep41Call('approve', rawArgs, 7, 'USDC');
+    expect(result).not.toBeNull();
+    expect(result!.args.expiration_ledger.formatted).toBe('5000000');
+    expect(result!.humanReadable).toContain('5000000');
+    expect(result!.humanReadable).toContain('USDC');
+  });
+});
+
+describe('parseSep41Call — balance_of', () => {
+  it('decodes the id address', () => {
+    const rawArgs = [new Address(ADDR_A).toScVal()];
+    const result = parseSep41Call('balance_of', rawArgs);
+    expect(result).not.toBeNull();
+    expect(result!.args.id.formatted).toBe(ADDR_A);
+    expect(result!.humanReadable).toContain('Balance query');
+  });
+});
+
+describe('parseSep41Call — allowance', () => {
+  it('decodes from and spender', () => {
+    const rawArgs = [
+      new Address(ADDR_A).toScVal(),
+      new Address(ADDR_B).toScVal(),
+    ];
+    const result = parseSep41Call('allowance', rawArgs);
+    expect(result).not.toBeNull();
+    expect(result!.args.from.formatted).toBe(ADDR_A);
+    expect(result!.args.spender.formatted).toBe(ADDR_B);
+  });
+});
+
+describe('parseSep41Call — no-arg functions', () => {
+  it.each(['decimals', 'name', 'symbol', 'admin'])('handles %s with no args', (fn) => {
+    const result = parseSep41Call(fn, []);
+    expect(result).not.toBeNull();
+    expect(result!.functionName).toBe(fn);
+    expect(result!.args).toEqual({});
+  });
+});
+
+describe('parseSep41Call — mint', () => {
+  it('decodes to and amount', () => {
+    const rawArgs = [
+      new Address(ADDR_A).toScVal(),
+      nativeToScVal(1_000_000_000n, { type: 'i128' }),
+    ];
+    const result = parseSep41Call('mint', rawArgs, 7, 'TOKEN');
+    expect(result).not.toBeNull();
+    expect(result!.args.to.formatted).toBe(ADDR_A);
+    expect(result!.args.amount.formatted).toBe('100.0000000');
+    expect(result!.humanReadable).toContain('Minted');
+    expect(result!.humanReadable).toContain('TOKEN');
+  });
+});
+
+describe('parseSep41Call — burn', () => {
+  it('decodes from and amount', () => {
+    const rawArgs = [
+      new Address(ADDR_A).toScVal(),
+      nativeToScVal(7_000_000n, { type: 'i128' }),
+    ];
+    const result = parseSep41Call('burn', rawArgs, 7, 'USDC');
+    expect(result).not.toBeNull();
+    expect(result!.args.from.formatted).toBe(ADDR_A);
+    expect(result!.humanReadable).toContain('burned');
+  });
+});
+
+describe('parseSep41Call — burn_from', () => {
+  it('decodes spender, from, amount', () => {
+    const rawArgs = [
+      new Address(ADDR_C).toScVal(),
+      new Address(ADDR_A).toScVal(),
+      nativeToScVal(3_000_000n, { type: 'i128' }),
+    ];
+    const result = parseSep41Call('burn_from', rawArgs, 7, 'USDC');
+    expect(result).not.toBeNull();
+    expect(result!.args.spender.formatted).toBe(ADDR_C);
+    expect(result!.args.from.formatted).toBe(ADDR_A);
+  });
+});
+
+describe('parseSep41Call — clawback', () => {
+  it('decodes from and amount', () => {
+    const rawArgs = [
+      new Address(ADDR_A).toScVal(),
+      nativeToScVal(2_000_000n, { type: 'i128' }),
+    ];
+    const result = parseSep41Call('clawback', rawArgs, 7, 'USDC');
+    expect(result).not.toBeNull();
+    expect(result!.humanReadable).toContain('clawed back');
+  });
+});
+
+describe('parseSep41Call — set_admin', () => {
+  it('decodes new_admin', () => {
+    const rawArgs = [new Address(ADDR_B).toScVal()];
+    const result = parseSep41Call('set_admin', rawArgs);
+    expect(result).not.toBeNull();
+    expect(result!.args.new_admin.formatted).toBe(ADDR_B);
+    expect(result!.humanReadable).toContain('Admin changed');
+  });
+});
+
+describe('parseSep41Call — unknown function', () => {
+  it('returns null for non-SEP-41 function names', () => {
+    expect(parseSep41Call('swap', [])).toBeNull();
+    expect(parseSep41Call('', [])).toBeNull();
+  });
+});
+
+describe('parseSep41Call — missing args', () => {
+  it('skips missing args gracefully without throwing', () => {
+    // transfer expects 3 args; pass only 1
+    const rawArgs = [new Address(ADDR_A).toScVal()];
+    const result = parseSep41Call('transfer', rawArgs, 7, 'USDC');
+    expect(result).not.toBeNull();
+    expect(result!.args.from.formatted).toBe(ADDR_A);
+    expect(result!.args.to).toBeUndefined();
+    expect(result!.args.amount).toBeUndefined();
+  });
+});
+
+// ─── parseSep41Event ──────────────────────────────────────────────────────────
+
+describe('parseSep41Event — transfer', () => {
+  it('decodes from, to, amount from topics and data', () => {
+    const topics = [symXdr('transfer'), addrXdr(ADDR_A), addrXdr(ADDR_B)];
+    const data = i128Xdr(50_000_000n);
+    const result = parseSep41Event(topics, data, 7, 'USDC');
+    expect(result).not.toBeNull();
+    expect(result!.symbol).toBe('transfer');
+    expect(result!.fields.from.formatted).toBe(ADDR_A);
+    expect(result!.fields.to.formatted).toBe(ADDR_B);
+    expect(result!.fields.amount.formatted).toBe('5.0000000');
+    expect(result!.humanReadable).toContain('USDC');
+    expect(result!.humanReadable).toContain('5.0000000');
+  });
+});
+
+describe('parseSep41Event — mint', () => {
+  it('decodes admin, to, amount', () => {
+    const topics = [symXdr('mint'), addrXdr(ADDR_C), addrXdr(ADDR_A)];
+    const data = i128Xdr(100_000_000n);
+    const result = parseSep41Event(topics, data, 7, 'TOKEN');
+    expect(result).not.toBeNull();
+    expect(result!.fields.admin.formatted).toBe(ADDR_C);
+    expect(result!.fields.to.formatted).toBe(ADDR_A);
+    expect(result!.fields.amount.formatted).toBe('10.0000000');
+    expect(result!.humanReadable).toContain('Minted');
+  });
+});
+
+describe('parseSep41Event — burn', () => {
+  it('decodes from and amount', () => {
+    const topics = [symXdr('burn'), addrXdr(ADDR_A)];
+    const data = i128Xdr(20_000_000n);
+    const result = parseSep41Event(topics, data, 7, 'USDC');
+    expect(result).not.toBeNull();
+    expect(result!.fields.from.formatted).toBe(ADDR_A);
+    expect(result!.fields.amount.formatted).toBe('2.0000000');
+    expect(result!.humanReadable).toContain('burned');
+  });
+});
+
+describe('parseSep41Event — approve', () => {
+  it('decodes from, spender, amount', () => {
+    const topics = [symXdr('approve'), addrXdr(ADDR_A), addrXdr(ADDR_B)];
+    const data = i128Xdr(500_000_000n);
+    const result = parseSep41Event(topics, data, 7, 'USDC');
+    expect(result).not.toBeNull();
+    expect(result!.fields.from.formatted).toBe(ADDR_A);
+    expect(result!.fields.spender.formatted).toBe(ADDR_B);
+    expect(result!.fields.amount.formatted).toBe('50.0000000');
+    expect(result!.humanReadable).toContain('approved');
+  });
+});
+
+describe('parseSep41Event — clawback', () => {
+  it('decodes admin, from, amount', () => {
+    const topics = [symXdr('clawback'), addrXdr(ADDR_C), addrXdr(ADDR_A)];
+    const data = i128Xdr(15_000_000n);
+    const result = parseSep41Event(topics, data, 7, 'USDC');
+    expect(result).not.toBeNull();
+    expect(result!.fields.admin.formatted).toBe(ADDR_C);
+    expect(result!.fields.from.formatted).toBe(ADDR_A);
+    expect(result!.humanReadable).toContain('clawed back');
+  });
+});
+
+describe('parseSep41Event — set_admin', () => {
+  it('decodes new_admin from topics', () => {
+    const topics = [symXdr('set_admin'), addrXdr(ADDR_B)];
+    const data = addrXdr(ADDR_B); // data mirrors the new admin per SEP-41 spec
+    const result = parseSep41Event(topics, data);
+    expect(result).not.toBeNull();
+    expect(result!.fields.new_admin.formatted).toBe(ADDR_B);
+    expect(result!.humanReadable).toContain('admin changed');
+  });
+});
+
+describe('parseSep41Event — unknown symbol', () => {
+  it('returns null for non-SEP-41 event symbols', () => {
+    const topics = [symXdr('swap'), addrXdr(ADDR_A)];
+    const data = i128Xdr(1n);
+    expect(parseSep41Event(topics, data)).toBeNull();
+  });
+});
+
+describe('parseSep41Event — empty topics', () => {
+  it('returns null when topics array is empty', () => {
+    expect(parseSep41Event([], i128Xdr(1n))).toBeNull();
+  });
+});
+
+describe('parseSep41Event — malformed XDR', () => {
+  it('returns null when the symbol topic is not valid XDR', () => {
+    expect(parseSep41Event(['not-valid-xdr'], i128Xdr(1n))).toBeNull();
+  });
+
+  it('falls back to raw XDR string when a topic arg is malformed', () => {
+    // Valid symbol, but second topic is garbage
+    const topics = [symXdr('transfer'), 'bad-xdr', addrXdr(ADDR_B)];
+    const data = i128Xdr(1n);
+    const result = parseSep41Event(topics, data, 7, 'USDC');
+    // Should still return a result — from field falls back to raw string
+    expect(result).not.toBeNull();
+    expect(result!.fields.from.formatted).toBe('bad-xdr');
+  });
+});
+
+// ─── renderSep41Template ──────────────────────────────────────────────────────
+
+describe('renderSep41Template', () => {
+  it('substitutes {key} placeholders', () => {
+    const args = {
+      from: { raw: ADDR_A, formatted: ADDR_A },
+      amount: { raw: 10n, formatted: '1.0000000' },
+    };
+    const out = renderSep41Template('{from} sent {amount}', args);
+    expect(out).toBe(`${ADDR_A} sent 1.0000000`);
+  });
+
+  it('truncates addresses with {key|truncate}', () => {
+    const addr = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345';
+    const args = { from: { raw: addr, formatted: addr } };
+    const out = renderSep41Template('{from|truncate}', args);
+    expect(out).toBe(`${addr.slice(0, 6)}…${addr.slice(-4)}`);
+  });
+
+  it('does not truncate short values', () => {
+    const args = { from: { raw: 'short', formatted: 'short' } };
+    const out = renderSep41Template('{from|truncate}', args);
+    expect(out).toBe('short');
+  });
+
+  it('replaces {token} with tokenSymbol', () => {
+    const args = { amount: { raw: 1n, formatted: '1.0000000' } };
+    const out = renderSep41Template('{amount} {token}', args, 7, 'USDC');
+    expect(out).toBe('1.0000000 USDC');
+  });
+
+  it('replaces {token} with empty string when no symbol provided', () => {
+    const args = { amount: { raw: 1n, formatted: '1.0000000' } };
+    const out = renderSep41Template('{amount} {token}', args);
+    expect(out).toBe('1.0000000 ');
+  });
+
+  it('returns empty string for missing keys', () => {
+    const out = renderSep41Template('{missing}', {});
+    expect(out).toBe('');
+  });
+});
+
+// ─── getSep41Abi ──────────────────────────────────────────────────────────────
+
+describe('getSep41Abi', () => {
+  it('returns an object with a functions array', () => {
+    const abi = getSep41Abi();
+    expect(Array.isArray(abi.functions)).toBe(true);
+    expect(abi.functions.length).toBeGreaterThan(0);
+  });
+
+  it('includes all 14 standard SEP-41 functions', () => {
+    const abi = getSep41Abi();
+    const names = abi.functions.map((f) => f.name);
+    const expected = [
+      'transfer', 'transfer_from', 'approve', 'balance_of', 'allowance',
+      'decimals', 'name', 'symbol', 'mint', 'burn', 'burn_from',
+      'clawback', 'set_admin', 'admin',
+    ];
+    for (const fn of expected) {
+      expect(names, `expected ${fn} in ABI`).toContain(fn);
+    }
+  });
+
+  it('every function has name, inputs array, and humanTemplate', () => {
+    const abi = getSep41Abi();
+    for (const fn of abi.functions) {
+      expect(typeof fn.name).toBe('string');
+      expect(Array.isArray(fn.inputs)).toBe(true);
+      expect(typeof fn.humanTemplate).toBe('string');
+    }
+  });
+
+  it('transfer function has correct input types', () => {
+    const abi = getSep41Abi();
+    const transfer = abi.functions.find((f) => f.name === 'transfer')!;
+    expect(transfer.inputs).toEqual([
+      { name: 'from', type: 'address' },
+      { name: 'to', type: 'address' },
+      { name: 'amount', type: 'i128' },
+    ]);
+  });
+});
+
+// ─── SEP41_FUNCTIONS / SEP41_EVENTS completeness ─────────────────────────────
+
+describe('SEP41_FUNCTIONS completeness', () => {
+  it('every entry has name, inputs, and humanTemplate', () => {
+    for (const [key, def] of Object.entries(SEP41_FUNCTIONS)) {
+      expect(def.name).toBe(key);
+      expect(Array.isArray(def.inputs)).toBe(true);
+      expect(typeof def.humanTemplate).toBe('string');
+      expect(def.humanTemplate.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('SEP41_EVENTS completeness', () => {
+  it('every entry has symbol, topicParams, dataParam, and humanTemplate', () => {
+    for (const [key, def] of Object.entries(SEP41_EVENTS)) {
+      expect(def.symbol).toBe(key);
+      expect(Array.isArray(def.topicParams)).toBe(true);
+      expect(def.dataParam).toBeDefined();
+      expect(typeof def.humanTemplate).toBe('string');
+      expect(def.humanTemplate.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
- Add src/indexer/sep41-parser.ts as single source of truth for SEP-41
- Covers all 14 standard functions: transfer, transfer_from, approve, balance_of, allowance, decimals, name, symbol, mint, burn, burn_from, clawback, set_admin, admin
- Covers all 6 standard events: transfer, mint, burn, approve, clawback, set_admin
- O(1) isSep41Function / isSep41Event guards via Set lookup
- parseSep41Call / parseSep41Event decode XDR args without custom ABIs
- renderSep41Template supports {key}, {key|truncate}, {token} placeholders
- Replace partial SEP41_ABI in registry.ts with getSep41Abi() from parser
- Replace inline ad-hoc event decoding in decoder.ts with parseSep41Event
- Add clawback and set_admin to normalizeEventType known list
- 42 tests passing in tests/sep41-parser.test.ts
closes #36