### PR TITLE
feat: add GET /api/v1/sync-state endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2400,6 +2400,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -6218,6 +6219,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "optional": true
     },
     "function-bind": {

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -21,6 +21,7 @@ import { webhooksRouter } from './webhooks';
 import { analyticsRouter } from './analytics';
 import { portfolioRouter } from './portfolio';
 import { exportsRouter } from './exports';
+import { syncStateRouter } from './sync-state';
 
 export const router = Router();
 
@@ -46,3 +47,4 @@ router.use('/webhooks', webhooksRouter);
 router.use('/analytics', analyticsRouter);
 router.use('/portfolio', portfolioRouter);
 router.use('/exports', exportsRouter);
+router.use('/sync-state', syncStateRouter);

--- a/src/api/sync-state.ts
+++ b/src/api/sync-state.ts
@@ -1,0 +1,43 @@
+/**
+ * GET /api/v1/sync-state
+ *
+ * Returns the DB's max synced ledger vs the live network tip so the frontend
+ * can display a "Syncing… (99.9%)" banner when the indexer lags behind.
+ */
+
+import { Router, Request, Response } from 'express';
+import { prismaRead as prisma } from '../db';
+import { getLatestLedger } from '../indexer/rpc';
+
+export const syncStateRouter = Router();
+
+export async function getSyncState(): Promise<{
+  dbLedger: number;
+  networkLedger: number;
+  syncPercent: number;
+  isSynced: boolean;
+}> {
+  const [agg, networkLedger] = await Promise.all([
+    prisma.ledger.aggregate({ _max: { sequence: true } }),
+    getLatestLedger(),
+  ]);
+
+  const dbLedger = agg._max.sequence ?? 0;
+  const syncPercent =
+    networkLedger > 0 ? Math.min(100, (dbLedger / networkLedger) * 100) : 100;
+
+  return {
+    dbLedger,
+    networkLedger,
+    syncPercent: Math.round(syncPercent * 10) / 10,
+    isSynced: dbLedger >= networkLedger,
+  };
+}
+
+syncStateRouter.get('/', async (_req: Request, res: Response) => {
+  try {
+    res.json(await getSyncState());
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});

--- a/tests/sync-state.test.ts
+++ b/tests/sync-state.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const ledgerAggregate = vi.fn();
+const getLatestLedgerMock = vi.fn();
+
+vi.mock('../src/db', () => ({
+  prismaRead: {
+    ledger: { aggregate: ledgerAggregate },
+  },
+  prismaWrite: {},
+  get prisma() { return (this as any).prismaWrite; },
+}));
+
+vi.mock('../src/indexer/rpc', () => ({
+  getLatestLedger: getLatestLedgerMock,
+}));
+
+describe('getSyncState', () => {
+  beforeEach(() => {
+    ledgerAggregate.mockReset();
+    getLatestLedgerMock.mockReset();
+  });
+
+  it('returns 100% and isSynced=true when db matches network', async () => {
+    ledgerAggregate.mockResolvedValue({ _max: { sequence: 5000 } });
+    getLatestLedgerMock.mockResolvedValue(5000);
+
+    const { getSyncState } = await import('../src/api/sync-state');
+    const result = await getSyncState();
+
+    expect(result).toEqual({
+      dbLedger: 5000,
+      networkLedger: 5000,
+      syncPercent: 100,
+      isSynced: true,
+    });
+  });
+
+  it('returns correct percentage when db lags behind', async () => {
+    ledgerAggregate.mockResolvedValue({ _max: { sequence: 999 } });
+    getLatestLedgerMock.mockResolvedValue(1000);
+
+    const { getSyncState } = await import('../src/api/sync-state');
+    const result = await getSyncState();
+
+    expect(result.dbLedger).toBe(999);
+    expect(result.networkLedger).toBe(1000);
+    expect(result.syncPercent).toBe(99.9);
+    expect(result.isSynced).toBe(false);
+  });
+
+  it('handles empty DB (no ledgers yet) gracefully', async () => {
+    ledgerAggregate.mockResolvedValue({ _max: { sequence: null } });
+    getLatestLedgerMock.mockResolvedValue(5000);
+
+    const { getSyncState } = await import('../src/api/sync-state');
+    const result = await getSyncState();
+
+    expect(result.dbLedger).toBe(0);
+    expect(result.syncPercent).toBe(0);
+    expect(result.isSynced).toBe(false);
+  });
+
+  it('caps syncPercent at 100 even if db somehow exceeds network', async () => {
+    ledgerAggregate.mockResolvedValue({ _max: { sequence: 5001 } });
+    getLatestLedgerMock.mockResolvedValue(5000);
+
+    const { getSyncState } = await import('../src/api/sync-state');
+    const result = await getSyncState();
+
+    expect(result.syncPercent).toBe(100);
+    expect(result.isSynced).toBe(true);
+  });
+});


### PR DESCRIPTION
closes #32 

Files changed:
- src/api/sync-state.ts — new route + exported getSyncState() function
- src/api/router.ts — wired in syncStateRouter at /sync-state
- tests/sync-state.test.ts — 4 tests covering all edge cases

How it works:
- GET /api/v1/sync-state fires two parallel calls: prisma.ledger.aggregate({ _max: { sequence } }) for the DB tip and getLatestLedger() for the live network tip
- Returns { dbLedger, networkLedger, syncPercent, isSynced } — the frontend uses syncPercent for the "Syncing… (99.9%)" banner and isSynced to hide it