### PR TITLE
feat: add block snapshot module, error queue test, and replica gateway

### DIFF
--- a/src/indexer/blockSnapshot.ts
+++ b/src/indexer/blockSnapshot.ts
@@ -1,0 +1,73 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface BlockChunk {
+  ledger: number;
+  transactions: Array<{
+    hash: string;
+    rawXdr: string;
+    contractId: string;
+    closeTime: number;
+  }>;
+  capturedAt: string;
+}
+
+const DEFAULT_SNAPSHOT_DIR = path.join(process.cwd(), '.block-snapshots');
+
+/**
+ * Save a raw block chunk to disk for local simulated parsing.
+ * Files are stored as JSON under `<snapshotDir>/<ledger>.json`.
+ */
+export function saveBlockSnapshot(chunk: BlockChunk, snapshotDir = DEFAULT_SNAPSHOT_DIR): string {
+  fs.mkdirSync(snapshotDir, { recursive: true });
+  const filePath = path.join(snapshotDir, `${chunk.ledger}.json`);
+  fs.writeFileSync(filePath, JSON.stringify(chunk, null, 2), 'utf8');
+  return filePath;
+}
+
+/**
+ * Load a previously saved block chunk from disk.
+ * Returns null if the snapshot does not exist.
+ */
+export function loadBlockSnapshot(ledger: number, snapshotDir = DEFAULT_SNAPSHOT_DIR): BlockChunk | null {
+  const filePath = path.join(snapshotDir, `${ledger}.json`);
+  if (!fs.existsSync(filePath)) return null;
+  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as BlockChunk;
+}
+
+/**
+ * List all saved snapshot ledger numbers, sorted ascending.
+ */
+export function listSnapshots(snapshotDir = DEFAULT_SNAPSHOT_DIR): number[] {
+  if (!fs.existsSync(snapshotDir)) return [];
+  return fs
+    .readdirSync(snapshotDir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => parseInt(f.replace('.json', ''), 10))
+    .filter((n) => !isNaN(n))
+    .sort((a, b) => a - b);
+}
+
+/**
+ * Delete a snapshot file. Returns true if deleted, false if it didn't exist.
+ */
+export function deleteSnapshot(ledger: number, snapshotDir = DEFAULT_SNAPSHOT_DIR): boolean {
+  const filePath = path.join(snapshotDir, `${ledger}.json`);
+  if (!fs.existsSync(filePath)) return false;
+  fs.unlinkSync(filePath);
+  return true;
+}
+
+/**
+ * Run a simulated parse pass over a saved snapshot using the provided parser.
+ * Returns the parser's output without touching the live network or database.
+ */
+export function replaySnapshot<T>(
+  ledger: number,
+  parser: (chunk: BlockChunk) => T,
+  snapshotDir = DEFAULT_SNAPSHOT_DIR,
+): T {
+  const chunk = loadBlockSnapshot(ledger, snapshotDir);
+  if (!chunk) throw new Error(`No snapshot found for ledger ${ledger}`);
+  return parser(chunk);
+}

--- a/tests/block-snapshot.test.ts
+++ b/tests/block-snapshot.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  saveBlockSnapshot,
+  loadBlockSnapshot,
+  listSnapshots,
+  deleteSnapshot,
+  replaySnapshot,
+  type BlockChunk,
+} from '../src/indexer/blockSnapshot';
+
+const TEST_DIR = path.join(os.tmpdir(), `block-snapshots-test-${process.pid}`);
+
+const sampleChunk: BlockChunk = {
+  ledger: 4521983,
+  transactions: [
+    { hash: 'abc123', rawXdr: 'AAAA==', contractId: 'CXXX', closeTime: 1700000000 },
+  ],
+  capturedAt: new Date().toISOString(),
+};
+
+beforeEach(() => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+describe('saveBlockSnapshot', () => {
+  it('creates the snapshot directory and file', () => {
+    const filePath = saveBlockSnapshot(sampleChunk, TEST_DIR);
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(filePath).toContain(`${sampleChunk.ledger}.json`);
+  });
+
+  it('persists the chunk data correctly', () => {
+    saveBlockSnapshot(sampleChunk, TEST_DIR);
+    const raw = fs.readFileSync(path.join(TEST_DIR, `${sampleChunk.ledger}.json`), 'utf8');
+    const parsed = JSON.parse(raw) as BlockChunk;
+    expect(parsed.ledger).toBe(sampleChunk.ledger);
+    expect(parsed.transactions).toHaveLength(1);
+    expect(parsed.transactions[0].hash).toBe('abc123');
+  });
+});
+
+describe('loadBlockSnapshot', () => {
+  it('returns null when snapshot does not exist', () => {
+    expect(loadBlockSnapshot(9999999, TEST_DIR)).toBeNull();
+  });
+
+  it('returns the saved chunk', () => {
+    saveBlockSnapshot(sampleChunk, TEST_DIR);
+    const loaded = loadBlockSnapshot(sampleChunk.ledger, TEST_DIR);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.ledger).toBe(sampleChunk.ledger);
+  });
+});
+
+describe('listSnapshots', () => {
+  it('returns empty array when directory does not exist', () => {
+    expect(listSnapshots(TEST_DIR)).toEqual([]);
+  });
+
+  it('returns sorted ledger numbers', () => {
+    saveBlockSnapshot({ ...sampleChunk, ledger: 300 }, TEST_DIR);
+    saveBlockSnapshot({ ...sampleChunk, ledger: 100 }, TEST_DIR);
+    saveBlockSnapshot({ ...sampleChunk, ledger: 200 }, TEST_DIR);
+    expect(listSnapshots(TEST_DIR)).toEqual([100, 200, 300]);
+  });
+});
+
+describe('deleteSnapshot', () => {
+  it('returns false when snapshot does not exist', () => {
+    expect(deleteSnapshot(9999999, TEST_DIR)).toBe(false);
+  });
+
+  it('deletes the file and returns true', () => {
+    saveBlockSnapshot(sampleChunk, TEST_DIR);
+    expect(deleteSnapshot(sampleChunk.ledger, TEST_DIR)).toBe(true);
+    expect(loadBlockSnapshot(sampleChunk.ledger, TEST_DIR)).toBeNull();
+  });
+});
+
+describe('replaySnapshot', () => {
+  it('throws when snapshot does not exist', () => {
+    expect(() => replaySnapshot(9999999, (c) => c, TEST_DIR)).toThrow('No snapshot found');
+  });
+
+  it('passes the chunk to the parser and returns its result', () => {
+    saveBlockSnapshot(sampleChunk, TEST_DIR);
+    const txCount = replaySnapshot(sampleChunk.ledger, (c) => c.transactions.length, TEST_DIR);
+    expect(txCount).toBe(1);
+  });
+
+  it('does not modify the snapshot file during replay', () => {
+    saveBlockSnapshot(sampleChunk, TEST_DIR);
+    replaySnapshot(sampleChunk.ledger, (c) => c, TEST_DIR);
+    const loaded = loadBlockSnapshot(sampleChunk.ledger, TEST_DIR);
+    expect(loaded!.ledger).toBe(sampleChunk.ledger);
+  });
+});

--- a/tests/error-queue.test.ts
+++ b/tests/error-queue.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Use inline factory — vi.mock is hoisted so external variables are not yet initialised
+vi.mock('../src/db', () => {
+  const mockFindFirst = vi.fn();
+  const mockCreate = vi.fn();
+  const mockUpdate = vi.fn();
+  const mockFindMany = vi.fn();
+  const mockDelete = vi.fn();
+
+  return {
+    prismaWrite: {
+      failedItem: {
+        findFirst: mockFindFirst,
+        create: mockCreate,
+        update: mockUpdate,
+        findMany: mockFindMany,
+        delete: mockDelete,
+      },
+    },
+  };
+});
+
+import { enqueueFailure, retryFailures } from '../src/indexer/errorQueue';
+import { prismaWrite } from '../src/db';
+
+// Typed helpers to access the mocked methods
+const db = prismaWrite.failedItem as {
+  findFirst: ReturnType<typeof vi.fn>;
+  create: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  findMany: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('enqueueFailure', () => {
+  it('creates a new record when item does not exist', async () => {
+    db.findFirst.mockResolvedValue(null);
+    db.create.mockResolvedValue({});
+
+    await enqueueFailure({
+      itemType: 'transaction',
+      itemId: 'tx-abc',
+      ledger: 100,
+      rawXdr: 'AAAA==',
+      error: new Error('decode failed'),
+    });
+
+    expect(db.create).toHaveBeenCalledOnce();
+    const data = db.create.mock.calls[0][0].data;
+    expect(data.itemType).toBe('transaction');
+    expect(data.itemId).toBe('tx-abc');
+    expect(data.ledger).toBe(100);
+    expect(data.retryCount).toBe(0);
+    expect(data.dead).toBe(false);
+  });
+
+  it('increments retryCount on an existing item', async () => {
+    db.findFirst.mockResolvedValue({ id: 1, retryCount: 1 });
+    db.update.mockResolvedValue({});
+
+    await enqueueFailure({
+      itemType: 'event',
+      itemId: 'ev-xyz',
+      ledger: 200,
+      error: 'bad format',
+    });
+
+    expect(db.update).toHaveBeenCalledOnce();
+    const data = db.update.mock.calls[0][0].data;
+    expect(data.retryCount).toBe(2);
+    expect(data.dead).toBe(false);
+  });
+
+  it('marks item as dead when retryCount reaches MAX_RETRIES (3)', async () => {
+    db.findFirst.mockResolvedValue({ id: 2, retryCount: 2 });
+    db.update.mockResolvedValue({});
+
+    await enqueueFailure({
+      itemType: 'transaction',
+      itemId: 'tx-dead',
+      ledger: 300,
+      error: new Error('persistent failure'),
+    });
+
+    const data = db.update.mock.calls[0][0].data;
+    expect(data.retryCount).toBe(3);
+    expect(data.dead).toBe(true);
+  });
+
+  it('converts non-Error errors to Error objects', async () => {
+    db.findFirst.mockResolvedValue(null);
+    db.create.mockResolvedValue({});
+
+    await enqueueFailure({ itemType: 'event', itemId: 'ev-1', ledger: 1, error: 'string error' });
+
+    const data = db.create.mock.calls[0][0].data;
+    expect(data.errorMsg).toBe('string error');
+  });
+});
+
+describe('retryFailures', () => {
+  it('calls handler for each pending item and deletes on success', async () => {
+    const pending = [
+      { id: 10, itemType: 'transaction', itemId: 'tx-1', ledger: 1, rawXdr: null, context: null },
+    ];
+    db.findMany.mockResolvedValue(pending);
+    db.delete.mockResolvedValue({});
+
+    const handler = vi.fn().mockResolvedValue(undefined);
+    await retryFailures(handler);
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(db.delete).toHaveBeenCalledWith({ where: { id: 10 } });
+  });
+
+  it('re-enqueues items that fail during retry', async () => {
+    const pending = [
+      { id: 11, itemType: 'event', itemId: 'ev-2', ledger: 5, rawXdr: 'XDR==', context: null },
+    ];
+    db.findMany.mockResolvedValue(pending);
+    db.findFirst.mockResolvedValue(null);
+    db.create.mockResolvedValue({});
+
+    const handler = vi.fn().mockRejectedValue(new Error('still broken'));
+    await retryFailures(handler);
+
+    expect(db.delete).not.toHaveBeenCalled();
+    expect(db.create).toHaveBeenCalledOnce();
+  });
+
+  it('does nothing when there are no pending items', async () => {
+    db.findMany.mockResolvedValue([]);
+    const handler = vi.fn();
+    await retryFailures(handler);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
closes #184 
closes #185 
closes #186 
closes #187 



- Task 1: DB request gateway with replication lag check (src/db/replicaGateway.ts + tests/replica-gateway.test.ts already existed)
- Task 2: Block snapshot testing module (src/indexer/blockSnapshot.ts) with save/load/list/delete/replay API; 11 tests in tests/block-snapshot.test.ts
- Task 3: Isolated error tracking for faulty blocks (src/indexer/errorQueue.ts already existed); added 7 tests in tests/error-queue.test.ts covering enqueue, retry, dead-letter logic