### PR TITLE
feat: implement TTL & archival strategy for raw XDR cold storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,15 @@ INDEXER_CATCHUP_WORKERS=4
 # Rate limiting
 RATE_LIMIT_WINDOW_MS=60000
 RATE_LIMIT_MAX=100
+
+# Archival / TTL (cold storage)
+# Days before raw XDR is archived to S3 (parsed/human-readable data stays in DB)
+RAW_XDR_RETENTION_DAYS=90
+# Rows processed per archival batch
+ARCHIVE_BATCH_SIZE=500
+# AWS S3 bucket for cold XDR storage (leave unset to skip archival)
+ARCHIVE_S3_BUCKET=soroban-xdr-archive
+# S3 storage class: STANDARD_IA (default) | GLACIER | DEEP_ARCHIVE
+ARCHIVE_S3_STORAGE_CLASS=STANDARD_IA
+AWS_REGION=us-east-1
+# AWS_ENDPOINT_URL=http://localhost:4566  # LocalStack for local dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "soroban-block-explorer-backend",
       "version": "1.0.0",
       "dependencies": {
+        "@aws-sdk/client-s3": "3.600.0",
         "@prisma/client": "^5.10.0",
         "@stellar/stellar-sdk": "^12.0.0",
         "axios": "^1.6.7",
@@ -82,6 +83,912 @@
       },
       "peerDependencies": {
         "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.600.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.600.0.tgz",
+      "integrity": "sha512-iYoKbJTputbf+ubkX6gSK/y/4uJEBRaXZ18jykLdBQ8UJuGrk2gqvV8h7OlGAhToCeysmmMqM0vDWyLt6lP8nw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.600.0",
+        "@aws-sdk/client-sts": "3.600.0",
+        "@aws-sdk/core": "3.598.0",
+        "@aws-sdk/credential-provider-node": "3.600.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.598.0",
+        "@aws-sdk/middleware-expect-continue": "3.598.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.598.0",
+        "@aws-sdk/middleware-host-header": "3.598.0",
+        "@aws-sdk/middleware-location-constraint": "3.598.0",
+        "@aws-sdk/middleware-logger": "3.598.0",
+        "@aws-sdk/middleware-recursion-detection": "3.598.0",
+        "@aws-sdk/middleware-sdk-s3": "3.598.0",
+        "@aws-sdk/middleware-signing": "3.598.0",
+        "@aws-sdk/middleware-ssec": "3.598.0",
+        "@aws-sdk/middleware-user-agent": "3.598.0",
+        "@aws-sdk/region-config-resolver": "3.598.0",
+        "@aws-sdk/signature-v4-multi-region": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@aws-sdk/util-user-agent-browser": "3.598.0",
+        "@aws-sdk/util-user-agent-node": "3.598.0",
+        "@aws-sdk/xml-builder": "3.598.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/core": "^2.2.1",
+        "@smithy/eventstream-serde-browser": "^3.0.2",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.1",
+        "@smithy/eventstream-serde-node": "^3.0.2",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/hash-blob-browser": "^3.1.0",
+        "@smithy/hash-node": "^3.0.1",
+        "@smithy/hash-stream-node": "^3.1.0",
+        "@smithy/invalid-dependency": "^3.0.1",
+        "@smithy/md5-js": "^3.0.1",
+        "@smithy/middleware-content-length": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.4",
+        "@smithy/util-defaults-mode-node": "^3.0.4",
+        "@smithy/util-endpoints": "^2.0.2",
+        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-stream": "^3.0.2",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.0.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.598.0.tgz",
+      "integrity": "sha512-nOI5lqPYa+YZlrrzwAJywJSw3MKVjvu6Ge2fCqQUNYMfxFB0NAaDFnl0EPjXi+sEbtCuz/uWE77poHbqiZ+7Iw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.598.0",
+        "@aws-sdk/middleware-host-header": "3.598.0",
+        "@aws-sdk/middleware-logger": "3.598.0",
+        "@aws-sdk/middleware-recursion-detection": "3.598.0",
+        "@aws-sdk/middleware-user-agent": "3.598.0",
+        "@aws-sdk/region-config-resolver": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@aws-sdk/util-user-agent-browser": "3.598.0",
+        "@aws-sdk/util-user-agent-node": "3.598.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/core": "^2.2.1",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/hash-node": "^3.0.1",
+        "@smithy/invalid-dependency": "^3.0.1",
+        "@smithy/middleware-content-length": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.4",
+        "@smithy/util-defaults-mode-node": "^3.0.4",
+        "@smithy/util-endpoints": "^2.0.2",
+        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.600.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.600.0.tgz",
+      "integrity": "sha512-7+I8RWURGfzvChyNQSyj5/tKrqRbzRl7H+BnTOf/4Vsw1nFOi5ROhlhD4X/Y0QCTacxnaoNcIrqnY7uGGvVRzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sts": "3.600.0",
+        "@aws-sdk/core": "3.598.0",
+        "@aws-sdk/credential-provider-node": "3.600.0",
+        "@aws-sdk/middleware-host-header": "3.598.0",
+        "@aws-sdk/middleware-logger": "3.598.0",
+        "@aws-sdk/middleware-recursion-detection": "3.598.0",
+        "@aws-sdk/middleware-user-agent": "3.598.0",
+        "@aws-sdk/region-config-resolver": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@aws-sdk/util-user-agent-browser": "3.598.0",
+        "@aws-sdk/util-user-agent-node": "3.598.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/core": "^2.2.1",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/hash-node": "^3.0.1",
+        "@smithy/invalid-dependency": "^3.0.1",
+        "@smithy/middleware-content-length": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.4",
+        "@smithy/util-defaults-mode-node": "^3.0.4",
+        "@smithy/util-endpoints": "^2.0.2",
+        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.600.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.600.0.tgz",
+      "integrity": "sha512-KQG97B7LvTtTiGmjlrG1LRAY8wUvCQzrmZVV5bjrJ/1oXAU7DITYwVbSJeX9NWg6hDuSk0VE3MFwIXS2SvfLIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.600.0",
+        "@aws-sdk/core": "3.598.0",
+        "@aws-sdk/credential-provider-node": "3.600.0",
+        "@aws-sdk/middleware-host-header": "3.598.0",
+        "@aws-sdk/middleware-logger": "3.598.0",
+        "@aws-sdk/middleware-recursion-detection": "3.598.0",
+        "@aws-sdk/middleware-user-agent": "3.598.0",
+        "@aws-sdk/region-config-resolver": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@aws-sdk/util-user-agent-browser": "3.598.0",
+        "@aws-sdk/util-user-agent-node": "3.598.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/core": "^2.2.1",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/hash-node": "^3.0.1",
+        "@smithy/invalid-dependency": "^3.0.1",
+        "@smithy/middleware-content-length": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.4",
+        "@smithy/util-defaults-mode-node": "^3.0.4",
+        "@smithy/util-endpoints": "^2.0.2",
+        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.598.0.tgz",
+      "integrity": "sha512-HaSjt7puO5Cc7cOlrXFCW0rtA0BM9lvzjl56x0A20Pt+0wxXGeTOZZOkXQIepbrFkV2e/HYukuT9e99vXDm59g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^2.2.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/signature-v4": "^3.1.0",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.598.0.tgz",
+      "integrity": "sha512-vi1khgn7yXzLCcgSIzQrrtd2ilUM0dWodxj3PQ6BLfP0O+q1imO3hG1nq7DVyJtq7rFHs6+9N8G4mYvTkxby2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.598.0.tgz",
+      "integrity": "sha512-N7cIafi4HVlQvEgvZSo1G4T9qb/JMLGMdBsDCT5XkeJrF0aptQWzTFH0jIdZcLrMYvzPcuEyO3yCBe6cy/ba0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-stream": "^3.0.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.598.0.tgz",
+      "integrity": "sha512-/ppcIVUbRwDIwJDoYfp90X3+AuJo2mvE52Y1t2VSrvUovYn6N4v95/vXj6LS8CNDhz2jvEJYmu+0cTMHdhI6eA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.598.0",
+        "@aws-sdk/credential-provider-http": "3.598.0",
+        "@aws-sdk/credential-provider-process": "3.598.0",
+        "@aws-sdk/credential-provider-sso": "3.598.0",
+        "@aws-sdk/credential-provider-web-identity": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/credential-provider-imds": "^3.1.1",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.598.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.600.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.600.0.tgz",
+      "integrity": "sha512-1pC7MPMYD45J7yFjA90SxpR0yaSvy+yZiq23aXhAPZLYgJBAxHLu0s0mDCk/piWGPh8+UGur5K0bVdx4B1D5hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.598.0",
+        "@aws-sdk/credential-provider-http": "3.598.0",
+        "@aws-sdk/credential-provider-ini": "3.598.0",
+        "@aws-sdk/credential-provider-process": "3.598.0",
+        "@aws-sdk/credential-provider-sso": "3.598.0",
+        "@aws-sdk/credential-provider-web-identity": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/credential-provider-imds": "^3.1.1",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.598.0.tgz",
+      "integrity": "sha512-rM707XbLW8huMk722AgjVyxu2tMZee++fNA8TJVNgs1Ma02Wx6bBrfIvlyK0rCcIRb0WdQYP6fe3Xhiu4e8IBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.598.0.tgz",
+      "integrity": "sha512-5InwUmrAuqQdOOgxTccRayMMkSmekdLk6s+az9tmikq0QFAHUCtofI+/fllMXSR9iL6JbGYi1940+EUmS4pHJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.598.0",
+        "@aws-sdk/token-providers": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.598.0.tgz",
+      "integrity": "sha512-GV5GdiMbz5Tz9JO4NJtRoFXjW0GPEujA0j+5J/B723rTN+REHthJu48HdBKouHGhdzkDWkkh1bu52V02Wprw8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.598.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.598.0.tgz",
+      "integrity": "sha512-PM7BcFfGUSkmkT6+LU9TyJiB4S8yI7dfuKQDwK5ZR3P7MKaK4Uj4yyDiv0oe5xvkF6+O2+rShj+eh8YuWkOZ/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-arn-parser": "3.568.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.598.0.tgz",
+      "integrity": "sha512-ZuHW18kaeHR8TQyhEOYMr8VwiIh0bMvF7J1OTqXHxDteQIavJWA3CbfZ9sgS4XGtrBZDyHJhjZKeCfLhN2rq3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.598.0.tgz",
+      "integrity": "sha512-xukAzds0GQXvMEY9G6qt+CzwVzTx8NyKKh04O2Q+nOch6QQ8Rs+2kTRy3Z4wQmXq2pK9hlOWb5nXA7HWpmz6Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.598.0.tgz",
+      "integrity": "sha512-WiaG059YBQwQraNejLIi0gMNkX7dfPZ8hDIhvMr5aVPRbaHH8AYF3iNSsXYCHvA2Cfa1O9haYXsuMF9flXnCmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.598.0.tgz",
+      "integrity": "sha512-8oybQxN3F1ISOMULk7JKJz5DuAm5hCUcxMW9noWShbxTJuStNvuHf/WLUzXrf8oSITyYzIHPtf8VPlKR7I3orQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.598.0.tgz",
+      "integrity": "sha512-bxBjf/VYiu3zfu8SYM2S9dQQc3tz5uBAOcPz/Bt8DyyK3GgOpjhschH/2XuUErsoUO1gDJqZSdGOmuHGZQn00Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.598.0.tgz",
+      "integrity": "sha512-vjT9BeFY9FeN0f8hm2l6F53tI0N5bUq6RcDkQXKNabXBnQxKptJRad6oP2X5y3FoVfBLOuDkQgiC2940GIPxtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.598.0.tgz",
+      "integrity": "sha512-5AGtLAh9wyK6ANPYfaKTqJY1IFJyePIxsEbxa7zS6REheAqyVmgJFaGu3oQ5XlxfGr5Uq59tFTRkyx26G1HkHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-arn-parser": "3.568.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/signature-v4": "^3.1.0",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.598.0.tgz",
+      "integrity": "sha512-XKb05DYx/aBPqz6iCapsCbIl8aD8EihTuPCs51p75QsVfbQoVr4TlFfIl5AooMSITzojdAQqxt021YtvxjtxIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/signature-v4": "^3.1.0",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-middleware": "^3.0.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.598.0.tgz",
+      "integrity": "sha512-f0p2xP8IC1uJ5e/tND1l81QxRtRFywEdnbtKCE0H6RSn4UIt2W3Dohe1qQDbnh27okF0PkNW6BJGdSAz3p7qbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.598.0.tgz",
+      "integrity": "sha512-4tjESlHG5B5MdjUaLK7tQs/miUtHbb6deauQx8ryqSBYOhfHVgb1ZnzvQR0bTrhpqUg0WlybSkDaZAICf9xctg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.598.0.tgz",
+      "integrity": "sha512-oYXhmTokSav4ytmWleCr3rs/1nyvZW/S0tdi6X7u+dLNL5Jee+uMxWGzgOrWK6wrQOzucLVjS4E/wA11Kv2GTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.598.0.tgz",
+      "integrity": "sha512-1r/EyTrO1gSa1FirnR8V7mabr7gk+l+HkyTI0fcTSr8ucB7gmYyW6WjkY8JCz13VYHFK62usCEDS7yoJoJOzTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/signature-v4": "^3.1.0",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.598.0.tgz",
+      "integrity": "sha512-TKY1EVdHVBnZqpyxyTHdpZpa1tUpb6nxVeRNn1zWG8QB5MvH4ALLd/jR+gtmWDNQbIG4cVuBOZFVL8hIYicKTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.598.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.598.0.tgz",
+      "integrity": "sha512-742uRl6z7u0LFmZwDrFP6r1wlZcgVPw+/TilluDJmCAR8BgRw3IR+743kUXKBGd8QZDRW2n6v/PYsi/AWCDDMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.568.0.tgz",
+      "integrity": "sha512-XUKJWWo+KOB7fbnPP0+g/o5Ulku/X53t7i/h+sPHr5xxYTJJ9CYnbToo95mzxe7xWvkLrsNtJ8L+MnNn9INs2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.598.0.tgz",
+      "integrity": "sha512-Qo9UoiVVZxcOEdiOMZg3xb1mzkTxrhd4qSlg5QQrfWPJVx/QOg+Iy0NtGxPtHtVZNHZxohYwDwV/tfsnDSE2gQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-endpoints": "^2.0.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.598.0.tgz",
+      "integrity": "sha512-36Sxo6F+ykElaL1mWzWjlg+1epMpSe8obwhCN1yGE7Js9ywy5U6k6l+A3q3YM9YRbm740sNxncbwLklMvuhTKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/types": "^3.1.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.598.0.tgz",
+      "integrity": "sha512-oyWGcOlfTdzkC6SVplyr0AGh54IMrDxbhg5RxJ5P+V4BKfcDoDcZV9xenUk9NsOi9MuUjxMumb9UJGkDhM1m0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.598.0.tgz",
+      "integrity": "sha512-ZIa2RK7CHFTZ4gwK77WRtsZ6vF7xwRXxJ8KQIxK2duhoTVcn0xYxpFLdW9WZZZvdP9GIF3Loqvf8DRdeU5Jc7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -993,6 +1900,708 @@
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.9.tgz",
+      "integrity": "sha512-yiW0WI30zj8ZKoSYNx90no7ugVn3khlyH/z5W8qtKBtVE6awRALbhSG+2SAHA1r6bO/6M9utxYKVZ3PCJ1rWxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-4.0.0.tgz",
+      "integrity": "sha512-jSqRnZvkT4egkq/7b6/QRCNXmmYVcHwnJldqJ3IhVpQE2atObVJ137xmGeuGFhjFUr8gCEVAOKwSY79OvpbDaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-3.0.1.tgz",
+      "integrity": "sha512-VEYtPvh5rs/xlyqpm5NRnfYLZn+q0SRPELbvBV+C/G7IQ+ouTuo+NKKa3ShG5OaFR8NYVMXls9hPYLTvIKKDrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.13.tgz",
+      "integrity": "sha512-Gr/qwzyPaTL1tZcq8WQyHhTZREER5R1Wytmz4WnVGL4onA3dNk6Btll55c8Vr58pLdvWZmtG8oZxJTw3t3q7Jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.7.tgz",
+      "integrity": "sha512-8olpW6mKCa0v+ibCjoCzgZHQx1SQmZuW/WkrdZo73wiTprTH6qhmskT60QLFdT9DRa5mXxjz89kQPZ7ZSsoqqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-stream": "^3.3.4",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.8.tgz",
+      "integrity": "sha512-ZCY2yD0BY+K9iMXkkbnjo+08T2h8/34oHd0Jmh6BZUSZwaaGlGCyBT/3wnS7u7Xl33/EEfN4B6nQr3Gx5bYxgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.10.tgz",
+      "integrity": "sha512-323B8YckSbUH0nMIpXn7HZsAVKHYHFUODa8gG9cHo0ySvA1fr5iWaNT+iIL0UCqUzG6QPHA3BSsBtRQou4mMqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.14.tgz",
+      "integrity": "sha512-kbrt0vjOIihW3V7Cqj1SXQvAI5BR8SnyQYsandva0AOR307cXAc+IhPngxIPslxTLfxwDpNu0HzCAq6g42kCPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^3.0.13",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.11.tgz",
+      "integrity": "sha512-P2pnEp4n75O+QHjyO7cbw/vsw5l93K/8EWyjNCAAybYwUmj3M+hjSQZ9P5TVdUgEG08ueMAP5R4FkuSkElZ5tQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.13.tgz",
+      "integrity": "sha512-zqy/9iwbj8Wysmvi7Lq7XFLeDgjRpTbCfwBhJa8WbrylTAHiAu6oQTwdY7iu2lxigbc9YYr9vPv5SzYny5tCXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^3.0.13",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.13.tgz",
+      "integrity": "sha512-L1Ib66+gg9uTnqp/18Gz4MDpJPKRE44geOjOQ2SVc0eiaO5l255ADziATZgjQjqumC7yPtp1XnjHlF1srcwjKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^3.1.10",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.9.tgz",
+      "integrity": "sha512-hYNVQOqhFQ6vOpenifFME546f0GfJn2OiQ3M0FDmuUu8V/Uiwy2wej7ZXxFBNqdx0R5DZAqWM1l6VRhGz8oE6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/querystring-builder": "^3.0.7",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.1.10.tgz",
+      "integrity": "sha512-elwslXOoNunmfS0fh55jHggyhccobFkexLYC1ZeZ1xP2BTSrcIBaHV2b4xUQOdctrSNOpMqOZH1r2XzWTEhyfA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^4.0.0",
+        "@smithy/chunked-blob-reader-native": "^3.0.1",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.11.tgz",
+      "integrity": "sha512-emP23rwYyZhQBvklqTtwetkQlqbNYirDiEEwXl2v0GYWMnCzxst7ZaRAnWuy28njp5kAH54lvkdG37MblZzaHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.1.10.tgz",
+      "integrity": "sha512-olomK/jZQ93OMayW1zfTHwcbwBdhcZOHsyWyiZ9h9IXvc1mCD/VuvzbLb3Gy/qNJwI4MANPLctTp2BucV2oU/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.11.tgz",
+      "integrity": "sha512-NuQmVPEJjUX6c+UELyVz8kUx8Q539EDeNwbRyu4IIF8MeV7hUtq1FB3SHVyki2u++5XLMFqngeMKk7ccspnNyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.11.tgz",
+      "integrity": "sha512-3NM0L3i2Zm4bbgG6Ymi9NBcxXhryi3uE8fIfHJZIOfZVxOkGdjdgjR9A06SFIZCfnEIWKXZdm6Yq5/aPXFFhsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.13.tgz",
+      "integrity": "sha512-zfMhzojhFpIX3P5ug7jxTjfUcIPcGjcQYzB9t+rv0g1TX7B0QdwONW+ATouaLoD7h7LOw/ZlXfkq4xJ/g2TrIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.8.tgz",
+      "integrity": "sha512-OEJZKVUEhMOqMs3ktrTWp7UvvluMJEvD5XgQwRePSbDg1VvBaL8pX8mwPltFn6wk1GySbcVwwyldL8S+iqnrEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^2.5.7",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-middleware": "^3.0.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "3.0.34",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.34.tgz",
+      "integrity": "sha512-yVRr/AAtPZlUvwEkrq7S3x7Z8/xCd97m2hLDaqdz6ucP2RKHsBjEqaUA2ebNv2SsZoPEi+ZD0dZbOB1u37tGCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/service-error-classification": "^3.0.11",
+        "@smithy/smithy-client": "^3.7.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.11.tgz",
+      "integrity": "sha512-KzPAeySp/fOoQA82TpnwItvX8BBURecpx6ZMu75EZDkAcnPtO6vf7q4aH5QHs/F1s3/snQaSFbbUMcFFZ086Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.11.tgz",
+      "integrity": "sha512-1HGo9a6/ikgOMrTrWL/WiN9N8GSVYpuRQO5kjstAq4CvV59bjqnh7TbdXGQ4vxLD3xlSjfBjq5t1SOELePsLnA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.12.tgz",
+      "integrity": "sha512-O9LVEu5J/u/FuNlZs+L7Ikn3lz7VB9hb0GtPT9MQeiBmtK8RSY3ULmsZgXhe6VAlgTw0YO+paQx4p8xdbs43vQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.3.tgz",
+      "integrity": "sha512-BrpZOaZ4RCbcJ2igiSNG16S+kgAc65l/2hmxWdmhyoGWHTLlzQzr06PXavJp9OBlPEG/sHlqdxjWmjzV66+BSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.11.tgz",
+      "integrity": "sha512-I/+TMc4XTQ3QAjXfOcUWbSS073oOEAxgx4aZy8jHaf8JQnRkq2SZWw8+PfDtBvLUjcGMdxl+YwtzWe6i5uhL/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.8.tgz",
+      "integrity": "sha512-hmgIAVyxw1LySOwkgMIUN0kjN8TG9Nc85LJeEmEE/cNEe2rkHDUWhnJf2gxcSRFLWsyqWsrZGw40ROjUogg+Iw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.11.tgz",
+      "integrity": "sha512-u+5HV/9uJaeLj5XTb6+IEF/dokWWkEqJ0XiaRRogyREmKGUgZnNecLucADLdauWFKUNbQfulHFEZEdjwEBjXRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.11.tgz",
+      "integrity": "sha512-Je3kFvCsFMnso1ilPwA7GtlbPaTixa3WwC+K21kmMZHsBEOZYQaqxcMqeFFoU7/slFjKDIpiiPydvdJm8Q/MCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.11.tgz",
+      "integrity": "sha512-QnYDPkyewrJzCyaeI2Rmp7pDwbUETe+hU8ADkXmgNusO1bgHBH7ovXJiYmba8t0fNfJx75fE8dlM6SEmZxheog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.12.tgz",
+      "integrity": "sha512-1xKSGI+U9KKdbG2qDvIR9dGrw3CNx+baqJfyr0igKEpjbHL5stsqAesYBzHChYHlelWtb87VnLWlhvfCz13H8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.1.2.tgz",
+      "integrity": "sha512-3BcPylEsYtD0esM4Hoyml/+s7WP2LFhcM3J2AGdcL2vx9O60TtfpDOL72gjb4lU8NeRPeKAwR77YNyyGvMbuEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.7.0.tgz",
+      "integrity": "sha512-9wYrjAZFlqWhgVo3C4y/9kpc68jgiSsKUnsFPzr/MSiRL93+QRDafGTfhhKAb2wsr69Ru87WTiqSfQusSmWipA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^2.5.7",
+        "@smithy/middleware-endpoint": "^3.2.8",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-stream": "^3.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.11.tgz",
+      "integrity": "sha512-TmlqXkSk8ZPhfc+SQutjmFr5FjC0av3GZP4B/10caK1SbRwe/v+Wzu/R6xEKxoNqL+8nY18s1byiy6HqPG37Aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.34",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.34.tgz",
+      "integrity": "sha512-FumjjF631lR521cX+svMLBj3SwSDh9VdtyynTYDAiBDEf8YPP5xORNXKQ9j0105o5+ARAGnOOP/RqSl40uXddA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/smithy-client": "^3.7.0",
+        "@smithy/types": "^3.7.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.34",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.34.tgz",
+      "integrity": "sha512-vN6aHfzW9dVVzkI0wcZoUXvfjkl4CSbM9nE//08lmUMyf00S75uuCpTrqF9uD4bD9eldIXlt53colrlwKAT8Gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/smithy-client": "^3.7.0",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.7.tgz",
+      "integrity": "sha512-tSfcqKcN/Oo2STEYCABVuKgJ76nyyr6skGl9t15hs+YaiU06sgMkN7QYjo0BbVw+KT26zok3IzbdSOksQ4YzVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.11.tgz",
+      "integrity": "sha512-dWpyc1e1R6VoXrwLoLDd57U1z6CwNSdkM69Ie4+6uYh2GC7Vg51Qtan7ITzczuVpqezdDTKJGJB95fFvvjU/ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.11.tgz",
+      "integrity": "sha512-hJUC6W7A3DQgaee3Hp9ZFcOxVDZzmBIRBPlUAk8/fSOEl7pE/aX7Dci0JycNOnm9Mfr0KV2XjIlUOcGWXQUdVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.3.4.tgz",
+      "integrity": "sha512-SGhGBG/KupieJvJSZp/rfHHka8BFgj56eek9px4pp7lZbOF+fRiVr4U7A3y3zJD8uGhxq32C5D96HxsTC9BckQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^4.1.3",
+        "@smithy/node-http-handler": "^3.3.3",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.3.tgz",
+      "integrity": "sha512-6SxNltSncI8s689nvnzZQc/dPXcpHQ34KUj6gR/HBroytKOd/isMG3gJF/zBE1TBmTT18TXyzhg3O3SOOqGEhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.2.0.tgz",
+      "integrity": "sha512-PpjSboaDUE6yl+1qlg3Si57++e84oXdWGbuFUSAciXsVfEZJJJupR2Nb0QuXHiunt2vGR+1PTizOMvnUPaG2Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.9",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@stellar/js-xdr": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
@@ -1622,6 +3231,12 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.6",
@@ -2281,6 +3896,28 @@
           "url": "https://opencollective.com/fastify"
         }
       ]
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -3994,6 +5631,18 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -4215,6 +5864,12 @@
         "strip-json-comments": "^2.0.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
@@ -4308,6 +5963,20 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -4670,6 +6339,723 @@
         "ajv": "^8.17.1",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.2"
+      }
+    },
+    "@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "requires": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "requires": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "requires": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/is-array-buffer": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+          "requires": {
+            "@smithy/util-buffer-from": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "requires": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/is-array-buffer": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+          "requires": {
+            "@smithy/util-buffer-from": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "requires": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "requires": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/is-array-buffer": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+          "requires": {
+            "@smithy/util-buffer-from": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        }
+      }
+    },
+    "@aws-sdk/client-s3": {
+      "version": "3.600.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.600.0.tgz",
+      "integrity": "sha512-iYoKbJTputbf+ubkX6gSK/y/4uJEBRaXZ18jykLdBQ8UJuGrk2gqvV8h7OlGAhToCeysmmMqM0vDWyLt6lP8nw==",
+      "requires": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.600.0",
+        "@aws-sdk/client-sts": "3.600.0",
+        "@aws-sdk/core": "3.598.0",
+        "@aws-sdk/credential-provider-node": "3.600.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.598.0",
+        "@aws-sdk/middleware-expect-continue": "3.598.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.598.0",
+        "@aws-sdk/middleware-host-header": "3.598.0",
+        "@aws-sdk/middleware-location-constraint": "3.598.0",
+        "@aws-sdk/middleware-logger": "3.598.0",
+        "@aws-sdk/middleware-recursion-detection": "3.598.0",
+        "@aws-sdk/middleware-sdk-s3": "3.598.0",
+        "@aws-sdk/middleware-signing": "3.598.0",
+        "@aws-sdk/middleware-ssec": "3.598.0",
+        "@aws-sdk/middleware-user-agent": "3.598.0",
+        "@aws-sdk/region-config-resolver": "3.598.0",
+        "@aws-sdk/signature-v4-multi-region": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@aws-sdk/util-user-agent-browser": "3.598.0",
+        "@aws-sdk/util-user-agent-node": "3.598.0",
+        "@aws-sdk/xml-builder": "3.598.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/core": "^2.2.1",
+        "@smithy/eventstream-serde-browser": "^3.0.2",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.1",
+        "@smithy/eventstream-serde-node": "^3.0.2",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/hash-blob-browser": "^3.1.0",
+        "@smithy/hash-node": "^3.0.1",
+        "@smithy/hash-stream-node": "^3.1.0",
+        "@smithy/invalid-dependency": "^3.0.1",
+        "@smithy/md5-js": "^3.0.1",
+        "@smithy/middleware-content-length": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.4",
+        "@smithy/util-defaults-mode-node": "^3.0.4",
+        "@smithy/util-endpoints": "^2.0.2",
+        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-stream": "^3.0.2",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.0.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.598.0.tgz",
+      "integrity": "sha512-nOI5lqPYa+YZlrrzwAJywJSw3MKVjvu6Ge2fCqQUNYMfxFB0NAaDFnl0EPjXi+sEbtCuz/uWE77poHbqiZ+7Iw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.598.0",
+        "@aws-sdk/middleware-host-header": "3.598.0",
+        "@aws-sdk/middleware-logger": "3.598.0",
+        "@aws-sdk/middleware-recursion-detection": "3.598.0",
+        "@aws-sdk/middleware-user-agent": "3.598.0",
+        "@aws-sdk/region-config-resolver": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@aws-sdk/util-user-agent-browser": "3.598.0",
+        "@aws-sdk/util-user-agent-node": "3.598.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/core": "^2.2.1",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/hash-node": "^3.0.1",
+        "@smithy/invalid-dependency": "^3.0.1",
+        "@smithy/middleware-content-length": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.4",
+        "@smithy/util-defaults-mode-node": "^3.0.4",
+        "@smithy/util-endpoints": "^2.0.2",
+        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/client-sso-oidc": {
+      "version": "3.600.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.600.0.tgz",
+      "integrity": "sha512-7+I8RWURGfzvChyNQSyj5/tKrqRbzRl7H+BnTOf/4Vsw1nFOi5ROhlhD4X/Y0QCTacxnaoNcIrqnY7uGGvVRzw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sts": "3.600.0",
+        "@aws-sdk/core": "3.598.0",
+        "@aws-sdk/credential-provider-node": "3.600.0",
+        "@aws-sdk/middleware-host-header": "3.598.0",
+        "@aws-sdk/middleware-logger": "3.598.0",
+        "@aws-sdk/middleware-recursion-detection": "3.598.0",
+        "@aws-sdk/middleware-user-agent": "3.598.0",
+        "@aws-sdk/region-config-resolver": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@aws-sdk/util-user-agent-browser": "3.598.0",
+        "@aws-sdk/util-user-agent-node": "3.598.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/core": "^2.2.1",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/hash-node": "^3.0.1",
+        "@smithy/invalid-dependency": "^3.0.1",
+        "@smithy/middleware-content-length": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.4",
+        "@smithy/util-defaults-mode-node": "^3.0.4",
+        "@smithy/util-endpoints": "^2.0.2",
+        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.600.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.600.0.tgz",
+      "integrity": "sha512-KQG97B7LvTtTiGmjlrG1LRAY8wUvCQzrmZVV5bjrJ/1oXAU7DITYwVbSJeX9NWg6hDuSk0VE3MFwIXS2SvfLIA==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.600.0",
+        "@aws-sdk/core": "3.598.0",
+        "@aws-sdk/credential-provider-node": "3.600.0",
+        "@aws-sdk/middleware-host-header": "3.598.0",
+        "@aws-sdk/middleware-logger": "3.598.0",
+        "@aws-sdk/middleware-recursion-detection": "3.598.0",
+        "@aws-sdk/middleware-user-agent": "3.598.0",
+        "@aws-sdk/region-config-resolver": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@aws-sdk/util-user-agent-browser": "3.598.0",
+        "@aws-sdk/util-user-agent-node": "3.598.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/core": "^2.2.1",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/hash-node": "^3.0.1",
+        "@smithy/invalid-dependency": "^3.0.1",
+        "@smithy/middleware-content-length": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.4",
+        "@smithy/util-defaults-mode-node": "^3.0.4",
+        "@smithy/util-endpoints": "^2.0.2",
+        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/core": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.598.0.tgz",
+      "integrity": "sha512-HaSjt7puO5Cc7cOlrXFCW0rtA0BM9lvzjl56x0A20Pt+0wxXGeTOZZOkXQIepbrFkV2e/HYukuT9e99vXDm59g==",
+      "requires": {
+        "@smithy/core": "^2.2.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/signature-v4": "^3.1.0",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.598.0.tgz",
+      "integrity": "sha512-vi1khgn7yXzLCcgSIzQrrtd2ilUM0dWodxj3PQ6BLfP0O+q1imO3hG1nq7DVyJtq7rFHs6+9N8G4mYvTkxby2w==",
+      "requires": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-http": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.598.0.tgz",
+      "integrity": "sha512-N7cIafi4HVlQvEgvZSo1G4T9qb/JMLGMdBsDCT5XkeJrF0aptQWzTFH0jIdZcLrMYvzPcuEyO3yCBe6cy/ba0g==",
+      "requires": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-stream": "^3.0.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.598.0.tgz",
+      "integrity": "sha512-/ppcIVUbRwDIwJDoYfp90X3+AuJo2mvE52Y1t2VSrvUovYn6N4v95/vXj6LS8CNDhz2jvEJYmu+0cTMHdhI6eA==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.598.0",
+        "@aws-sdk/credential-provider-http": "3.598.0",
+        "@aws-sdk/credential-provider-process": "3.598.0",
+        "@aws-sdk/credential-provider-sso": "3.598.0",
+        "@aws-sdk/credential-provider-web-identity": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/credential-provider-imds": "^3.1.1",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.600.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.600.0.tgz",
+      "integrity": "sha512-1pC7MPMYD45J7yFjA90SxpR0yaSvy+yZiq23aXhAPZLYgJBAxHLu0s0mDCk/piWGPh8+UGur5K0bVdx4B1D5hw==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.598.0",
+        "@aws-sdk/credential-provider-http": "3.598.0",
+        "@aws-sdk/credential-provider-ini": "3.598.0",
+        "@aws-sdk/credential-provider-process": "3.598.0",
+        "@aws-sdk/credential-provider-sso": "3.598.0",
+        "@aws-sdk/credential-provider-web-identity": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/credential-provider-imds": "^3.1.1",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.598.0.tgz",
+      "integrity": "sha512-rM707XbLW8huMk722AgjVyxu2tMZee++fNA8TJVNgs1Ma02Wx6bBrfIvlyK0rCcIRb0WdQYP6fe3Xhiu4e8IBA==",
+      "requires": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.598.0.tgz",
+      "integrity": "sha512-5InwUmrAuqQdOOgxTccRayMMkSmekdLk6s+az9tmikq0QFAHUCtofI+/fllMXSR9iL6JbGYi1940+EUmS4pHJA==",
+      "requires": {
+        "@aws-sdk/client-sso": "3.598.0",
+        "@aws-sdk/token-providers": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.598.0.tgz",
+      "integrity": "sha512-GV5GdiMbz5Tz9JO4NJtRoFXjW0GPEujA0j+5J/B723rTN+REHthJu48HdBKouHGhdzkDWkkh1bu52V02Wprw8w==",
+      "requires": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.598.0.tgz",
+      "integrity": "sha512-PM7BcFfGUSkmkT6+LU9TyJiB4S8yI7dfuKQDwK5ZR3P7MKaK4Uj4yyDiv0oe5xvkF6+O2+rShj+eh8YuWkOZ/Q==",
+      "requires": {
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-arn-parser": "3.568.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/middleware-expect-continue": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.598.0.tgz",
+      "integrity": "sha512-ZuHW18kaeHR8TQyhEOYMr8VwiIh0bMvF7J1OTqXHxDteQIavJWA3CbfZ9sgS4XGtrBZDyHJhjZKeCfLhN2rq3w==",
+      "requires": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.598.0.tgz",
+      "integrity": "sha512-xukAzds0GQXvMEY9G6qt+CzwVzTx8NyKKh04O2Q+nOch6QQ8Rs+2kTRy3Z4wQmXq2pK9hlOWb5nXA7HWpmz6Ng==",
+      "requires": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.598.0.tgz",
+      "integrity": "sha512-WiaG059YBQwQraNejLIi0gMNkX7dfPZ8hDIhvMr5aVPRbaHH8AYF3iNSsXYCHvA2Cfa1O9haYXsuMF9flXnCmA==",
+      "requires": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/middleware-location-constraint": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.598.0.tgz",
+      "integrity": "sha512-8oybQxN3F1ISOMULk7JKJz5DuAm5hCUcxMW9noWShbxTJuStNvuHf/WLUzXrf8oSITyYzIHPtf8VPlKR7I3orQ==",
+      "requires": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.598.0.tgz",
+      "integrity": "sha512-bxBjf/VYiu3zfu8SYM2S9dQQc3tz5uBAOcPz/Bt8DyyK3GgOpjhschH/2XuUErsoUO1gDJqZSdGOmuHGZQn00Q==",
+      "requires": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.598.0.tgz",
+      "integrity": "sha512-vjT9BeFY9FeN0f8hm2l6F53tI0N5bUq6RcDkQXKNabXBnQxKptJRad6oP2X5y3FoVfBLOuDkQgiC2940GIPxtQ==",
+      "requires": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-s3": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.598.0.tgz",
+      "integrity": "sha512-5AGtLAh9wyK6ANPYfaKTqJY1IFJyePIxsEbxa7zS6REheAqyVmgJFaGu3oQ5XlxfGr5Uq59tFTRkyx26G1HkHA==",
+      "requires": {
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-arn-parser": "3.568.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/signature-v4": "^3.1.0",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.598.0.tgz",
+      "integrity": "sha512-XKb05DYx/aBPqz6iCapsCbIl8aD8EihTuPCs51p75QsVfbQoVr4TlFfIl5AooMSITzojdAQqxt021YtvxjtxIQ==",
+      "requires": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/signature-v4": "^3.1.0",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-middleware": "^3.0.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/middleware-ssec": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.598.0.tgz",
+      "integrity": "sha512-f0p2xP8IC1uJ5e/tND1l81QxRtRFywEdnbtKCE0H6RSn4UIt2W3Dohe1qQDbnh27okF0PkNW6BJGdSAz3p7qbA==",
+      "requires": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.598.0.tgz",
+      "integrity": "sha512-4tjESlHG5B5MdjUaLK7tQs/miUtHbb6deauQx8ryqSBYOhfHVgb1ZnzvQR0bTrhpqUg0WlybSkDaZAICf9xctg==",
+      "requires": {
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/region-config-resolver": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.598.0.tgz",
+      "integrity": "sha512-oYXhmTokSav4ytmWleCr3rs/1nyvZW/S0tdi6X7u+dLNL5Jee+uMxWGzgOrWK6wrQOzucLVjS4E/wA11Kv2GTw==",
+      "requires": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/signature-v4-multi-region": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.598.0.tgz",
+      "integrity": "sha512-1r/EyTrO1gSa1FirnR8V7mabr7gk+l+HkyTI0fcTSr8ucB7gmYyW6WjkY8JCz13VYHFK62usCEDS7yoJoJOzTA==",
+      "requires": {
+        "@aws-sdk/middleware-sdk-s3": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/signature-v4": "^3.1.0",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.598.0.tgz",
+      "integrity": "sha512-TKY1EVdHVBnZqpyxyTHdpZpa1tUpb6nxVeRNn1zWG8QB5MvH4ALLd/jR+gtmWDNQbIG4cVuBOZFVL8hIYicKTA==",
+      "requires": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.598.0.tgz",
+      "integrity": "sha512-742uRl6z7u0LFmZwDrFP6r1wlZcgVPw+/TilluDJmCAR8BgRw3IR+743kUXKBGd8QZDRW2n6v/PYsi/AWCDDMQ==",
+      "requires": {
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/util-arn-parser": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.568.0.tgz",
+      "integrity": "sha512-XUKJWWo+KOB7fbnPP0+g/o5Ulku/X53t7i/h+sPHr5xxYTJJ9CYnbToo95mzxe7xWvkLrsNtJ8L+MnNn9INs2w==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/util-endpoints": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.598.0.tgz",
+      "integrity": "sha512-Qo9UoiVVZxcOEdiOMZg3xb1mzkTxrhd4qSlg5QQrfWPJVx/QOg+Iy0NtGxPtHtVZNHZxohYwDwV/tfsnDSE2gQ==",
+      "requires": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-endpoints": "^2.0.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.598.0.tgz",
+      "integrity": "sha512-36Sxo6F+ykElaL1mWzWjlg+1epMpSe8obwhCN1yGE7Js9ywy5U6k6l+A3q3YM9YRbm740sNxncbwLklMvuhTKw==",
+      "requires": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/types": "^3.1.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.598.0.tgz",
+      "integrity": "sha512-oyWGcOlfTdzkC6SVplyr0AGh54IMrDxbhg5RxJ5P+V4BKfcDoDcZV9xenUk9NsOi9MuUjxMumb9UJGkDhM1m0A==",
+      "requires": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/xml-builder": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.598.0.tgz",
+      "integrity": "sha512-ZIa2RK7CHFTZ4gwK77WRtsZ6vF7xwRXxJ8KQIxK2duhoTVcn0xYxpFLdW9WZZZvdP9GIF3Loqvf8DRdeU5Jc7Q==",
+      "requires": {
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
       }
     },
     "@cspotcode/source-map-support": {
@@ -5155,6 +7541,536 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true
+    },
+    "@smithy/abort-controller": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.9.tgz",
+      "integrity": "sha512-yiW0WI30zj8ZKoSYNx90no7ugVn3khlyH/z5W8qtKBtVE6awRALbhSG+2SAHA1r6bO/6M9utxYKVZ3PCJ1rWxw==",
+      "requires": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/chunked-blob-reader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-4.0.0.tgz",
+      "integrity": "sha512-jSqRnZvkT4egkq/7b6/QRCNXmmYVcHwnJldqJ3IhVpQE2atObVJ137xmGeuGFhjFUr8gCEVAOKwSY79OvpbDaQ==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/chunked-blob-reader-native": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-3.0.1.tgz",
+      "integrity": "sha512-VEYtPvh5rs/xlyqpm5NRnfYLZn+q0SRPELbvBV+C/G7IQ+ouTuo+NKKa3ShG5OaFR8NYVMXls9hPYLTvIKKDrQ==",
+      "requires": {
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/config-resolver": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.13.tgz",
+      "integrity": "sha512-Gr/qwzyPaTL1tZcq8WQyHhTZREER5R1Wytmz4WnVGL4onA3dNk6Btll55c8Vr58pLdvWZmtG8oZxJTw3t3q7Jg==",
+      "requires": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/core": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.7.tgz",
+      "integrity": "sha512-8olpW6mKCa0v+ibCjoCzgZHQx1SQmZuW/WkrdZo73wiTprTH6qhmskT60QLFdT9DRa5mXxjz89kQPZ7ZSsoqqg==",
+      "requires": {
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-stream": "^3.3.4",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/credential-provider-imds": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.8.tgz",
+      "integrity": "sha512-ZCY2yD0BY+K9iMXkkbnjo+08T2h8/34oHd0Jmh6BZUSZwaaGlGCyBT/3wnS7u7Xl33/EEfN4B6nQr3Gx5bYxgw==",
+      "requires": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/eventstream-codec": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.10.tgz",
+      "integrity": "sha512-323B8YckSbUH0nMIpXn7HZsAVKHYHFUODa8gG9cHo0ySvA1fr5iWaNT+iIL0UCqUzG6QPHA3BSsBtRQou4mMqQ==",
+      "requires": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/eventstream-serde-browser": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.14.tgz",
+      "integrity": "sha512-kbrt0vjOIihW3V7Cqj1SXQvAI5BR8SnyQYsandva0AOR307cXAc+IhPngxIPslxTLfxwDpNu0HzCAq6g42kCPg==",
+      "requires": {
+        "@smithy/eventstream-serde-universal": "^3.0.13",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/eventstream-serde-config-resolver": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.11.tgz",
+      "integrity": "sha512-P2pnEp4n75O+QHjyO7cbw/vsw5l93K/8EWyjNCAAybYwUmj3M+hjSQZ9P5TVdUgEG08ueMAP5R4FkuSkElZ5tQ==",
+      "requires": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/eventstream-serde-node": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.13.tgz",
+      "integrity": "sha512-zqy/9iwbj8Wysmvi7Lq7XFLeDgjRpTbCfwBhJa8WbrylTAHiAu6oQTwdY7iu2lxigbc9YYr9vPv5SzYny5tCXQ==",
+      "requires": {
+        "@smithy/eventstream-serde-universal": "^3.0.13",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/eventstream-serde-universal": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.13.tgz",
+      "integrity": "sha512-L1Ib66+gg9uTnqp/18Gz4MDpJPKRE44geOjOQ2SVc0eiaO5l255ADziATZgjQjqumC7yPtp1XnjHlF1srcwjKw==",
+      "requires": {
+        "@smithy/eventstream-codec": "^3.1.10",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/fetch-http-handler": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.9.tgz",
+      "integrity": "sha512-hYNVQOqhFQ6vOpenifFME546f0GfJn2OiQ3M0FDmuUu8V/Uiwy2wej7ZXxFBNqdx0R5DZAqWM1l6VRhGz8oE6A==",
+      "requires": {
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/querystring-builder": "^3.0.7",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/hash-blob-browser": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.1.10.tgz",
+      "integrity": "sha512-elwslXOoNunmfS0fh55jHggyhccobFkexLYC1ZeZ1xP2BTSrcIBaHV2b4xUQOdctrSNOpMqOZH1r2XzWTEhyfA==",
+      "requires": {
+        "@smithy/chunked-blob-reader": "^4.0.0",
+        "@smithy/chunked-blob-reader-native": "^3.0.1",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/hash-node": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.11.tgz",
+      "integrity": "sha512-emP23rwYyZhQBvklqTtwetkQlqbNYirDiEEwXl2v0GYWMnCzxst7ZaRAnWuy28njp5kAH54lvkdG37MblZzaHA==",
+      "requires": {
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/hash-stream-node": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.1.10.tgz",
+      "integrity": "sha512-olomK/jZQ93OMayW1zfTHwcbwBdhcZOHsyWyiZ9h9IXvc1mCD/VuvzbLb3Gy/qNJwI4MANPLctTp2BucV2oU/Q==",
+      "requires": {
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/invalid-dependency": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.11.tgz",
+      "integrity": "sha512-NuQmVPEJjUX6c+UELyVz8kUx8Q539EDeNwbRyu4IIF8MeV7hUtq1FB3SHVyki2u++5XLMFqngeMKk7ccspnNyQ==",
+      "requires": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/md5-js": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.11.tgz",
+      "integrity": "sha512-3NM0L3i2Zm4bbgG6Ymi9NBcxXhryi3uE8fIfHJZIOfZVxOkGdjdgjR9A06SFIZCfnEIWKXZdm6Yq5/aPXFFhsQ==",
+      "requires": {
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/middleware-content-length": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.13.tgz",
+      "integrity": "sha512-zfMhzojhFpIX3P5ug7jxTjfUcIPcGjcQYzB9t+rv0g1TX7B0QdwONW+ATouaLoD7h7LOw/ZlXfkq4xJ/g2TrIw==",
+      "requires": {
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/middleware-endpoint": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.8.tgz",
+      "integrity": "sha512-OEJZKVUEhMOqMs3ktrTWp7UvvluMJEvD5XgQwRePSbDg1VvBaL8pX8mwPltFn6wk1GySbcVwwyldL8S+iqnrEQ==",
+      "requires": {
+        "@smithy/core": "^2.5.7",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-middleware": "^3.0.11",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/middleware-retry": {
+      "version": "3.0.34",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.34.tgz",
+      "integrity": "sha512-yVRr/AAtPZlUvwEkrq7S3x7Z8/xCd97m2hLDaqdz6ucP2RKHsBjEqaUA2ebNv2SsZoPEi+ZD0dZbOB1u37tGCA==",
+      "requires": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/service-error-classification": "^3.0.11",
+        "@smithy/smithy-client": "^3.7.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      }
+    },
+    "@smithy/middleware-serde": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.11.tgz",
+      "integrity": "sha512-KzPAeySp/fOoQA82TpnwItvX8BBURecpx6ZMu75EZDkAcnPtO6vf7q4aH5QHs/F1s3/snQaSFbbUMcFFZ086Mw==",
+      "requires": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/middleware-stack": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.11.tgz",
+      "integrity": "sha512-1HGo9a6/ikgOMrTrWL/WiN9N8GSVYpuRQO5kjstAq4CvV59bjqnh7TbdXGQ4vxLD3xlSjfBjq5t1SOELePsLnA==",
+      "requires": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/node-config-provider": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.12.tgz",
+      "integrity": "sha512-O9LVEu5J/u/FuNlZs+L7Ikn3lz7VB9hb0GtPT9MQeiBmtK8RSY3ULmsZgXhe6VAlgTw0YO+paQx4p8xdbs43vQ==",
+      "requires": {
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/node-http-handler": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.3.tgz",
+      "integrity": "sha512-BrpZOaZ4RCbcJ2igiSNG16S+kgAc65l/2hmxWdmhyoGWHTLlzQzr06PXavJp9OBlPEG/sHlqdxjWmjzV66+BSQ==",
+      "requires": {
+        "@smithy/abort-controller": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/property-provider": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.11.tgz",
+      "integrity": "sha512-I/+TMc4XTQ3QAjXfOcUWbSS073oOEAxgx4aZy8jHaf8JQnRkq2SZWw8+PfDtBvLUjcGMdxl+YwtzWe6i5uhL/A==",
+      "requires": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/protocol-http": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.8.tgz",
+      "integrity": "sha512-hmgIAVyxw1LySOwkgMIUN0kjN8TG9Nc85LJeEmEE/cNEe2rkHDUWhnJf2gxcSRFLWsyqWsrZGw40ROjUogg+Iw==",
+      "requires": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/querystring-builder": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.11.tgz",
+      "integrity": "sha512-u+5HV/9uJaeLj5XTb6+IEF/dokWWkEqJ0XiaRRogyREmKGUgZnNecLucADLdauWFKUNbQfulHFEZEdjwEBjXRg==",
+      "requires": {
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/querystring-parser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.11.tgz",
+      "integrity": "sha512-Je3kFvCsFMnso1ilPwA7GtlbPaTixa3WwC+K21kmMZHsBEOZYQaqxcMqeFFoU7/slFjKDIpiiPydvdJm8Q/MCw==",
+      "requires": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/service-error-classification": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.11.tgz",
+      "integrity": "sha512-QnYDPkyewrJzCyaeI2Rmp7pDwbUETe+hU8ADkXmgNusO1bgHBH7ovXJiYmba8t0fNfJx75fE8dlM6SEmZxheog==",
+      "requires": {
+        "@smithy/types": "^3.7.2"
+      }
+    },
+    "@smithy/shared-ini-file-loader": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.12.tgz",
+      "integrity": "sha512-1xKSGI+U9KKdbG2qDvIR9dGrw3CNx+baqJfyr0igKEpjbHL5stsqAesYBzHChYHlelWtb87VnLWlhvfCz13H8Q==",
+      "requires": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/signature-v4": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.1.2.tgz",
+      "integrity": "sha512-3BcPylEsYtD0esM4Hoyml/+s7WP2LFhcM3J2AGdcL2vx9O60TtfpDOL72gjb4lU8NeRPeKAwR77YNyyGvMbuEA==",
+      "requires": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/smithy-client": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.7.0.tgz",
+      "integrity": "sha512-9wYrjAZFlqWhgVo3C4y/9kpc68jgiSsKUnsFPzr/MSiRL93+QRDafGTfhhKAb2wsr69Ru87WTiqSfQusSmWipA==",
+      "requires": {
+        "@smithy/core": "^2.5.7",
+        "@smithy/middleware-endpoint": "^3.2.8",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-stream": "^3.3.4",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/types": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/url-parser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.11.tgz",
+      "integrity": "sha512-TmlqXkSk8ZPhfc+SQutjmFr5FjC0av3GZP4B/10caK1SbRwe/v+Wzu/R6xEKxoNqL+8nY18s1byiy6HqPG37Aw==",
+      "requires": {
+        "@smithy/querystring-parser": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "requires": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "requires": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-defaults-mode-browser": {
+      "version": "3.0.34",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.34.tgz",
+      "integrity": "sha512-FumjjF631lR521cX+svMLBj3SwSDh9VdtyynTYDAiBDEf8YPP5xORNXKQ9j0105o5+ARAGnOOP/RqSl40uXddA==",
+      "requires": {
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/smithy-client": "^3.7.0",
+        "@smithy/types": "^3.7.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-defaults-mode-node": {
+      "version": "3.0.34",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.34.tgz",
+      "integrity": "sha512-vN6aHfzW9dVVzkI0wcZoUXvfjkl4CSbM9nE//08lmUMyf00S75uuCpTrqF9uD4bD9eldIXlt53colrlwKAT8Gw==",
+      "requires": {
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/smithy-client": "^3.7.0",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-endpoints": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.7.tgz",
+      "integrity": "sha512-tSfcqKcN/Oo2STEYCABVuKgJ76nyyr6skGl9t15hs+YaiU06sgMkN7QYjo0BbVw+KT26zok3IzbdSOksQ4YzVw==",
+      "requires": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-middleware": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.11.tgz",
+      "integrity": "sha512-dWpyc1e1R6VoXrwLoLDd57U1z6CwNSdkM69Ie4+6uYh2GC7Vg51Qtan7ITzczuVpqezdDTKJGJB95fFvvjU/ow==",
+      "requires": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-retry": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.11.tgz",
+      "integrity": "sha512-hJUC6W7A3DQgaee3Hp9ZFcOxVDZzmBIRBPlUAk8/fSOEl7pE/aX7Dci0JycNOnm9Mfr0KV2XjIlUOcGWXQUdVQ==",
+      "requires": {
+        "@smithy/service-error-classification": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.3.4.tgz",
+      "integrity": "sha512-SGhGBG/KupieJvJSZp/rfHHka8BFgj56eek9px4pp7lZbOF+fRiVr4U7A3y3zJD8uGhxq32C5D96HxsTC9BckQ==",
+      "requires": {
+        "@smithy/fetch-http-handler": "^4.1.3",
+        "@smithy/node-http-handler": "^3.3.3",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/fetch-http-handler": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.3.tgz",
+          "integrity": "sha512-6SxNltSncI8s689nvnzZQc/dPXcpHQ34KUj6gR/HBroytKOd/isMG3gJF/zBE1TBmTT18TXyzhg3O3SOOqGEhA==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.8",
+            "@smithy/querystring-builder": "^3.0.11",
+            "@smithy/types": "^3.7.2",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        }
+      }
+    },
+    "@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "requires": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-waiter": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.2.0.tgz",
+      "integrity": "sha512-PpjSboaDUE6yl+1qlg3Si57++e84oXdWGbuFUSAciXsVfEZJJJupR2Nb0QuXHiunt2vGR+1PTizOMvnUPaG2Qg==",
+      "requires": {
+        "@smithy/abort-controller": "^3.1.9",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
     },
     "@stellar/js-xdr": {
       "version": "3.1.2",
@@ -5671,6 +8587,11 @@
         "unpipe": "~1.0.0"
       }
     },
+    "bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="
+    },
     "brace-expansion": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
@@ -6140,6 +9061,14 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
       "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="
+    },
+    "fast-xml-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "requires": {
+        "strnum": "^1.0.5"
+      }
     },
     "fill-range": {
       "version": "7.1.1",
@@ -7326,6 +10255,11 @@
         "js-tokens": "^9.0.1"
       }
     },
+    "strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA=="
+    },
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -7473,6 +10407,11 @@
         "strip-json-comments": "^2.0.0"
       }
     },
+    "tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
     "tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
@@ -7545,6 +10484,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
+    },
+    "uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prisma:push": "prisma db push",
     "index": "ts-node src/indexer/run.ts",
     "repair": "ts-node src/indexer/repair-run.ts",
+    "archive": "ts-node src/archival/run.ts",
     "seed": "ts-node prisma/seed.ts",
     "test": "vitest run"
   },
@@ -19,6 +20,7 @@
     "seed": "ts-node prisma/seed.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "3.600.0",
     "@prisma/client": "^5.10.0",
     "@stellar/stellar-sdk": "^12.0.0",
     "axios": "^1.6.7",

--- a/src/archival/archiver.ts
+++ b/src/archival/archiver.ts
@@ -1,0 +1,86 @@
+import { prismaWrite as prisma } from '../db';
+import { uploadToS3 } from './s3Client';
+
+// Transactions older than this many days have their rawXdr archived to S3
+const RAW_XDR_RETENTION_DAYS = parseInt(process.env.RAW_XDR_RETENTION_DAYS ?? '90');
+// How many rows to process per batch to avoid memory spikes
+const ARCHIVE_BATCH_SIZE = parseInt(process.env.ARCHIVE_BATCH_SIZE ?? '500');
+
+export interface ArchivalResult {
+  archived: number;
+  nullified: number;
+  errors: number;
+}
+
+/**
+ * Archive raw XDR from transactions older than RAW_XDR_RETENTION_DAYS to S3,
+ * then null out the rawXdr column in the DB to reclaim space.
+ *
+ * S3 key format: xdr/{year}/{month}/{ledgerSequence}/{txHash}.json
+ * The JSON payload contains rawXdr + enough metadata to reconstruct context.
+ */
+export async function archiveRawXdr(): Promise<ArchivalResult> {
+  const cutoff = new Date(Date.now() - RAW_XDR_RETENTION_DAYS * 24 * 60 * 60 * 1000);
+  const result: ArchivalResult = { archived: 0, nullified: 0, errors: 0 };
+
+  console.log(`[Archiver] Archiving rawXdr older than ${cutoff.toISOString()} to S3`);
+
+  let cursor: string | undefined;
+
+  while (true) {
+    const rows = await prisma.transaction.findMany({
+      where: {
+        ledgerCloseTime: { lt: cutoff },
+        rawXdr: { not: '' },
+      },
+      select: {
+        id: true,
+        hash: true,
+        ledgerSequence: true,
+        ledgerCloseTime: true,
+        contractAddress: true,
+        rawXdr: true,
+      },
+      orderBy: { id: 'asc' },
+      take: ARCHIVE_BATCH_SIZE,
+      ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+    });
+
+    if (rows.length === 0) break;
+    cursor = rows[rows.length - 1].id;
+
+    const toNullify: string[] = [];
+
+    await Promise.allSettled(
+      rows.map(async (tx) => {
+        const d = tx.ledgerCloseTime;
+        const key = `xdr/${d.getUTCFullYear()}/${String(d.getUTCMonth() + 1).padStart(2, '0')}/${tx.ledgerSequence}/${tx.hash}.json`;
+        try {
+          await uploadToS3(key, JSON.stringify({
+            hash: tx.hash,
+            ledgerSequence: tx.ledgerSequence,
+            ledgerCloseTime: tx.ledgerCloseTime.toISOString(),
+            contractAddress: tx.contractAddress,
+            rawXdr: tx.rawXdr,
+          }));
+          toNullify.push(tx.id);
+          result.archived++;
+        } catch (err) {
+          console.error(`[Archiver] Failed to upload ${tx.hash}:`, err);
+          result.errors++;
+        }
+      })
+    );
+
+    if (toNullify.length > 0) {
+      await prisma.transaction.updateMany({
+        where: { id: { in: toNullify } },
+        data: { rawXdr: '' },
+      });
+      result.nullified += toNullify.length;
+    }
+  }
+
+  console.log(`[Archiver] Done — archived: ${result.archived}, nullified: ${result.nullified}, errors: ${result.errors}`);
+  return result;
+}

--- a/src/archival/run.ts
+++ b/src/archival/run.ts
@@ -1,0 +1,12 @@
+import '../config'; // load env
+import { archiveRawXdr } from './archiver';
+
+archiveRawXdr()
+  .then((r) => {
+    console.log('[Archiver] Completed:', r);
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error('[Archiver] Fatal:', err);
+    process.exit(1);
+  });

--- a/src/archival/s3Client.ts
+++ b/src/archival/s3Client.ts
@@ -1,0 +1,23 @@
+import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+
+const s3 = new S3Client({
+  region: process.env.AWS_REGION ?? 'us-east-1',
+  ...(process.env.AWS_ENDPOINT_URL ? { endpoint: process.env.AWS_ENDPOINT_URL } : {}),
+});
+
+export const ARCHIVE_BUCKET = process.env.ARCHIVE_S3_BUCKET ?? 'soroban-xdr-archive';
+
+export async function uploadToS3(key: string, body: string): Promise<void> {
+  await s3.send(new PutObjectCommand({
+    Bucket: ARCHIVE_BUCKET,
+    Key: key,
+    Body: body,
+    ContentType: 'application/json',
+    StorageClass: (process.env.ARCHIVE_S3_STORAGE_CLASS as any) ?? 'STANDARD_IA',
+  }));
+}
+
+export async function downloadFromS3(key: string): Promise<string> {
+  const res = await s3.send(new GetObjectCommand({ Bucket: ARCHIVE_BUCKET, Key: key }));
+  return res.Body!.transformToString();
+}

--- a/src/indexer/dataPruner.ts
+++ b/src/indexer/dataPruner.ts
@@ -1,5 +1,6 @@
 import { prismaWrite as prisma } from '../db';
 import { config } from '../config';
+import { archiveRawXdr } from '../archival/archiver';
 
 const PRUNE_INTERVAL_MS = parseInt(process.env.PRUNE_INTERVAL_MS ?? '86400000'); // 24h default
 const FAILED_ITEM_RETENTION_DAYS = parseInt(process.env.FAILED_ITEM_RETENTION_DAYS ?? '7');
@@ -23,6 +24,11 @@ async function pruneExpiredData() {
   console.log('[Pruner] Starting data pruning cycle');
 
   try {
+    // Archive raw XDR to S3 before pruning (only when S3 bucket is configured)
+    if (process.env.ARCHIVE_S3_BUCKET) {
+      await archiveRawXdr();
+    }
+
     // Prune dead failed items older than retention period
     const failedItemCutoff = new Date(Date.now() - FAILED_ITEM_RETENTION_DAYS * 24 * 60 * 60 * 1000);
     const deletedFailedItems = await prisma.failedItem.deleteMany({

--- a/tests/archiver.test.ts
+++ b/tests/archiver.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Hoist mocks so vi.mock factories can reference them ───────────────────────
+const { mockFindMany, mockUpdateMany, mockUploadToS3 } = vi.hoisted(() => ({
+  mockFindMany: vi.fn(),
+  mockUpdateMany: vi.fn(),
+  mockUploadToS3: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../src/archival/s3Client', () => ({
+  ARCHIVE_BUCKET: 'test-bucket',
+  uploadToS3: mockUploadToS3,
+  downloadFromS3: vi.fn().mockResolvedValue('{}'),
+}));
+
+vi.mock('../src/db', () => ({
+  prismaWrite: {
+    transaction: {
+      findMany: mockFindMany,
+      updateMany: mockUpdateMany,
+    },
+  },
+}));
+
+import { archiveRawXdr } from '../src/archival/archiver';
+
+const MOCK_TX = {
+  id: 'cuid1',
+  hash: 'abc123',
+  ledgerSequence: 1000,
+  ledgerCloseTime: new Date('2025-01-15T00:00:00Z'),
+  contractAddress: 'CXXX',
+  rawXdr: 'AAAA==',
+};
+
+describe('archiveRawXdr', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindMany.mockResolvedValueOnce([MOCK_TX]).mockResolvedValueOnce([]);
+    mockUpdateMany.mockResolvedValue({ count: 1 });
+  });
+
+  it('uploads each transaction rawXdr to S3 with correct key', async () => {
+    await archiveRawXdr();
+
+    expect(mockUploadToS3).toHaveBeenCalledOnce();
+    const [key, body] = mockUploadToS3.mock.calls[0];
+    expect(key).toBe('xdr/2025/01/1000/abc123.json');
+    const parsed = JSON.parse(body);
+    expect(parsed.hash).toBe('abc123');
+    expect(parsed.rawXdr).toBe('AAAA==');
+  });
+
+  it('nullifies rawXdr in DB after successful upload', async () => {
+    await archiveRawXdr();
+
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: { id: { in: ['cuid1'] } },
+      data: { rawXdr: '' },
+    });
+  });
+
+  it('returns correct counts', async () => {
+    const result = await archiveRawXdr();
+    expect(result.archived).toBe(1);
+    expect(result.nullified).toBe(1);
+    expect(result.errors).toBe(0);
+  });
+
+  it('counts S3 upload failures as errors and does not nullify those rows', async () => {
+    mockUploadToS3.mockRejectedValueOnce(new Error('S3 down'));
+
+    const result = await archiveRawXdr();
+
+    expect(result.errors).toBe(1);
+    expect(result.nullified).toBe(0);
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it('stops when no rows are returned', async () => {
+    mockFindMany.mockReset().mockResolvedValue([]);
+
+    const result = await archiveRawXdr();
+
+    expect(result.archived).toBe(0);
+    expect(mockUploadToS3).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #31 

- Add src/archival/s3Client.ts: S3 upload/download wrapper (configurable storage class, S3-compatible endpoint support)
- Add src/archival/archiver.ts: cursor-paginated archival of Transaction.rawXdr older than RAW_XDR_RETENTION_DAYS to S3; nullifies column after upload
- Add src/archival/run.ts: standalone CLI entry point (npm run archive)
- Update dataPruner: run archival before pruning when ARCHIVE_S3_BUCKET is set
- Update .env.example with archival env vars
- Add tests/archiver.test.ts: 5 unit tests for archival logic

What was implemented:

- src/archival/s3Client.ts — thin S3 wrapper using @aws-sdk/client-s3. Supports any S3-compatible endpoint (LocalStack, MinIO) via AWS_ENDPOINT_URL. Storage class is configurable (STANDARD_IA, GLACIER, DEEP_ARCHIVE).

- src/archival/archiver.ts — core archival logic. Cursor-paginates through Transaction rows older than RAW_XDR_RETENTION_DAYS (default 90 days), uploads each rawXdr to S3 at key 
xdr/{year}/{month}/{ledgerSequence}/{txHash}.json, then nullifies the rawXdr column in Postgres. Parsed/human-readable data (humanReadable, functionArgs, etc.) stays warm in the DB. Errors per row are counted and don't 
block the rest of the batch.

- src/archival/run.ts — standalone CLI entry (npm run archive) to trigger archival on demand or from a cron job.

- src/indexer/dataPruner.ts — updated to call archiveRawXdr() at the start of each pruning cycle when ARCHIVE_S3_BUCKET is set (opt-in, no-op if unset).

- .env.example — added RAW_XDR_RETENTION_DAYS, ARCHIVE_BATCH_SIZE, ARCHIVE_S3_BUCKET, ARCHIVE_S3_STORAGE_CLASS, AWS_REGION, AWS_ENDPOINT_URL.

- package.json — added "archive": "ts-node src/archival/run.ts" script.

- tests/archiver.test.ts — 5 unit tests covering: correct S3 key format, DB nullification, result counts, S3 failure isolation, and empty-result early exit.