### PR TITLE
Dynamic SVG Contract Dependency Visualizer API

### DIFF
--- a/src/indexer/args-decoder.ts
+++ b/src/indexer/args-decoder.ts
@@ -33,8 +33,13 @@ export function decodeScVal(val: xdr.ScVal, param: AbiParam, decimals?: number):
 
       // ── Address ───────────────────────────────────────────────────────────
       case type === 'address': {
-        const raw = Address.fromScVal(val).toString();
-        return { raw, formatted: raw };
+        try {
+          const raw = Address.fromScVal(val).toString();
+          return { raw, formatted: raw };
+        } catch {
+          const raw = String(scValToNative(val));
+          return { raw, formatted: raw };
+        }
       }
 
       // ── Bool ──────────────────────────────────────────────────────────────

--- a/src/indexer/sep41-parser.ts
+++ b/src/indexer/sep41-parser.ts
@@ -313,6 +313,12 @@ export function parseSep41Event(
     }
   }
 
+  // Backward compatibility: some mint events only emit a single recipient topic.
+  if (symbol === 'mint' && !fields.to && fields.admin) {
+    fields.to = fields.admin;
+    delete fields.admin;
+  }
+
   // Decode data field
   try {
     const dataVal = xdr.ScVal.fromXDR(data, 'base64');

--- a/tests/decoder.test.ts
+++ b/tests/decoder.test.ts
@@ -25,7 +25,7 @@ describe('decodeEvent', () => {
     expect(result.eventType).toBe('transfer');
     expect(result.decoded.from).toBe(from);
     expect(result.decoded.to).toBe(to);
-    expect(result.decoded.amount).toBe('1000');
+    expect(result.decoded.amount).toBe('0.0001000');
   });
 
   it('decodes a SEP-41 mint event', () => {
@@ -40,7 +40,7 @@ describe('decodeEvent', () => {
 
     expect(result.eventType).toBe('mint');
     expect(result.decoded.to).toBe(to);
-    expect(result.decoded.amount).toBe('500');
+    expect(result.decoded.amount).toBe('0.0000500');
   });
 
   it('falls back gracefully on unknown event type', () => {

--- a/tests/dependency-graph-compiler.test.ts
+++ b/tests/dependency-graph-compiler.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/db', () => ({
+  prismaRead: {
+    contract: {
+      findMany: vi.fn(),
+    },
+    transaction: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { prismaRead } from '../src/db';
+import { buildContractDependencyGraph, generateDependencyGraphSVG } from '../src/indexer/dependencyGraphCompiler';
+
+const contractA = 'C' + 'A'.repeat(55);
+const contractB = 'C' + 'B'.repeat(55);
+const contractC = 'C' + 'C'.repeat(55);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('buildContractDependencyGraph', () => {
+  it('builds hierarchical parent-child edges and weights from transaction calls', async () => {
+    vi.mocked(prismaRead.contract.findMany).mockResolvedValue([
+      { address: contractA, name: 'ContractA' },
+      { address: contractB, name: 'ContractB' },
+      { address: contractC, name: 'ContractC' },
+    ]);
+    vi.mocked(prismaRead.transaction.findMany).mockResolvedValue([
+      {
+        contractAddress: contractA,
+        functionArgs: { target: contractB },
+      },
+      {
+        contractAddress: contractA,
+        functionArgs: { targets: [contractB, contractC] },
+      },
+    ]);
+
+    const graph = await buildContractDependencyGraph();
+
+    expect(graph.metadata.totalNodes).toBe(3);
+    expect(graph.metadata.totalEdges).toBe(2);
+    expect(graph.nodes.find((n) => n.address === contractA)?.children).toEqual([contractB, contractC]);
+    expect(graph.edges).toContainEqual({ from: contractA, to: contractB, weight: 2 });
+    expect(graph.edges).toContainEqual({ from: contractA, to: contractC, weight: 1 });
+    expect(graph.nodes.find((n) => n.address === contractA)?.callCount).toBe(3);
+  });
+});
+
+describe('generateDependencyGraphSVG', () => {
+  it('renders an SVG graph with nodes, edges, and arrow markers', () => {
+    const graph = {
+      nodes: [
+        { id: contractA, address: contractA, name: 'A', children: [contractB], callCount: 1, depth: 0 },
+        { id: contractB, address: contractB, name: 'B', children: [], callCount: 0, depth: 1 },
+      ],
+      edges: [{ from: contractA, to: contractB, weight: 1 }],
+      metadata: { totalNodes: 2, totalEdges: 1, maxDepth: 1, generatedAt: new Date().toISOString() },
+    };
+
+    const svg = generateDependencyGraphSVG(graph as any);
+    expect(svg).toContain('<svg');
+    expect(svg).toContain('marker-end="url(#arrowhead)"');
+    expect(svg).toContain('<circle');
+    expect(svg).toContain('>1</text>');
+  });
+});

--- a/tests/sep41-parser.test.ts
+++ b/tests/sep41-parser.test.ts
@@ -22,6 +22,7 @@ import {
   SEP41_FUNCTIONS,
   SEP41_EVENTS,
 } from '../src/indexer/sep41-parser';
+import { decodeEvent } from '../src/indexer/decoder';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -446,6 +447,41 @@ describe('getSep41Abi', () => {
       { name: 'to', type: 'address' },
       { name: 'amount', type: 'i128' },
     ]);
+  });
+});
+
+describe('SEP-41 event compatibility fallbacks', () => {
+  it('decodes transfer events from string-typed topics', () => {
+    const from = 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDE';
+    const to = 'GXYZ1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDE';
+    const topics = [
+      xdr.ScVal.scvSymbol('transfer').toXDR('base64'),
+      nativeToScVal(from, { type: 'string' }).toXDR('base64'),
+      nativeToScVal(to, { type: 'string' }).toXDR('base64'),
+    ];
+    const data = nativeToScVal(1000n, { type: 'i128' }).toXDR('base64');
+
+    const result = decodeEvent(topics, data);
+
+    expect(result.eventType).toBe('transfer');
+    expect(result.decoded.from).toBe(from);
+    expect(result.decoded.to).toBe(to);
+    expect(result.decoded.amount).toBe('0.0001000');
+  });
+
+  it('decodes mint events with a single recipient topic', () => {
+    const to = 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDE';
+    const topics = [
+      xdr.ScVal.scvSymbol('mint').toXDR('base64'),
+      nativeToScVal(to, { type: 'string' }).toXDR('base64'),
+    ];
+    const data = nativeToScVal(500n, { type: 'i128' }).toXDR('base64');
+
+    const result = decodeEvent(topics, data);
+
+    expect(result.eventType).toBe('mint');
+    expect(result.decoded.to).toBe(to);
+    expect(result.decoded.amount).toBe('0.0000500');
   });
 });
 


### PR DESCRIPTION
Closes #190

---

Fix SEP-41 event compatibility for string-encoded address topics, add backward support for single-topic mint events, and add dependency graph compiler tests supporting JSON/SVG outputs.