### PR TITLE
feat(i18n): #191 Multi-Language i18n Translation Matrix Engine

### DIFF
--- a/src/api/i18n.ts
+++ b/src/api/i18n.ts
@@ -1,143 +1,499 @@
+/**
+ * i18n Translation Matrix Engine — API routes
+ *
+ * Endpoints:
+ *   GET  /i18n/languages              — list supported languages + coverage stats
+ *   GET  /i18n/keys                   — list all translation keys (DB + static)
+ *   POST /i18n/keys                   — register a new translation key
+ *   GET  /i18n/translate              — translate a single key with interpolation
+ *   POST /i18n/translate/batch        — translate multiple keys at once
+ *   GET  /i18n/matrix                 — full translation matrix across all languages
+ *   GET  /i18n/dictionary/:language   — full static dictionary for a language
+ *   POST /i18n/translations           — add/update a DB translation for a key
+ *   PATCH /i18n/translations/:id      — approve a translation
+ *   POST /i18n/seed                   — bulk-seed static dictionary into DB
+ */
+
 import { Router, Request, Response } from 'express';
-import { prismaRead as prisma } from '../db';
 import { z } from 'zod';
+import { prismaRead as prisma, prismaWrite } from '../db';
+import {
+  SUPPORTED_LANGUAGES,
+  SupportedLanguage,
+  DEFAULT_LANGUAGE,
+  normaliseLocale,
+  t,
+  tAsync,
+  buildStaticMatrix,
+  getAllStaticKeys,
+  getStaticDictionary,
+} from '../i18n/engine';
 
 export const i18nRouter = Router();
 
-// Simple template interpolation: replace {key} with values
-function interpolate(template: string, values: Record<string, any>): string {
-  return template.replace(/{(\w+)}/g, (_, key) => {
-    const val = values[key];
-    return val !== undefined ? String(val) : `{${key}}`;
-  });
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Resolve language from request: X-Language header > ?lang= > Accept-Language > default */
+function resolveLanguage(req: Request): SupportedLanguage {
+  // Middleware already resolved it if i18nMiddleware is applied globally
+  if (req.locale) return req.locale;
+
+  const xLang = req.headers['x-language'] as string | undefined;
+  const qLang = req.query['lang'] as string | undefined;
+  return normaliseLocale(xLang ?? qLang ?? DEFAULT_LANGUAGE);
 }
 
-// POST /i18n/keys — register translation key
-i18nRouter.post('/keys', async (req: Request, res: Response) => {
+// ── GET /i18n/languages ───────────────────────────────────────────────────────
+
+/**
+ * @swagger
+ * /i18n/languages:
+ *   get:
+ *     summary: List supported languages with static coverage stats
+ *     tags: [i18n]
+ *     responses:
+ *       200:
+ *         description: Language list with coverage percentages
+ */
+i18nRouter.get('/languages', async (_req: Request, res: Response) => {
   try {
-    const { key, defaultText, context } = z.object({
-      key: z.string().min(1),
-      defaultText: z.string().min(1),
-      context: z.string().optional(),
-    }).parse(req.body);
+    const masterKeys = getAllStaticKeys();
+    const total = masterKeys.length;
 
-    const translationKey = await prisma.translationKey.create({
-      data: { key, defaultText, context },
-    });
+    const coverage: Record<string, { static: number; staticPct: number; hasStaticDictionary: boolean }> = {};
 
-    res.status(201).json(translationKey);
-  } catch (e) {
-    res.status(400).json({ error: String(e) });
-  }
-});
-
-// POST /i18n/translations — add translation for a key
-i18nRouter.post('/translations', async (req: Request, res: Response) => {
-  try {
-    const { keyId, language, translatedText, approvedBy } = z.object({
-      keyId: z.string().min(1),
-      language: z.string().min(2).max(5),
-      translatedText: z.string().min(1),
-      approvedBy: z.string().optional(),
-    }).parse(req.body);
-
-    const translation = await prisma.translation.create({
-      data: {
-        keyId,
-        language,
-        translatedText,
-        approvedBy,
-        approvedAt: approvedBy ? new Date() : null,
-      },
-    });
-
-    res.status(201).json(translation);
-  } catch (e) {
-    res.status(400).json({ error: String(e) });
-  }
-});
-
-// GET /i18n/translate — translate text with interpolation
-i18nRouter.get('/translate', async (req: Request, res: Response) => {
-  try {
-    const { key, language, values } = z.object({
-      key: z.string().min(1),
-      language: z.string().min(2).max(5).default('en'),
-      values: z.record(z.any()).optional(),
-    }).parse(req.query);
-
-    const translationKey = await prisma.translationKey.findUnique({
-      where: { key },
-      include: {
-        translations: {
-          where: { language },
-        },
-      },
-    });
-
-    if (!translationKey) {
-      return res.status(404).json({ error: 'Translation key not found' });
+    for (const lang of SUPPORTED_LANGUAGES) {
+      const dict = getStaticDictionary(lang as SupportedLanguage);
+      const covered = masterKeys.filter((k) => dict[k] && dict[k] !== k).length;
+      coverage[lang] = {
+        static: covered,
+        staticPct: total > 0 ? Math.round((covered / total) * 100) : 0,
+        hasStaticDictionary: ['en', 'es', 'ko'].includes(lang),
+      };
     }
 
-    const translation = translationKey.translations[0];
-    const template = translation?.translatedText || translationKey.defaultText;
-    const parsed = typeof values === 'string' ? JSON.parse(values) : values || {};
-    const result = interpolate(template, parsed);
-
-    res.json({ key, language, result });
-  } catch (e) {
-    res.status(400).json({ error: String(e) });
-  }
-});
-
-// GET /i18n/keys — list all translation keys
-i18nRouter.get('/keys', async (req: Request, res: Response) => {
-  try {
-    const keys = await prisma.translationKey.findMany({
-      include: {
-        translations: true,
-      },
-      orderBy: { createdAt: 'desc' },
-      take: 100,
-    });
-
-    res.json({ data: keys });
-  } catch (e) {
-    res.status(400).json({ error: String(e) });
-  }
-});
-
-// GET /i18n/languages — list supported languages
-i18nRouter.get('/languages', async (req: Request, res: Response) => {
-  try {
-    const languages = await prisma.translation.findMany({
+    // DB-stored distinct languages
+    const dbLanguages = await prisma.translation.findMany({
       distinct: ['language'],
       select: { language: true },
     });
 
     res.json({
-      languages: languages.map(l => l.language),
-      supported: ['en', 'es', 'ko', 'fr', 'de', 'ja', 'zh'],
+      supported: SUPPORTED_LANGUAGES,
+      default: DEFAULT_LANGUAGE,
+      staticDictionaries: ['en', 'es', 'ko'],
+      dbLanguages: dbLanguages.map((l) => l.language),
+      totalStaticKeys: total,
+      coverage,
+    });
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// ── GET /i18n/keys ────────────────────────────────────────────────────────────
+
+/**
+ * @swagger
+ * /i18n/keys:
+ *   get:
+ *     summary: List translation keys (static + DB)
+ *     tags: [i18n]
+ *     parameters:
+ *       - in: query
+ *         name: source
+ *         schema:
+ *           type: string
+ *           enum: [static, db, all]
+ *         description: Filter by key source (default all)
+ */
+i18nRouter.get('/keys', async (req: Request, res: Response) => {
+  try {
+    const source = (req.query['source'] as string) ?? 'all';
+
+    const staticKeys = getAllStaticKeys().map((key) => ({
+      key,
+      defaultText: getStaticDictionary('en')[key],
+      source: 'static' as const,
+    }));
+
+    if (source === 'static') {
+      return res.json({ data: staticKeys, total: staticKeys.length });
+    }
+
+    const dbKeys = await prisma.translationKey.findMany({
+      include: { translations: true },
+      orderBy: { createdAt: 'desc' },
+      take: 200,
+    });
+
+    if (source === 'db') {
+      return res.json({ data: dbKeys, total: dbKeys.length });
+    }
+
+    // Merge: DB keys take precedence over static for the same key name
+    const dbKeyNames = new Set(dbKeys.map((k) => k.key));
+    const staticOnly = staticKeys.filter((k) => !dbKeyNames.has(k.key));
+
+    res.json({
+      data: [...dbKeys, ...staticOnly],
+      total: dbKeys.length + staticOnly.length,
+      dbCount: dbKeys.length,
+      staticCount: staticOnly.length,
+    });
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// ── POST /i18n/keys ───────────────────────────────────────────────────────────
+
+/**
+ * @swagger
+ * /i18n/keys:
+ *   post:
+ *     summary: Register a new translation key
+ *     tags: [i18n]
+ */
+i18nRouter.post('/keys', async (req: Request, res: Response) => {
+  try {
+    const { key, defaultText, context } = z
+      .object({
+        key: z.string().min(1).max(255),
+        defaultText: z.string().min(1),
+        context: z.string().optional(),
+      })
+      .parse(req.body);
+
+    const translationKey = await prismaWrite.translationKey.create({
+      data: { key, defaultText, context },
+    });
+
+    const lang = resolveLanguage(req);
+    res.status(201).json({
+      ...translationKey,
+      message: t('i18n.key_created', lang, { key }),
+    });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('Unique constraint')) {
+      return res.status(409).json({ error: `Key already exists` });
+    }
+    res.status(400).json({ error: msg });
+  }
+});
+
+// ── GET /i18n/translate ───────────────────────────────────────────────────────
+
+/**
+ * @swagger
+ * /i18n/translate:
+ *   get:
+ *     summary: Translate a single key with optional interpolation values
+ *     tags: [i18n]
+ *     parameters:
+ *       - in: query
+ *         name: key
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: language
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: values
+ *         schema:
+ *           type: string
+ *         description: JSON-encoded interpolation values
+ */
+i18nRouter.get('/translate', async (req: Request, res: Response) => {
+  try {
+    const schema = z.object({
+      key: z.string().min(1),
+      language: z.string().min(2).max(10).optional(),
+      values: z.string().optional(), // JSON string
+    });
+
+    const { key, language, values: valuesRaw } = schema.parse(req.query);
+
+    const lang = normaliseLocale(language ?? resolveLanguage(req));
+    const values = valuesRaw ? (JSON.parse(valuesRaw) as Record<string, unknown>) : {};
+
+    const result = await tAsync(key, lang, values);
+
+    res.json({ key, language: lang, result });
+  } catch (e) {
+    res.status(400).json({ error: String(e) });
+  }
+});
+
+// ── POST /i18n/translate/batch ────────────────────────────────────────────────
+
+/**
+ * @swagger
+ * /i18n/translate/batch:
+ *   post:
+ *     summary: Translate multiple keys at once
+ *     tags: [i18n]
+ */
+i18nRouter.post('/translate/batch', async (req: Request, res: Response) => {
+  try {
+    const schema = z.object({
+      language: z.string().min(2).max(10).optional(),
+      keys: z
+        .array(
+          z.object({
+            key: z.string().min(1),
+            values: z.record(z.unknown()).optional(),
+          }),
+        )
+        .min(1)
+        .max(100),
+    });
+
+    const { language, keys } = schema.parse(req.body);
+    const lang = normaliseLocale(language ?? resolveLanguage(req));
+
+    const results = await Promise.all(
+      keys.map(async ({ key, values }) => ({
+        key,
+        result: await tAsync(key, lang, values ?? {}),
+      })),
+    );
+
+    res.json({ language: lang, results });
+  } catch (e) {
+    res.status(400).json({ error: String(e) });
+  }
+});
+
+// ── GET /i18n/matrix ──────────────────────────────────────────────────────────
+
+/**
+ * @swagger
+ * /i18n/matrix:
+ *   get:
+ *     summary: Full translation matrix — all keys × all languages
+ *     tags: [i18n]
+ *     parameters:
+ *       - in: query
+ *         name: keys
+ *         schema:
+ *           type: string
+ *         description: Comma-separated list of keys to include (default all static keys)
+ *       - in: query
+ *         name: domain
+ *         schema:
+ *           type: string
+ *         description: Filter keys by domain prefix, e.g. "transaction"
+ */
+i18nRouter.get('/matrix', async (req: Request, res: Response) => {
+  try {
+    const keysParam = req.query['keys'] as string | undefined;
+    const domain = req.query['domain'] as string | undefined;
+
+    let keys: string[];
+
+    if (keysParam) {
+      keys = keysParam.split(',').map((k) => k.trim()).filter(Boolean);
+    } else {
+      keys = getAllStaticKeys();
+    }
+
+    if (domain) {
+      keys = keys.filter((k) => k.startsWith(`${domain}.`));
+    }
+
+    if (keys.length === 0) {
+      return res.status(400).json({ error: 'No keys matched the filter' });
+    }
+
+    if (keys.length > 500) {
+      return res.status(400).json({ error: 'Too many keys requested (max 500)' });
+    }
+
+    // Build static matrix
+    const matrix = buildStaticMatrix(keys);
+
+    // Overlay DB translations on top of static ones
+    try {
+      const dbTranslations = await prisma.translation.findMany({
+        where: {
+          key: { key: { in: keys } },
+        },
+        include: { key: { select: { key: true } } },
+      });
+
+      for (const row of dbTranslations) {
+        const keyName = row.key.key;
+        if (matrix[keyName]) {
+          matrix[keyName][row.language] = row.translatedText;
+        }
+      }
+    } catch {
+      // DB unavailable — static matrix is still valid
+    }
+
+    res.json({
+      languages: SUPPORTED_LANGUAGES,
+      keyCount: keys.length,
+      matrix,
+    });
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// ── GET /i18n/dictionary/:language ───────────────────────────────────────────
+
+/**
+ * @swagger
+ * /i18n/dictionary/{language}:
+ *   get:
+ *     summary: Return the full static dictionary for a language
+ *     tags: [i18n]
+ */
+i18nRouter.get('/dictionary/:language', (req: Request, res: Response) => {
+  const lang = normaliseLocale(req.params['language']);
+  const dict = getStaticDictionary(lang);
+
+  res.json({
+    language: lang,
+    keyCount: Object.keys(dict).length,
+    dictionary: dict,
+  });
+});
+
+// ── POST /i18n/translations ───────────────────────────────────────────────────
+
+/**
+ * @swagger
+ * /i18n/translations:
+ *   post:
+ *     summary: Add or update a DB translation for a key
+ *     tags: [i18n]
+ */
+i18nRouter.post('/translations', async (req: Request, res: Response) => {
+  try {
+    const { keyId, language, translatedText, approvedBy } = z
+      .object({
+        keyId: z.string().min(1),
+        language: z.string().min(2).max(10),
+        translatedText: z.string().min(1),
+        approvedBy: z.string().optional(),
+      })
+      .parse(req.body);
+
+    const lang = normaliseLocale(language);
+
+    const translation = await prismaWrite.translation.upsert({
+      where: { keyId_language: { keyId, language: lang } },
+      create: {
+        keyId,
+        language: lang,
+        translatedText,
+        approvedBy,
+        approvedAt: approvedBy ? new Date() : null,
+      },
+      update: {
+        translatedText,
+        ...(approvedBy && { approvedBy, approvedAt: new Date() }),
+      },
+    });
+
+    const reqLang = resolveLanguage(req);
+    res.status(201).json({
+      ...translation,
+      message: t('i18n.translation_added', reqLang, { key: keyId, language: lang }),
     });
   } catch (e) {
     res.status(400).json({ error: String(e) });
   }
 });
 
-// PATCH /i18n/translations/:id — approve translation
+// ── PATCH /i18n/translations/:id ──────────────────────────────────────────────
+
+/**
+ * @swagger
+ * /i18n/translations/{id}:
+ *   patch:
+ *     summary: Approve a translation
+ *     tags: [i18n]
+ */
 i18nRouter.patch('/translations/:id', async (req: Request, res: Response) => {
   try {
-    const { approvedBy } = req.body;
-    const translation = await prisma.translation.update({
-      where: { id: req.params.id },
-      data: {
-        approvedBy,
-        approvedAt: new Date(),
-      },
+    const { approvedBy } = z
+      .object({ approvedBy: z.string().min(1) })
+      .parse(req.body);
+
+    const translation = await prismaWrite.translation.update({
+      where: { id: req.params['id'] },
+      data: { approvedBy, approvedAt: new Date() },
     });
 
-    res.json(translation);
+    const lang = resolveLanguage(req);
+    res.json({
+      ...translation,
+      message: t('i18n.translation_approved', lang, { approver: approvedBy }),
+    });
   } catch (e) {
     res.status(400).json({ error: String(e) });
+  }
+});
+
+// ── POST /i18n/seed ───────────────────────────────────────────────────────────
+
+/**
+ * @swagger
+ * /i18n/seed:
+ *   post:
+ *     summary: Bulk-seed static dictionaries into the DB
+ *     description: >
+ *       Upserts all keys from the static English dictionary and their
+ *       translations for all bundled languages (en, es, ko) into the DB.
+ *       Safe to run multiple times (idempotent).
+ *     tags: [i18n]
+ */
+i18nRouter.post('/seed', async (req: Request, res: Response) => {
+  try {
+    const enDict = getStaticDictionary('en');
+    const esDict = getStaticDictionary('es');
+    const koDict = getStaticDictionary('ko');
+
+    let seeded = 0;
+
+    for (const [key, defaultText] of Object.entries(enDict)) {
+      // Upsert the key
+      const tkRecord = await prismaWrite.translationKey.upsert({
+        where: { key },
+        create: { key, defaultText },
+        update: { defaultText },
+      });
+
+      // Upsert translations for es and ko
+      const pairs: Array<{ language: string; text: string }> = [
+        { language: 'es', text: esDict[key] ?? defaultText },
+        { language: 'ko', text: koDict[key] ?? defaultText },
+      ];
+
+      for (const { language, text } of pairs) {
+        await prismaWrite.translation.upsert({
+          where: { keyId_language: { keyId: tkRecord.id, language } },
+          create: { keyId: tkRecord.id, language, translatedText: text },
+          update: { translatedText: text },
+        });
+      }
+
+      seeded++;
+    }
+
+    const lang = resolveLanguage(req);
+    res.json({
+      message: t('i18n.bulk_seeded', lang, { count: seeded }),
+      seeded,
+    });
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
   }
 });

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { i18nRouter } from './i18n';
 import { transactionRouter } from './transactions';
 import { eventRouter } from './events';
 import { contractRouter } from './contracts';
@@ -46,3 +47,4 @@ router.use('/webhooks', webhooksRouter);
 router.use('/analytics', analyticsRouter);
 router.use('/portfolio', portfolioRouter);
 router.use('/exports', exportsRouter);
+router.use('/i18n', i18nRouter);

--- a/src/i18n/engine.ts
+++ b/src/i18n/engine.ts
@@ -1,0 +1,228 @@
+/**
+ * i18n Translation Matrix Engine
+ *
+ * Resolution order for any (key, language) pair:
+ *   1. In-memory static dictionary for the requested language
+ *   2. In-memory static dictionary for the base language (e.g. "en" from "en-US")
+ *   3. English (en) fallback dictionary
+ *   4. DB-stored translation (async path only)
+ *   5. Raw defaultText from DB TranslationKey
+ *   6. The key itself (last resort)
+ *
+ * Sync path (t / tSync): uses only steps 1-3 (static dictionaries).
+ * Async path (tAsync):   uses all 6 steps, hitting the DB when static misses.
+ */
+
+import { en, es, ko } from './locales';
+import { prismaRead } from '../db';
+
+// ── Supported languages ───────────────────────────────────────────────────────
+
+export const SUPPORTED_LANGUAGES = ['en', 'es', 'ko', 'fr', 'de', 'ja', 'zh'] as const;
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+export const DEFAULT_LANGUAGE: SupportedLanguage = 'en';
+
+/** Static dictionaries — only languages with bundled locale files. */
+const STATIC_DICTIONARIES: Partial<Record<SupportedLanguage, Record<string, string>>> = {
+  en,
+  es,
+  ko,
+};
+
+// ── Locale normalisation ──────────────────────────────────────────────────────
+
+/**
+ * Normalise a raw locale tag to a supported language code.
+ * "en-US" → "en", "es-419" → "es", "ko-KR" → "ko", "fr" → "fr"
+ * Falls back to DEFAULT_LANGUAGE if the tag is unrecognised.
+ */
+export function normaliseLocale(raw: string | undefined | null): SupportedLanguage {
+  if (!raw) return DEFAULT_LANGUAGE;
+
+  const cleaned = raw.trim().toLowerCase();
+
+  // Exact match first
+  if (SUPPORTED_LANGUAGES.includes(cleaned as SupportedLanguage)) {
+    return cleaned as SupportedLanguage;
+  }
+
+  // Base language from BCP-47 tag (e.g. "en-US" → "en")
+  const base = cleaned.split(/[-_]/)[0];
+  if (SUPPORTED_LANGUAGES.includes(base as SupportedLanguage)) {
+    return base as SupportedLanguage;
+  }
+
+  return DEFAULT_LANGUAGE;
+}
+
+/**
+ * Parse the value of an Accept-Language header and return the best
+ * supported language, respecting q-values.
+ * "es-419;q=0.9,en;q=0.8" → "es"
+ */
+export function parseAcceptLanguage(header: string | undefined | null): SupportedLanguage {
+  if (!header) return DEFAULT_LANGUAGE;
+
+  const candidates = header
+    .split(',')
+    .map((part) => {
+      const [tag, q] = part.trim().split(';q=');
+      return { tag: tag.trim(), q: q ? parseFloat(q) : 1.0 };
+    })
+    .sort((a, b) => b.q - a.q);
+
+  for (const { tag } of candidates) {
+    const lang = normaliseLocale(tag);
+    if (lang !== DEFAULT_LANGUAGE || tag.toLowerCase().startsWith('en')) {
+      return lang;
+    }
+  }
+
+  return DEFAULT_LANGUAGE;
+}
+
+// ── Interpolation ─────────────────────────────────────────────────────────────
+
+/**
+ * Replace {placeholder} tokens in a template string with values from the map.
+ * Unknown placeholders are left as-is.
+ */
+export function interpolate(
+  template: string,
+  values: Record<string, unknown> = {},
+): string {
+  return template.replace(/\{(\w+)\}/g, (match, key: string) => {
+    const val = values[key];
+    return val !== undefined && val !== null ? String(val) : match;
+  });
+}
+
+// ── Static (sync) translation ─────────────────────────────────────────────────
+
+/**
+ * Synchronous translation using only static dictionaries.
+ * Safe to call anywhere — no DB access.
+ *
+ * @param key      Dot-notation key, e.g. "transaction.swap_description"
+ * @param language Resolved language code
+ * @param values   Interpolation values
+ * @returns        Translated + interpolated string, or the key itself on miss
+ */
+export function t(
+  key: string,
+  language: SupportedLanguage = DEFAULT_LANGUAGE,
+  values: Record<string, unknown> = {},
+): string {
+  const dict = STATIC_DICTIONARIES[language];
+  const enDict = STATIC_DICTIONARIES['en']!;
+
+  const template =
+    dict?.[key] ??           // requested language
+    enDict[key] ??           // English fallback
+    key;                     // last resort: return the key
+
+  return interpolate(template, values);
+}
+
+/** Alias for t() — explicit sync variant. */
+export const tSync = t;
+
+// ── Async translation (static + DB) ──────────────────────────────────────────
+
+/**
+ * Async translation: tries static dictionaries first, then falls back to the
+ * database (TranslationKey / Translation models).
+ *
+ * @param key      Dot-notation key
+ * @param language Resolved language code
+ * @param values   Interpolation values
+ * @returns        Translated + interpolated string
+ */
+export async function tAsync(
+  key: string,
+  language: SupportedLanguage = DEFAULT_LANGUAGE,
+  values: Record<string, unknown> = {},
+): Promise<string> {
+  // 1-3: static dictionaries
+  const dict = STATIC_DICTIONARIES[language];
+  const enDict = STATIC_DICTIONARIES['en']!;
+
+  if (dict?.[key]) return interpolate(dict[key], values);
+  if (enDict[key]) return interpolate(enDict[key], values);
+
+  // 4-5: DB lookup
+  try {
+    const translationKey = await prismaRead.translationKey.findUnique({
+      where: { key },
+      include: {
+        translations: {
+          where: { language },
+          take: 1,
+        },
+      },
+    });
+
+    if (translationKey) {
+      const template =
+        translationKey.translations[0]?.translatedText ??
+        translationKey.defaultText;
+      return interpolate(template, values);
+    }
+  } catch {
+    // DB unavailable — fall through to key
+  }
+
+  // 6: key itself
+  return key;
+}
+
+// ── Translation matrix ────────────────────────────────────────────────────────
+
+/**
+ * Build a full translation matrix for a set of keys across all supported
+ * languages. Used by the /i18n/matrix endpoint.
+ *
+ * Returns:
+ * {
+ *   "transaction.swap_description": {
+ *     "en": "Address {from} swapped ...",
+ *     "es": "La dirección {from} intercambió ...",
+ *     "ko": "주소 {from}이(가) ... 스왑했습니다",
+ *     ...
+ *   },
+ *   ...
+ * }
+ */
+export function buildStaticMatrix(
+  keys: string[],
+): Record<string, Record<string, string>> {
+  const matrix: Record<string, Record<string, string>> = {};
+
+  for (const key of keys) {
+    matrix[key] = {};
+    for (const lang of SUPPORTED_LANGUAGES) {
+      const dict = STATIC_DICTIONARIES[lang as SupportedLanguage];
+      const enDict = STATIC_DICTIONARIES['en']!;
+      matrix[key][lang] = dict?.[key] ?? enDict[key] ?? key;
+    }
+  }
+
+  return matrix;
+}
+
+/**
+ * Return all keys defined in the English (master) static dictionary.
+ */
+export function getAllStaticKeys(): string[] {
+  return Object.keys(STATIC_DICTIONARIES['en']!);
+}
+
+/**
+ * Return the static dictionary for a given language (read-only).
+ */
+export function getStaticDictionary(
+  language: SupportedLanguage,
+): Record<string, string> {
+  return { ...(STATIC_DICTIONARIES[language] ?? STATIC_DICTIONARIES['en']!) };
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,2 @@
+export * from './engine';
+export { i18nMiddleware } from './middleware';

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1,0 +1,91 @@
+/**
+ * English (en) — default / fallback locale.
+ * Keys follow dot-notation: <domain>.<key>
+ * Placeholders use {name} syntax.
+ */
+export const en: Record<string, string> = {
+  // ── General ──────────────────────────────────────────────────────────────
+  'general.not_found':            'Resource not found',
+  'general.bad_request':          'Bad request: {reason}',
+  'general.internal_error':       'Internal server error',
+  'general.unauthorized':         'Unauthorized',
+  'general.forbidden':            'Forbidden',
+  'general.ok':                   'OK',
+
+  // ── Transactions ─────────────────────────────────────────────────────────
+  'transaction.not_found':        'Transaction not found',
+  'transaction.swap_description': 'Address {from} swapped {amountIn} {assetIn} → {amountOut} {assetOut}',
+  'transaction.transfer_description': 'Address {from} transferred {amount} {asset} to {to}',
+  'transaction.mint_description': 'Address {minter} minted {amount} {asset}',
+  'transaction.burn_description': 'Address {burner} burned {amount} {asset}',
+  'transaction.invoke_description': 'Address {caller} invoked {function} on contract {contract}',
+  'transaction.status_success':   'Success',
+  'transaction.status_failed':    'Failed',
+  'transaction.failure_reason':   'Transaction failed: {reason}',
+  'transaction.fee_charged':      'Fee charged: {fee} stroops',
+
+  // ── Contracts ────────────────────────────────────────────────────────────
+  'contract.not_found':           'Contract not found',
+  'contract.verified':            'Contract {address} is verified',
+  'contract.unverified':          'Contract {address} is not verified',
+  'contract.deployed':            'Contract deployed at {address} in ledger {ledger}',
+  'contract.upgraded':            'Contract {address} upgraded from {oldHash} to {newHash}',
+
+  // ── Tokens ───────────────────────────────────────────────────────────────
+  'token.not_found':              'Token not found',
+  'token.transfer':               '{amount} {symbol} transferred from {from} to {to}',
+  'token.mint':                   '{amount} {symbol} minted to {to}',
+  'token.burn':                   '{amount} {symbol} burned from {from}',
+  'token.approval':               '{owner} approved {spender} to spend {amount} {symbol}',
+
+  // ── Wallets ──────────────────────────────────────────────────────────────
+  'wallet.not_found':             'Wallet not found',
+  'wallet.balance':               'Balance: {amount} {asset}',
+  'wallet.transaction_count':     '{count} transactions found',
+
+  // ── Events ───────────────────────────────────────────────────────────────
+  'event.not_found':              'Event not found',
+  'event.type_transfer':          'Transfer event on contract {contract}',
+  'event.type_swap':              'Swap event on contract {contract}',
+  'event.type_mint':              'Mint event on contract {contract}',
+  'event.type_burn':              'Burn event on contract {contract}',
+  'event.type_custom':            'Custom event "{symbol}" on contract {contract}',
+
+  // ── DEX ──────────────────────────────────────────────────────────────────
+  'dex.swap_route':               'Swap {amountIn} {assetIn} → {amountOut} {assetOut} via {pool}',
+  'dex.liquidity_added':          '{provider} added {amountA} {assetA} + {amountB} {assetB} to pool {pool}',
+  'dex.liquidity_removed':        '{provider} removed liquidity from pool {pool}',
+  'dex.pool_not_found':           'Liquidity pool not found',
+
+  // ── NFT ──────────────────────────────────────────────────────────────────
+  'nft.minted':                   'NFT #{tokenId} minted to {owner} on contract {contract}',
+  'nft.transferred':              'NFT #{tokenId} transferred from {from} to {to}',
+  'nft.burned':                   'NFT #{tokenId} burned by {owner}',
+  'nft.not_found':                'NFT not found',
+
+  // ── Compliance ───────────────────────────────────────────────────────────
+  'compliance.sanctioned_sender':   'Sender {address} is on the {list} sanctions list',
+  'compliance.sanctioned_receiver': 'Receiver {address} is on the {list} sanctions list',
+  'compliance.clean':               'No compliance flags found',
+  'compliance.flagged':             '{count} compliance flag(s) detected',
+
+  // ── Analytics ────────────────────────────────────────────────────────────
+  'analytics.gas_avg':            'Average gas fee: {avg} stroops',
+  'analytics.gas_peak':           'Peak gas fee: {peak} stroops',
+  'analytics.volume_spike':       'Volume spike detected on {contract}: {count} transactions (z-score: {zScore})',
+  'analytics.no_data':            'No analytics data available for the requested period',
+
+  // ── Alerts ───────────────────────────────────────────────────────────────
+  'alert.reentrancy':             'Re-entrancy attack detected on contract {contract} (severity: {severity})',
+  'alert.flash_loan':             'Flash loan attack detected in transaction {hash}',
+  'alert.volume_spike':           'Unusual volume spike on {contract}',
+  'alert.low_balance':            'Treasury wallet {address} balance below threshold',
+
+  // ── i18n system ──────────────────────────────────────────────────────────
+  'i18n.key_created':             'Translation key "{key}" created',
+  'i18n.translation_added':       'Translation for "{key}" in {language} added',
+  'i18n.translation_approved':    'Translation approved by {approver}',
+  'i18n.key_not_found':           'Translation key "{key}" not found',
+  'i18n.language_not_supported':  'Language "{language}" is not supported. Supported: {supported}',
+  'i18n.bulk_seeded':             '{count} translation keys seeded successfully',
+};

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1,0 +1,90 @@
+/**
+ * Spanish (es) translation dictionary.
+ * Placeholders use {name} syntax — must match the English keys exactly.
+ */
+export const es: Record<string, string> = {
+  // ── General ──────────────────────────────────────────────────────────────
+  'general.not_found':            'Recurso no encontrado',
+  'general.bad_request':          'Solicitud incorrecta: {reason}',
+  'general.internal_error':       'Error interno del servidor',
+  'general.unauthorized':         'No autorizado',
+  'general.forbidden':            'Prohibido',
+  'general.ok':                   'OK',
+
+  // ── Transactions ─────────────────────────────────────────────────────────
+  'transaction.not_found':        'Transacción no encontrada',
+  'transaction.swap_description': 'La dirección {from} intercambió {amountIn} {assetIn} → {amountOut} {assetOut}',
+  'transaction.transfer_description': 'La dirección {from} transfirió {amount} {asset} a {to}',
+  'transaction.mint_description': 'La dirección {minter} acuñó {amount} {asset}',
+  'transaction.burn_description': 'La dirección {burner} quemó {amount} {asset}',
+  'transaction.invoke_description': 'La dirección {caller} invocó {function} en el contrato {contract}',
+  'transaction.status_success':   'Exitoso',
+  'transaction.status_failed':    'Fallido',
+  'transaction.failure_reason':   'La transacción falló: {reason}',
+  'transaction.fee_charged':      'Comisión cobrada: {fee} stroops',
+
+  // ── Contracts ────────────────────────────────────────────────────────────
+  'contract.not_found':           'Contrato no encontrado',
+  'contract.verified':            'El contrato {address} está verificado',
+  'contract.unverified':          'El contrato {address} no está verificado',
+  'contract.deployed':            'Contrato desplegado en {address} en el ledger {ledger}',
+  'contract.upgraded':            'Contrato {address} actualizado de {oldHash} a {newHash}',
+
+  // ── Tokens ───────────────────────────────────────────────────────────────
+  'token.not_found':              'Token no encontrado',
+  'token.transfer':               '{amount} {symbol} transferido de {from} a {to}',
+  'token.mint':                   '{amount} {symbol} acuñado para {to}',
+  'token.burn':                   '{amount} {symbol} quemado de {from}',
+  'token.approval':               '{owner} autorizó a {spender} a gastar {amount} {symbol}',
+
+  // ── Wallets ──────────────────────────────────────────────────────────────
+  'wallet.not_found':             'Billetera no encontrada',
+  'wallet.balance':               'Saldo: {amount} {asset}',
+  'wallet.transaction_count':     '{count} transacciones encontradas',
+
+  // ── Events ───────────────────────────────────────────────────────────────
+  'event.not_found':              'Evento no encontrado',
+  'event.type_transfer':          'Evento de transferencia en el contrato {contract}',
+  'event.type_swap':              'Evento de intercambio en el contrato {contract}',
+  'event.type_mint':              'Evento de acuñación en el contrato {contract}',
+  'event.type_burn':              'Evento de quema en el contrato {contract}',
+  'event.type_custom':            'Evento personalizado "{symbol}" en el contrato {contract}',
+
+  // ── DEX ──────────────────────────────────────────────────────────────────
+  'dex.swap_route':               'Intercambio de {amountIn} {assetIn} → {amountOut} {assetOut} vía {pool}',
+  'dex.liquidity_added':          '{provider} añadió {amountA} {assetA} + {amountB} {assetB} al pool {pool}',
+  'dex.liquidity_removed':        '{provider} retiró liquidez del pool {pool}',
+  'dex.pool_not_found':           'Pool de liquidez no encontrado',
+
+  // ── NFT ──────────────────────────────────────────────────────────────────
+  'nft.minted':                   'NFT #{tokenId} acuñado para {owner} en el contrato {contract}',
+  'nft.transferred':              'NFT #{tokenId} transferido de {from} a {to}',
+  'nft.burned':                   'NFT #{tokenId} quemado por {owner}',
+  'nft.not_found':                'NFT no encontrado',
+
+  // ── Compliance ───────────────────────────────────────────────────────────
+  'compliance.sanctioned_sender':   'El remitente {address} está en la lista de sanciones {list}',
+  'compliance.sanctioned_receiver': 'El destinatario {address} está en la lista de sanciones {list}',
+  'compliance.clean':               'No se encontraron indicadores de cumplimiento',
+  'compliance.flagged':             '{count} indicador(es) de cumplimiento detectado(s)',
+
+  // ── Analytics ────────────────────────────────────────────────────────────
+  'analytics.gas_avg':            'Comisión de gas promedio: {avg} stroops',
+  'analytics.gas_peak':           'Comisión de gas máxima: {peak} stroops',
+  'analytics.volume_spike':       'Pico de volumen detectado en {contract}: {count} transacciones (z-score: {zScore})',
+  'analytics.no_data':            'No hay datos de análisis disponibles para el período solicitado',
+
+  // ── Alerts ───────────────────────────────────────────────────────────────
+  'alert.reentrancy':             'Ataque de reentrada detectado en el contrato {contract} (gravedad: {severity})',
+  'alert.flash_loan':             'Ataque de préstamo flash detectado en la transacción {hash}',
+  'alert.volume_spike':           'Pico de volumen inusual en {contract}',
+  'alert.low_balance':            'El saldo de la billetera de tesorería {address} está por debajo del umbral',
+
+  // ── i18n system ──────────────────────────────────────────────────────────
+  'i18n.key_created':             'Clave de traducción "{key}" creada',
+  'i18n.translation_added':       'Traducción para "{key}" en {language} añadida',
+  'i18n.translation_approved':    'Traducción aprobada por {approver}',
+  'i18n.key_not_found':           'Clave de traducción "{key}" no encontrada',
+  'i18n.language_not_supported':  'El idioma "{language}" no está soportado. Soportados: {supported}',
+  'i18n.bulk_seeded':             '{count} claves de traducción sembradas exitosamente',
+};

--- a/src/i18n/locales/index.ts
+++ b/src/i18n/locales/index.ts
@@ -1,0 +1,3 @@
+export { en } from './en';
+export { es } from './es';
+export { ko } from './ko';

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -1,0 +1,90 @@
+/**
+ * Korean (ko) translation dictionary.
+ * Placeholders use {name} syntax — must match the English keys exactly.
+ */
+export const ko: Record<string, string> = {
+  // ── General ──────────────────────────────────────────────────────────────
+  'general.not_found':            '리소스를 찾을 수 없습니다',
+  'general.bad_request':          '잘못된 요청: {reason}',
+  'general.internal_error':       '내부 서버 오류',
+  'general.unauthorized':         '인증되지 않음',
+  'general.forbidden':            '접근 금지',
+  'general.ok':                   '확인',
+
+  // ── Transactions ─────────────────────────────────────────────────────────
+  'transaction.not_found':        '트랜잭션을 찾을 수 없습니다',
+  'transaction.swap_description': '주소 {from}이(가) {amountIn} {assetIn} → {amountOut} {assetOut}을(를) 스왑했습니다',
+  'transaction.transfer_description': '주소 {from}이(가) {to}에게 {amount} {asset}을(를) 전송했습니다',
+  'transaction.mint_description': '주소 {minter}이(가) {amount} {asset}을(를) 발행했습니다',
+  'transaction.burn_description': '주소 {burner}이(가) {amount} {asset}을(를) 소각했습니다',
+  'transaction.invoke_description': '주소 {caller}이(가) 컨트랙트 {contract}에서 {function}을(를) 호출했습니다',
+  'transaction.status_success':   '성공',
+  'transaction.status_failed':    '실패',
+  'transaction.failure_reason':   '트랜잭션 실패: {reason}',
+  'transaction.fee_charged':      '수수료 청구: {fee} stroops',
+
+  // ── Contracts ────────────────────────────────────────────────────────────
+  'contract.not_found':           '컨트랙트를 찾을 수 없습니다',
+  'contract.verified':            '컨트랙트 {address}이(가) 검증되었습니다',
+  'contract.unverified':          '컨트랙트 {address}이(가) 검증되지 않았습니다',
+  'contract.deployed':            '컨트랙트가 레저 {ledger}의 {address}에 배포되었습니다',
+  'contract.upgraded':            '컨트랙트 {address}이(가) {oldHash}에서 {newHash}로 업그레이드되었습니다',
+
+  // ── Tokens ───────────────────────────────────────────────────────────────
+  'token.not_found':              '토큰을 찾을 수 없습니다',
+  'token.transfer':               '{from}에서 {to}로 {amount} {symbol} 전송됨',
+  'token.mint':                   '{to}에게 {amount} {symbol} 발행됨',
+  'token.burn':                   '{from}에서 {amount} {symbol} 소각됨',
+  'token.approval':               '{owner}이(가) {spender}에게 {amount} {symbol} 사용 승인',
+
+  // ── Wallets ──────────────────────────────────────────────────────────────
+  'wallet.not_found':             '지갑을 찾을 수 없습니다',
+  'wallet.balance':               '잔액: {amount} {asset}',
+  'wallet.transaction_count':     '{count}개의 트랜잭션 발견',
+
+  // ── Events ───────────────────────────────────────────────────────────────
+  'event.not_found':              '이벤트를 찾을 수 없습니다',
+  'event.type_transfer':          '컨트랙트 {contract}의 전송 이벤트',
+  'event.type_swap':              '컨트랙트 {contract}의 스왑 이벤트',
+  'event.type_mint':              '컨트랙트 {contract}의 발행 이벤트',
+  'event.type_burn':              '컨트랙트 {contract}의 소각 이벤트',
+  'event.type_custom':            '컨트랙트 {contract}의 커스텀 이벤트 "{symbol}"',
+
+  // ── DEX ──────────────────────────────────────────────────────────────────
+  'dex.swap_route':               '{pool}을(를) 통해 {amountIn} {assetIn} → {amountOut} {assetOut} 스왑',
+  'dex.liquidity_added':          '{provider}이(가) 풀 {pool}에 {amountA} {assetA} + {amountB} {assetB} 추가',
+  'dex.liquidity_removed':        '{provider}이(가) 풀 {pool}에서 유동성 제거',
+  'dex.pool_not_found':           '유동성 풀을 찾을 수 없습니다',
+
+  // ── NFT ──────────────────────────────────────────────────────────────────
+  'nft.minted':                   'NFT #{tokenId}이(가) 컨트랙트 {contract}에서 {owner}에게 발행됨',
+  'nft.transferred':              'NFT #{tokenId}이(가) {from}에서 {to}로 전송됨',
+  'nft.burned':                   'NFT #{tokenId}이(가) {owner}에 의해 소각됨',
+  'nft.not_found':                'NFT를 찾을 수 없습니다',
+
+  // ── Compliance ───────────────────────────────────────────────────────────
+  'compliance.sanctioned_sender':   '발신자 {address}이(가) {list} 제재 목록에 있습니다',
+  'compliance.sanctioned_receiver': '수신자 {address}이(가) {list} 제재 목록에 있습니다',
+  'compliance.clean':               '컴플라이언스 플래그가 없습니다',
+  'compliance.flagged':             '{count}개의 컴플라이언스 플래그 감지됨',
+
+  // ── Analytics ────────────────────────────────────────────────────────────
+  'analytics.gas_avg':            '평균 가스 수수료: {avg} stroops',
+  'analytics.gas_peak':           '최대 가스 수수료: {peak} stroops',
+  'analytics.volume_spike':       '{contract}에서 거래량 급증 감지: {count}건 (z-점수: {zScore})',
+  'analytics.no_data':            '요청한 기간에 대한 분석 데이터가 없습니다',
+
+  // ── Alerts ───────────────────────────────────────────────────────────────
+  'alert.reentrancy':             '컨트랙트 {contract}에서 재진입 공격 감지됨 (심각도: {severity})',
+  'alert.flash_loan':             '트랜잭션 {hash}에서 플래시 론 공격 감지됨',
+  'alert.volume_spike':           '{contract}에서 비정상적인 거래량 급증',
+  'alert.low_balance':            '재무 지갑 {address}의 잔액이 임계값 미만입니다',
+
+  // ── i18n system ──────────────────────────────────────────────────────────
+  'i18n.key_created':             '번역 키 "{key}" 생성됨',
+  'i18n.translation_added':       '{language}의 "{key}" 번역이 추가됨',
+  'i18n.translation_approved':    '{approver}에 의해 번역 승인됨',
+  'i18n.key_not_found':           '번역 키 "{key}"를 찾을 수 없습니다',
+  'i18n.language_not_supported':  '"{language}" 언어는 지원되지 않습니다. 지원 언어: {supported}',
+  'i18n.bulk_seeded':             '{count}개의 번역 키가 성공적으로 시드됨',
+};

--- a/src/i18n/middleware.ts
+++ b/src/i18n/middleware.ts
@@ -1,0 +1,67 @@
+/**
+ * i18n locale-detection middleware.
+ *
+ * Reads the user's preferred language from (in priority order):
+ *   1. X-Language header          — explicit override, e.g. "ko"
+ *   2. lang query parameter        — e.g. ?lang=es
+ *   3. Accept-Language header      — standard browser/client negotiation
+ *
+ * Attaches to req:
+ *   req.locale   — resolved SupportedLanguage code, e.g. "es"
+ *   req.t        — bound sync translator: req.t('key', { values })
+ *   req.tAsync   — bound async translator: await req.tAsync('key', { values })
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import {
+  SupportedLanguage,
+  DEFAULT_LANGUAGE,
+  normaliseLocale,
+  parseAcceptLanguage,
+  t as translate,
+  tAsync as translateAsync,
+} from './engine';
+
+// Extend Express Request type
+declare global {
+  namespace Express {
+    interface Request {
+      locale: SupportedLanguage;
+      t: (key: string, values?: Record<string, unknown>) => string;
+      tAsync: (key: string, values?: Record<string, unknown>) => Promise<string>;
+    }
+  }
+}
+
+/**
+ * Express middleware — resolves locale and attaches translation helpers.
+ */
+export function i18nMiddleware(req: Request, _res: Response, next: NextFunction): void {
+  // 1. Explicit header override
+  const xLang = req.headers['x-language'] as string | undefined;
+  // 2. Query param
+  const qLang = req.query['lang'] as string | undefined;
+  // 3. Accept-Language
+  const acceptLang = req.headers['accept-language'] as string | undefined;
+
+  let locale: SupportedLanguage = DEFAULT_LANGUAGE;
+
+  if (xLang) {
+    locale = normaliseLocale(xLang);
+  } else if (qLang) {
+    locale = normaliseLocale(qLang);
+  } else if (acceptLang) {
+    locale = parseAcceptLanguage(acceptLang);
+  }
+
+  req.locale = locale;
+
+  // Bind helpers so handlers can call req.t('key', { amount: 100 })
+  req.t = (key: string, values?: Record<string, unknown>) =>
+    translate(key, locale, values ?? {});
+
+  req.tAsync = (key: string, values?: Record<string, unknown>) =>
+    translateAsync(key, locale, values ?? {});
+
+  next();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { startIndexerService } from './indexer/indexer';
 import { tieredRateLimit } from './middleware/rateLimit';
 import { metricsMiddleware } from './middleware/metricsMiddleware';
 import { sanitizeInputs } from './middleware/sanitize';
+import { i18nMiddleware } from './i18n';
 import { registry, dbConnectionStatus } from './metrics';
 import { replicaGuard } from './middleware/replicaGuard';
 import { coldStorageRouter } from './middleware/coldStorageRouter';
@@ -31,6 +32,7 @@ app.use(express.json());
 app.use(tieredRateLimit);
 app.use(metricsMiddleware);
 app.use(sanitizeInputs);
+app.use(i18nMiddleware);
 app.use(replicaGuard);
 
 // #134: Cold storage routing for deep history queries


### PR DESCRIPTION
## Summary

Closes #191

### What this PR does

- Adds static translation dictionaries for **English**, **Spanish**, and **Korean** (src/i18n/locales/)
- Builds a full i18n engine (src/i18n/engine.ts) with sync (	) and async (	Async) translation helpers, locale normalisation, Accept-Language parsing, and {placeholder} interpolation
- Adds locale-detection middleware (src/i18n/middleware.ts) that reads X-Language header > ?lang= query param > Accept-Language header and attaches eq.locale, eq.t(), eq.tAsync() to every request
- Rewrites src/api/i18n.ts with 10 endpoints (see below)
- Mounts i18nRouter at /api/v1/i18n (was missing from router.ts)
- Applies i18nMiddleware globally in index.ts`n
### New endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | /api/v1/i18n/languages | Supported languages + per-language coverage % |
| GET | /api/v1/i18n/keys | List keys from static, DB, or both |
| POST | /api/v1/i18n/keys | Register a new translation key |
| GET | /api/v1/i18n/translate | Translate one key with interpolation |
| POST | /api/v1/i18n/translate/batch | Translate up to 100 keys at once |
| GET | /api/v1/i18n/matrix | Full key x language translation matrix |
| GET | /api/v1/i18n/dictionary/:lang | Full static dictionary for a language |
| POST | /api/v1/i18n/translations | Add/update a DB translation (upsert) |
| PATCH | /api/v1/i18n/translations/:id | Approve a translation |
| POST | /api/v1/i18n/seed | Bulk-seed static dicts into DB (idempotent) |

### Technical approach

- **Separate translation dictionaries** per language - no mixing of locales
- **Resolution chain**: static dict (requested lang) ? static dict (en fallback) ? DB translation ? DB defaultText ? key itself
- **Zero DB cost** for the common path - eq.t() is fully synchronous
- **No new dependencies** - pure TypeScript, uses existing Prisma models
- **Idempotent seed** - safe to run multiple times via POST /i18n/seed`n
### Files changed

- src/i18n/locales/en.ts (new)
- src/i18n/locales/es.ts (new)
- src/i18n/locales/ko.ts (new)
- src/i18n/locales/index.ts (new)
- src/i18n/engine.ts (new)
- src/i18n/middleware.ts (new)
- src/i18n/index.ts (new)
- src/api/i18n.ts (rewritten)
- src/api/router.ts (mount i18nRouter)
- src/index.ts (apply i18nMiddleware)