### PR TITLE
feat(#192): add micro-block time sync polling handler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ INDEXER_BATCH_SIZE=100
 # Number of parallel workers during historical catch-up (1 = sequential)
 INDEXER_CATCHUP_WORKERS=4
 
+# Micro-block sync — matches Stellar's ~2.5 s block close times (#192)
+MICRO_BLOCK_SYNC_ENABLED=true
+MICRO_BLOCK_POLL_INTERVAL_MS=2500
+
 # Rate limiting
 RATE_LIMIT_WINDOW_MS=60000
 RATE_LIMIT_MAX=100

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,10 @@ export const config = {
   indexerBatchSize:      parseInt(process.env.INDEXER_BATCH_SIZE       ?? '100'),
   indexerCatchupWorkers: Math.max(1, parseInt(process.env.INDEXER_CATCHUP_WORKERS ?? '4')),
 
+  // ── Micro-block sync (2.5 s block close times) ────────────────────────────
+  microBlockSyncEnabled:    (process.env.MICRO_BLOCK_SYNC_ENABLED ?? 'true') !== 'false',
+  microBlockPollIntervalMs: parseInt(process.env.MICRO_BLOCK_POLL_INTERVAL_MS ?? '2500'),
+
   // ── Rate limiting ─────────────────────────────────────────────────────────
   rateLimitWindowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS ?? '60000'),
   rateLimitMax:      parseInt(process.env.RATE_LIMIT_MAX        ?? '100'),

--- a/src/indexer/microBlockPoller.ts
+++ b/src/indexer/microBlockPoller.ts
@@ -1,0 +1,80 @@
+/**
+ * Micro-Block Time Sync Polling Handler (#192)
+ *
+ * Polls the RPC node every MICRO_BLOCK_POLL_INTERVAL_MS (default 2500 ms) to
+ * match Stellar's ~2.5-second block close times. On each new ledger it fetches
+ * events and broadcasts them to all connected SSE and WebSocket clients with
+ * minimal overhead.
+ */
+
+import { config } from '../config';
+import { getLatestLedger, fetchEvents } from './rpc';
+import { broadcastSSEEvent } from '../api/sse';
+import { broadcastEvent } from '../ws/eventBroadcaster';
+
+let lastBroadcastLedger = 0;
+let pollTimer: ReturnType<typeof setTimeout> | null = null;
+let running = false;
+
+async function poll(): Promise<void> {
+  try {
+    const latest = await getLatestLedger();
+    if (latest <= lastBroadcastLedger) return;
+
+    const from = lastBroadcastLedger > 0 ? lastBroadcastLedger + 1 : latest;
+    const events = await fetchEvents(from, latest);
+
+    for (const ev of events) {
+      const payload = {
+        id: `${ev.transactionHash}-${ev.topics[0] ?? '0'}`,
+        contractAddress: ev.contractId,
+        eventType: 'raw',
+        decoded: { topics: ev.topics, data: ev.data },
+        ledger: ev.ledgerSequence,
+        ledgerCloseTime: ev.ledgerCloseTime,
+        transactionHash: ev.transactionHash,
+      };
+      broadcastSSEEvent(payload);
+      broadcastEvent(payload);
+    }
+
+    lastBroadcastLedger = latest;
+  } catch (err) {
+    // Non-fatal: log and continue polling
+    console.error('[microBlockPoller] poll error:', (err as Error).message ?? err);
+  }
+}
+
+function schedule(): void {
+  if (!running) return;
+  pollTimer = setTimeout(async () => {
+    await poll();
+    schedule();
+  }, config.microBlockPollIntervalMs);
+}
+
+/**
+ * Start the micro-block polling loop.
+ * Safe to call multiple times — subsequent calls are no-ops.
+ */
+export function startMicroBlockPoller(): void {
+  if (!config.microBlockSyncEnabled) {
+    console.log('[microBlockPoller] disabled (MICRO_BLOCK_SYNC_ENABLED=false)');
+    return;
+  }
+  if (running) return;
+  running = true;
+  console.log(`[microBlockPoller] started (interval=${config.microBlockPollIntervalMs}ms)`);
+  schedule();
+}
+
+/**
+ * Stop the polling loop (useful for graceful shutdown / tests).
+ */
+export function stopMicroBlockPoller(): void {
+  running = false;
+  if (pollTimer !== null) {
+    clearTimeout(pollTimer);
+    pollTimer = null;
+  }
+}

--- a/src/indexer/run.ts
+++ b/src/indexer/run.ts
@@ -5,6 +5,7 @@ import { scheduleReconciliation } from './reconciliation';
 import { startProtocolMonitor } from './protocol-guard';
 import { schedulePruner } from './dataPruner';
 import { initWhaleWatcher } from './whaleWatcher';
+import { startMicroBlockPoller } from './microBlockPoller';
 
 async function main() {
   await prisma.$connect();
@@ -20,6 +21,9 @@ async function main() {
 
   // #136: Initialize whale transaction watcher
   initWhaleWatcher();
+
+  // #192: Start micro-block polling for 2.5 s block close time notifications
+  startMicroBlockPoller();
 
   await runIndexer();
 }


### PR DESCRIPTION
- Poll RPC every 2500ms to match Stellar's ~2.5s block close times
- Broadcast new ledger events to SSE and WebSocket clients on each tick
- Add MICRO_BLOCK_SYNC_ENABLED / MICRO_BLOCK_POLL_INTERVAL_MS config
- Expose stopMicroBlockPoller() for graceful shutdown and tests
- No-op when disabled; non-fatal poll errors are logged and skipped
close #192 