### PR TITLE
feat: DTCC Settlement ID Bridge and Commodity Dual-Signer Verification Logging

### DIFF
--- a/prisma/migrations/20260531000001_dtcc_settlement_commodity_dual_signer/migration.sql
+++ b/prisma/migrations/20260531000001_dtcc_settlement_commodity_dual_signer/migration.sql
@@ -1,0 +1,66 @@
+-- #218: DTCC Tokenized Securities Settlement ID Bridge
+CREATE TABLE "DtccSettlementBridge" (
+    "id"                 TEXT NOT NULL,
+    "transactionHash"    TEXT NOT NULL,
+    "dtccSettlementId"   TEXT NOT NULL,
+    "securityId"         TEXT NOT NULL,
+    "securityType"       TEXT NOT NULL,
+    "sellerAddress"      TEXT NOT NULL,
+    "buyerAddress"       TEXT NOT NULL,
+    "quantity"           TEXT NOT NULL,
+    "settlementAmount"   TEXT NOT NULL,
+    "currency"           TEXT NOT NULL DEFAULT 'USD',
+    "settlementStatus"   TEXT NOT NULL DEFAULT 'pending',
+    "settlementDate"     TIMESTAMP(3),
+    "contractAddress"    TEXT,
+    "ledgerSequence"     INTEGER NOT NULL,
+    "ledgerCloseTime"    TIMESTAMP(3) NOT NULL,
+    "createdAt"          TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"          TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DtccSettlementBridge_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "DtccSettlementBridge_transactionHash_key" ON "DtccSettlementBridge"("transactionHash");
+CREATE INDEX "DtccSettlementBridge_dtccSettlementId_idx" ON "DtccSettlementBridge"("dtccSettlementId");
+CREATE INDEX "DtccSettlementBridge_securityId_idx" ON "DtccSettlementBridge"("securityId");
+CREATE INDEX "DtccSettlementBridge_sellerAddress_idx" ON "DtccSettlementBridge"("sellerAddress");
+CREATE INDEX "DtccSettlementBridge_buyerAddress_idx" ON "DtccSettlementBridge"("buyerAddress");
+CREATE INDEX "DtccSettlementBridge_settlementStatus_idx" ON "DtccSettlementBridge"("settlementStatus");
+CREATE INDEX "DtccSettlementBridge_ledgerSequence_idx" ON "DtccSettlementBridge"("ledgerSequence");
+
+-- #219: Commodity Compliance Dual-Signer Verification Log
+CREATE TABLE "CommodityDualSignerLog" (
+    "id"                       TEXT NOT NULL,
+    "transactionHash"          TEXT NOT NULL,
+    "commodityType"            TEXT NOT NULL,
+    "commodityCode"            TEXT NOT NULL,
+    "contractAddress"          TEXT NOT NULL,
+    "traderAddress"            TEXT NOT NULL,
+    "primarySignerAddress"     TEXT NOT NULL,
+    "secondarySignerAddress"   TEXT NOT NULL,
+    "primarySigned"            BOOLEAN NOT NULL DEFAULT false,
+    "secondarySigned"          BOOLEAN NOT NULL DEFAULT false,
+    "bothSigned"               BOOLEAN NOT NULL DEFAULT false,
+    "quantity"                 TEXT NOT NULL,
+    "unit"                     TEXT NOT NULL,
+    "notionalValueUsd"         TEXT,
+    "regulatoryJurisdiction"   TEXT NOT NULL DEFAULT 'CFTC',
+    "complianceStatus"         TEXT NOT NULL DEFAULT 'pending',
+    "expiresAt"                TIMESTAMP(3),
+    "ledgerSequence"           INTEGER NOT NULL,
+    "ledgerCloseTime"          TIMESTAMP(3) NOT NULL,
+    "createdAt"                TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"                TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CommodityDualSignerLog_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "CommodityDualSignerLog_transactionHash_key" ON "CommodityDualSignerLog"("transactionHash");
+CREATE INDEX "CommodityDualSignerLog_commodityCode_idx" ON "CommodityDualSignerLog"("commodityCode");
+CREATE INDEX "CommodityDualSignerLog_contractAddress_idx" ON "CommodityDualSignerLog"("contractAddress");
+CREATE INDEX "CommodityDualSignerLog_traderAddress_idx" ON "CommodityDualSignerLog"("traderAddress");
+CREATE INDEX "CommodityDualSignerLog_primarySignerAddress_idx" ON "CommodityDualSignerLog"("primarySignerAddress");
+CREATE INDEX "CommodityDualSignerLog_secondarySignerAddress_idx" ON "CommodityDualSignerLog"("secondarySignerAddress");
+CREATE INDEX "CommodityDualSignerLog_complianceStatus_idx" ON "CommodityDualSignerLog"("complianceStatus");
+CREATE INDEX "CommodityDualSignerLog_ledgerSequence_idx" ON "CommodityDualSignerLog"("ledgerSequence");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -688,6 +688,69 @@ model AccountActivation {
   @@index([ledgerSequence])
 }
 
+// #218: DTCC Tokenized Securities Settlement ID Bridge
+// Maps on-chain Soroban settlement transactions to DTCC settlement IDs
+model DtccSettlementBridge {
+  id                  String   @id @default(cuid())
+  transactionHash     String   @unique
+  dtccSettlementId    String   // DTCC-assigned settlement identifier (e.g. "DTCC-2026-0001234")
+  securityId          String   // ISIN or CUSIP of the tokenized security
+  securityType        String   // "equity" | "bond" | "etf" | "other"
+  sellerAddress       String   // Soroban address of the seller
+  buyerAddress        String   // Soroban address of the buyer
+  quantity            String   // token quantity (string for precision)
+  settlementAmount    String   // cash leg amount in USD cents (string for precision)
+  currency            String   @default("USD")
+  settlementStatus    String   @default("pending") // "pending" | "settled" | "failed" | "cancelled"
+  settlementDate      DateTime?
+  contractAddress     String?  // tokenized security contract
+  ledgerSequence      Int
+  ledgerCloseTime     DateTime
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+
+  @@index([dtccSettlementId])
+  @@index([securityId])
+  @@index([sellerAddress])
+  @@index([buyerAddress])
+  @@index([settlementStatus])
+  @@index([ledgerSequence])
+}
+
+// #219: Commodity Compliance Dual-Signer Verification Log
+// Records dual-signer approval events for regulated commodity transactions
+model CommodityDualSignerLog {
+  id                  String   @id @default(cuid())
+  transactionHash     String   @unique
+  commodityType       String   // "crude_oil" | "natural_gas" | "gold" | "wheat" | "other"
+  commodityCode       String   // standardized commodity code (e.g. "WTI", "XAU")
+  contractAddress     String   // commodity token contract
+  traderAddress       String   // initiating trader
+  primarySignerAddress  String // first required signer
+  secondarySignerAddress String // second required signer
+  primarySigned       Boolean  @default(false)
+  secondarySigned     Boolean  @default(false)
+  bothSigned          Boolean  @default(false)
+  quantity            String   // commodity quantity
+  unit                String   // "barrel" | "troy_oz" | "bushel" | "mmbtu" | "other"
+  notionalValueUsd    String?  // estimated USD value
+  regulatoryJurisdiction String @default("CFTC") // "CFTC" | "FCA" | "ESMA" | "other"
+  complianceStatus    String   @default("pending") // "pending" | "approved" | "rejected" | "expired"
+  expiresAt           DateTime?
+  ledgerSequence      Int
+  ledgerCloseTime     DateTime
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+
+  @@index([commodityCode])
+  @@index([contractAddress])
+  @@index([traderAddress])
+  @@index([primarySignerAddress])
+  @@index([secondarySignerAddress])
+  @@index([complianceStatus])
+  @@index([ledgerSequence])
+}
+
 // i18n translation dictionary
 model TranslationKey {
   id              String   @id @default(cuid())

--- a/src/api/commodity-compliance.ts
+++ b/src/api/commodity-compliance.ts
@@ -1,0 +1,158 @@
+/**
+ * #219 — Commodity Compliance Dual-Signer Verification Logging
+ *
+ * POST  /api/v1/commodity-compliance              — log a dual-signer verification event
+ * GET   /api/v1/commodity-compliance              — list logs (filterable)
+ * GET   /api/v1/commodity-compliance/:txHash      — get by transaction hash
+ * PATCH /api/v1/commodity-compliance/:txHash/sign — record a signer approval
+ */
+
+import { Router, Request, Response } from 'express';
+import { prismaRead as prisma } from '../db';
+import { z } from 'zod';
+
+export const commodityComplianceRouter = Router();
+
+const createSchema = z.object({
+  transactionHash:         z.string().min(1),
+  commodityType:           z.enum(['crude_oil', 'natural_gas', 'gold', 'wheat', 'other']),
+  commodityCode:           z.string().min(1),
+  contractAddress:         z.string().min(1),
+  traderAddress:           z.string().min(1),
+  primarySignerAddress:    z.string().min(1),
+  secondarySignerAddress:  z.string().min(1),
+  quantity:                z.string().min(1),
+  unit:                    z.enum(['barrel', 'troy_oz', 'bushel', 'mmbtu', 'other']),
+  notionalValueUsd:        z.string().optional(),
+  regulatoryJurisdiction:  z.enum(['CFTC', 'FCA', 'ESMA', 'other']).default('CFTC'),
+  expiresAt:               z.string().datetime().optional(),
+  ledgerSequence:          z.number().int().min(0),
+  ledgerCloseTime:         z.string().datetime(),
+});
+
+const listSchema = z.object({
+  commodityCode:  z.string().optional(),
+  commodityType:  z.enum(['crude_oil', 'natural_gas', 'gold', 'wheat', 'other']).optional(),
+  contract:       z.string().optional(),
+  trader:         z.string().optional(),
+  signer:         z.string().optional(),
+  status:         z.enum(['pending', 'approved', 'rejected', 'expired']).optional(),
+  jurisdiction:   z.string().optional(),
+  ledgerMin:      z.coerce.number().int().min(0).optional(),
+  ledgerMax:      z.coerce.number().int().min(0).optional(),
+  page:           z.coerce.number().min(1).default(1),
+  limit:          z.coerce.number().min(1).max(100).default(20),
+});
+
+const signSchema = z.object({
+  signerAddress: z.string().min(1),
+  approved:      z.boolean(),
+});
+
+// POST /commodity-compliance — log a new dual-signer verification event
+commodityComplianceRouter.post('/', async (req: Request, res: Response) => {
+  try {
+    const data = createSchema.parse(req.body);
+    const record = await prisma.commodityDualSignerLog.create({
+      data: {
+        ...data,
+        expiresAt: data.expiresAt ? new Date(data.expiresAt) : undefined,
+        ledgerCloseTime: new Date(data.ledgerCloseTime),
+      },
+    });
+    res.status(201).json(record);
+  } catch (e) {
+    res.status(400).json({ error: String(e) });
+  }
+});
+
+// GET /commodity-compliance — list with filters
+commodityComplianceRouter.get('/', async (req: Request, res: Response) => {
+  try {
+    const q = listSchema.parse(req.query);
+    const where = {
+      ...(q.commodityCode && { commodityCode: q.commodityCode }),
+      ...(q.commodityType && { commodityType: q.commodityType }),
+      ...(q.contract      && { contractAddress: q.contract }),
+      ...(q.trader        && { traderAddress: q.trader }),
+      ...(q.status        && { complianceStatus: q.status }),
+      ...(q.jurisdiction  && { regulatoryJurisdiction: q.jurisdiction }),
+      ...(q.signer && {
+        OR: [
+          { primarySignerAddress: q.signer },
+          { secondarySignerAddress: q.signer },
+        ],
+      }),
+      ...((q.ledgerMin !== undefined || q.ledgerMax !== undefined) && {
+        ledgerSequence: {
+          ...(q.ledgerMin !== undefined && { gte: q.ledgerMin }),
+          ...(q.ledgerMax !== undefined && { lte: q.ledgerMax }),
+        },
+      }),
+    };
+
+    const skip = (q.page - 1) * q.limit;
+    const [data, total] = await Promise.all([
+      prisma.commodityDualSignerLog.findMany({
+        where,
+        orderBy: { ledgerSequence: 'desc' },
+        skip,
+        take: q.limit,
+      }),
+      prisma.commodityDualSignerLog.count({ where }),
+    ]);
+
+    res.json({ data, total, page: q.page, limit: q.limit, pages: Math.ceil(total / q.limit) });
+  } catch (e) {
+    res.status(400).json({ error: String(e) });
+  }
+});
+
+// GET /commodity-compliance/:txHash — get by transaction hash
+commodityComplianceRouter.get('/:txHash', async (req: Request, res: Response) => {
+  const record = await prisma.commodityDualSignerLog.findUnique({
+    where: { transactionHash: req.params.txHash },
+  });
+  if (!record) return res.status(404).json({ error: 'Not found' });
+  res.json(record);
+});
+
+// PATCH /commodity-compliance/:txHash/sign — record a signer approval/rejection
+commodityComplianceRouter.patch('/:txHash/sign', async (req: Request, res: Response) => {
+  try {
+    const { signerAddress, approved } = signSchema.parse(req.body);
+
+    const existing = await prisma.commodityDualSignerLog.findUnique({
+      where: { transactionHash: req.params.txHash },
+    });
+    if (!existing) return res.status(404).json({ error: 'Not found' });
+
+    const isPrimary   = existing.primarySignerAddress === signerAddress;
+    const isSecondary = existing.secondarySignerAddress === signerAddress;
+
+    if (!isPrimary && !isSecondary) {
+      return res.status(403).json({ error: 'Address is not a registered signer for this record' });
+    }
+
+    const primarySigned   = isPrimary   ? approved : existing.primarySigned;
+    const secondarySigned = isSecondary ? approved : existing.secondarySigned;
+    const bothSigned      = primarySigned && secondarySigned;
+
+    // Determine compliance status
+    let complianceStatus = existing.complianceStatus;
+    if (!approved) {
+      complianceStatus = 'rejected';
+    } else if (bothSigned) {
+      complianceStatus = 'approved';
+    }
+
+    const record = await prisma.commodityDualSignerLog.update({
+      where: { transactionHash: req.params.txHash },
+      data: { primarySigned, secondarySigned, bothSigned, complianceStatus },
+    });
+
+    res.json(record);
+  } catch (e) {
+    res.status(400).json({ error: String(e) });
+  }
+});

--- a/src/api/dtcc-settlement.ts
+++ b/src/api/dtcc-settlement.ts
@@ -1,0 +1,140 @@
+/**
+ * #218 — DTCC Tokenized Securities Settlement ID Bridge
+ *
+ * POST /api/v1/dtcc-settlement          — register a settlement bridge record
+ * GET  /api/v1/dtcc-settlement          — list records (filterable)
+ * GET  /api/v1/dtcc-settlement/:txHash  — get by transaction hash
+ * GET  /api/v1/dtcc-settlement/id/:dtccId — get by DTCC settlement ID
+ * PATCH /api/v1/dtcc-settlement/:txHash/status — update settlement status
+ */
+
+import { Router, Request, Response } from 'express';
+import { prismaRead as prisma } from '../db';
+import { z } from 'zod';
+
+export const dtccSettlementRouter = Router();
+
+const createSchema = z.object({
+  transactionHash:   z.string().min(1),
+  dtccSettlementId:  z.string().min(1),
+  securityId:        z.string().min(1),
+  securityType:      z.enum(['equity', 'bond', 'etf', 'other']),
+  sellerAddress:     z.string().min(1),
+  buyerAddress:      z.string().min(1),
+  quantity:          z.string().min(1),
+  settlementAmount:  z.string().min(1),
+  currency:          z.string().default('USD'),
+  contractAddress:   z.string().optional(),
+  settlementDate:    z.string().datetime().optional(),
+  ledgerSequence:    z.number().int().min(0),
+  ledgerCloseTime:   z.string().datetime(),
+});
+
+const listSchema = z.object({
+  securityId:       z.string().optional(),
+  securityType:     z.enum(['equity', 'bond', 'etf', 'other']).optional(),
+  seller:           z.string().optional(),
+  buyer:            z.string().optional(),
+  status:           z.enum(['pending', 'settled', 'failed', 'cancelled']).optional(),
+  ledgerMin:        z.coerce.number().int().min(0).optional(),
+  ledgerMax:        z.coerce.number().int().min(0).optional(),
+  page:             z.coerce.number().min(1).default(1),
+  limit:            z.coerce.number().min(1).max(100).default(20),
+});
+
+const statusSchema = z.object({
+  settlementStatus: z.enum(['pending', 'settled', 'failed', 'cancelled']),
+  settlementDate:   z.string().datetime().optional(),
+});
+
+// POST /dtcc-settlement — register a new settlement bridge record
+dtccSettlementRouter.post('/', async (req: Request, res: Response) => {
+  try {
+    const data = createSchema.parse(req.body);
+    const record = await prisma.dtccSettlementBridge.create({
+      data: {
+        ...data,
+        settlementDate: data.settlementDate ? new Date(data.settlementDate) : undefined,
+        ledgerCloseTime: new Date(data.ledgerCloseTime),
+      },
+    });
+    res.status(201).json(record);
+  } catch (e) {
+    res.status(400).json({ error: String(e) });
+  }
+});
+
+// GET /dtcc-settlement — list with filters
+dtccSettlementRouter.get('/', async (req: Request, res: Response) => {
+  try {
+    const q = listSchema.parse(req.query);
+    const where = {
+      ...(q.securityId   && { securityId: q.securityId }),
+      ...(q.securityType && { securityType: q.securityType }),
+      ...(q.seller       && { sellerAddress: q.seller }),
+      ...(q.buyer        && { buyerAddress: q.buyer }),
+      ...(q.status       && { settlementStatus: q.status }),
+      ...((q.ledgerMin !== undefined || q.ledgerMax !== undefined) && {
+        ledgerSequence: {
+          ...(q.ledgerMin !== undefined && { gte: q.ledgerMin }),
+          ...(q.ledgerMax !== undefined && { lte: q.ledgerMax }),
+        },
+      }),
+    };
+
+    const skip = (q.page - 1) * q.limit;
+    const [data, total] = await Promise.all([
+      prisma.dtccSettlementBridge.findMany({
+        where,
+        orderBy: { ledgerSequence: 'desc' },
+        skip,
+        take: q.limit,
+      }),
+      prisma.dtccSettlementBridge.count({ where }),
+    ]);
+
+    res.json({ data, total, page: q.page, limit: q.limit, pages: Math.ceil(total / q.limit) });
+  } catch (e) {
+    res.status(400).json({ error: String(e) });
+  }
+});
+
+// GET /dtcc-settlement/id/:dtccId — lookup by DTCC settlement ID
+dtccSettlementRouter.get('/id/:dtccId', async (req: Request, res: Response) => {
+  try {
+    const records = await prisma.dtccSettlementBridge.findMany({
+      where: { dtccSettlementId: req.params.dtccId },
+      orderBy: { createdAt: 'desc' },
+    });
+    if (!records.length) return res.status(404).json({ error: 'Not found' });
+    res.json({ dtccSettlementId: req.params.dtccId, count: records.length, records });
+  } catch (e) {
+    res.status(400).json({ error: String(e) });
+  }
+});
+
+// GET /dtcc-settlement/:txHash — get by transaction hash
+dtccSettlementRouter.get('/:txHash', async (req: Request, res: Response) => {
+  const record = await prisma.dtccSettlementBridge.findUnique({
+    where: { transactionHash: req.params.txHash },
+  });
+  if (!record) return res.status(404).json({ error: 'Not found' });
+  res.json(record);
+});
+
+// PATCH /dtcc-settlement/:txHash/status — update settlement status
+dtccSettlementRouter.patch('/:txHash/status', async (req: Request, res: Response) => {
+  try {
+    const { settlementStatus, settlementDate } = statusSchema.parse(req.body);
+    const record = await prisma.dtccSettlementBridge.update({
+      where: { transactionHash: req.params.txHash },
+      data: {
+        settlementStatus,
+        ...(settlementDate && { settlementDate: new Date(settlementDate) }),
+      },
+    });
+    res.json(record);
+  } catch (e) {
+    res.status(400).json({ error: String(e) });
+  }
+});

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -23,6 +23,8 @@ import { analyticsRouter } from './analytics';
 import { portfolioRouter } from './portfolio';
 import { exportsRouter } from './exports';
 import { syncStateRouter } from './sync-state';
+import { dtccSettlementRouter } from './dtcc-settlement';
+import { commodityComplianceRouter } from './commodity-compliance';
 
 export const router = Router();
 
@@ -49,3 +51,5 @@ router.use('/analytics', analyticsRouter);
 router.use('/portfolio', portfolioRouter);
 router.use('/exports', exportsRouter);
 router.use('/sync-state', syncStateRouter);
+router.use('/dtcc-settlement', dtccSettlementRouter);
+router.use('/commodity-compliance', commodityComplianceRouter);


### PR DESCRIPTION
## Summary

Implements two new features for regulated financial asset tracking on Soroban.

### #218 — DTCC Tokenized Securities Settlement ID Bridge
- New `DtccSettlementBridge` Prisma model mapping on-chain settlement transactions to DTCC settlement IDs
- Migration `20260531000001_dtcc_settlement_commodity_dual_signer`
- REST API at `/api/v1/dtcc-settlement`:
  - `POST /` — register a bridge record
  - `GET /` — list with filters (securityId, securityType, seller, buyer, status, ledger range)
  - `GET /:txHash` — lookup by transaction hash
  - `GET /id/:dtccId` — lookup by DTCC settlement ID
  - `PATCH /:txHash/status` — update settlement status

### #219 — Commodity Compliance Dual-Signer Verification Logging
- New `CommodityDualSignerLog` Prisma model for dual-signer approval events (CFTC/FCA/ESMA)
- REST API at `/api/v1/commodity-compliance`:
  - `POST /` — log a new dual-signer event
  - `GET /` — list with filters (commodityCode, type, trader, signer, status, jurisdiction)
  - `GET /:txHash` — lookup by transaction hash
  - `PATCH /:txHash/sign` — record signer approval; auto-sets status to `approved` when both signers sign, `rejected` on any rejection

## What was tested
- `npx tsc --noEmit` — no errors in new files
- Prisma client regenerated successfully

closes #218
closes #219