### PR TITLE
feat: add Redis rate-limit store with in-memory fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,9 @@ INDEXER_CATCHUP_WORKERS=4
 # ─── Rate limiting ────────────────────────────────────────────────────────────
 RATE_LIMIT_WINDOW_MS=60000
 RATE_LIMIT_MAX=100
+# Optional: shared Redis store so rate limits are enforced across multiple API
+# instances (e.g. Docker Compose scale-out). Omit to use the in-memory fallback.
+# REDIS_URL=redis://localhost:6379
 
 # ─── Archival / TTL (cold storage) ───────────────────────────────────────────
 # Days before raw XDR is archived to S3 (parsed/human-readable data stays in DB)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,23 @@ x-db-healthcheck: &db-healthcheck
 services:
 
   # ═══════════════════════════════════════════════════════════════════════════
+  # REDIS  (optional – enables shared rate-limit store across API instances)
+  # Uncomment this service and set REDIS_URL=redis://redis:6379 in each API
+  # service's environment block to activate the Redis rate-limit store.
+  # ═══════════════════════════════════════════════════════════════════════════
+  # redis:
+  #   image: redis:7-alpine
+  #   ports:
+  #     - '6379:6379'
+  #   volumes:
+  #     - redis-data:/data
+  #   healthcheck:
+  #     test: ['CMD', 'redis-cli', 'ping']
+  #     interval: 5s
+  #     timeout: 5s
+  #     retries: 5
+
+  # ═══════════════════════════════════════════════════════════════════════════
   # TESTNET
   # ═══════════════════════════════════════════════════════════════════════════
   db-testnet:
@@ -171,3 +188,4 @@ volumes:
   pgdata-testnet:
   pgdata-mainnet:
   pgdata-devnet:
+  # redis-data:  # Uncomment when the redis service above is enabled

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
     "ws": "^8.13.0",
     "zod": "^3.22.4"
   },
+  "optionalDependencies": {
+    "rate-limit-redis": "^4.2.0",
+    "redis": "^6.0.0"
+  },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
@@ -56,7 +60,6 @@
     "@types/swagger-ui-express": "^4.1.7",
     "@types/ws": "^8.5.0",
     "prisma": "^5.10.0",
-    "redis": "^6.0.0",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.3.3",
     "vitest": "^1.4.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { config } from './config';
 import { router } from './api/router';
 import { prismaWrite as prisma } from './db';
 import { startIndexerService } from './indexer/indexer';
-import { tieredRateLimit } from './middleware/rateLimit';
+import { tieredRateLimit, initRateLimitStore } from './middleware/rateLimit';
 import { metricsMiddleware } from './middleware/metricsMiddleware';
 import { sanitizeInputs } from './middleware/sanitize';
 import { i18nMiddleware } from './i18n';
@@ -57,6 +57,7 @@ app.get('/health', (_req, res) => res.json({ status: 'ok', network: config.stell
 app.use((_req, res) => res.status(404).json({ error: 'Not found' }));
 
 async function main() {
+  await initRateLimitStore();
   await cacheConnect();
   await prisma.$connect();
   dbConnectionStatus.set(1);

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -1,4 +1,4 @@
-import rateLimit from 'express-rate-limit';
+import rateLimit, { Store, RateLimitRequestHandler } from 'express-rate-limit';
 import { Request, Response, NextFunction } from 'express';
 
 /**
@@ -49,12 +49,62 @@ function getTier(apiKey: string | undefined): keyof typeof TIERS {
   return 'public';
 }
 
-// One limiter instance per tier, keyed by IP + tier
-const limiters = {
-  premium: rateLimit({ ...TIERS.premium, standardHeaders: true, legacyHeaders: false, keyGenerator: (req) => `premium:${req.ip}` }),
-  developer: rateLimit({ ...TIERS.developer, standardHeaders: true, legacyHeaders: false, keyGenerator: (req) => `developer:${req.ip}` }),
-  public: rateLimit({ ...TIERS.public, standardHeaders: true, legacyHeaders: false, keyGenerator: (req) => `public:${req.ip}` }),
-};
+type Limiters = Record<keyof typeof TIERS, RateLimitRequestHandler>;
+
+function buildLimiters(store?: Store): Limiters {
+  const make = (tierName: keyof typeof TIERS) =>
+    rateLimit({
+      ...TIERS[tierName],
+      standardHeaders: true,
+      legacyHeaders: false,
+      keyGenerator: (req) => `${tierName}:${req.ip}`,
+      ...(store ? { store } : {}),
+    });
+
+  return {
+    premium: make('premium'),
+    developer: make('developer'),
+    public: make('public'),
+  };
+}
+
+// Default: in-memory store (works immediately, single-instance only)
+let limiters: Limiters = buildLimiters();
+
+/**
+ * Call once at startup. If REDIS_URL is set and rate-limit-redis is installed,
+ * replaces the in-memory store with a shared Redis store so rate limits are
+ * enforced consistently across multiple API instances.
+ */
+export async function initRateLimitStore(): Promise<void> {
+  const redisUrl = process.env.REDIS_URL;
+  if (!redisUrl) return;
+
+  try {
+    const { createClient } = await import('redis');
+    const { RedisStore } = await import('rate-limit-redis');
+
+    const client = createClient({ url: redisUrl });
+    client.on('error', (err: Error) =>
+      console.warn('[rate-limit] Redis error:', err.message)
+    );
+    await client.connect();
+
+    const store = new RedisStore({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sendCommand: (...args: string[]) => (client as any).sendCommand(args),
+      prefix: 'rl:',
+    });
+
+    limiters = buildLimiters(store);
+    console.log('[rate-limit] Using Redis store at', redisUrl);
+  } catch (err) {
+    console.warn(
+      '[rate-limit] Redis unavailable, falling back to in-memory store:',
+      (err as Error).message
+    );
+  }
+}
 
 /**
  * Middleware: reads X-API-Key, selects the appropriate rate limiter tier,


### PR DESCRIPTION
## Summary

- Add `rate-limit-redis` and `redis` as `optionalDependencies` — installed by default but the app starts fine without them
- `initRateLimitStore()` dynamically imports both packages at startup **only** when `REDIS_URL` is set; any connection failure silently falls back to the existing in-memory store
- `tieredRateLimit` middleware signature is unchanged — no breaking change to callers
- Add `REDIS_URL=redis://localhost:6379` (commented out) to `.env.example` with an explanatory note
- Add a fully commented-out Redis 7 Alpine service + volume to `docker-compose.yml` with activation instructions

## Why

The default `express-rate-limit` in-memory store is per-process. When multiple API containers run behind a load balancer, each process counts independently, so a client can exceed the intended limit by `N × limit` across `N` instances. A shared Redis store fixes this.

## Test plan

- [ ] Start app without `REDIS_URL` — confirm in-memory store is used (no Redis errors logged)
- [ ] Set `REDIS_URL=redis://localhost:6379` with Redis running — confirm `[rate-limit] Using Redis store at redis://localhost:6379` is logged
- [ ] Set `REDIS_URL` pointing to an unreachable host — confirm warning is logged and server still starts with in-memory fallback
- [ ] Verify rate-limit headers (`RateLimit-*`) are present on responses in all three scenarios
- [ ] Run existing test suite: `npm test`

closes #227 