### PR TITLE
feat: Horizon fallback for transaction fetch (#222)

### DIFF
--- a/src/indexer/indexer.ts
+++ b/src/indexer/indexer.ts
@@ -1,7 +1,7 @@
 import WebSocket from 'ws';
 import { prismaWrite as prisma } from '../db';
 import { config } from '../config';
-import { fetchEvents, getLatestLedger, getRpcWebsocketUrl, getTransaction, type LedgerEvent } from './rpc';
+import { fetchEvents, getLatestLedger, getRpcWebsocketUrl, getTransaction, getTransactionFromHorizon, type LedgerEvent } from './rpc';
 import { decodeTransaction, decodeEvent } from './decoder';
 
 const BATCH = config.indexerBatchSize;
@@ -41,7 +41,8 @@ async function processLedgerRange(start: number, end: number) {
 
     const existingTx = await prisma.transaction.findUnique({ where: { hash: event.transactionHash } });
     if (!existingTx) {
-      const txResult = await getTransaction(event.transactionHash).catch(() => null);
+      const txResult = await getTransaction(event.transactionHash)
+        .catch(() => getTransactionFromHorizon(event.transactionHash).catch(() => null));
       const rawXdr = (txResult as any)?.envelopeXdr?.toXDR('base64') ?? '';
       const decoded = rawXdr
         ? await decodeTransaction(rawXdr)

--- a/src/indexer/rpc.ts
+++ b/src/indexer/rpc.ts
@@ -131,6 +131,23 @@ export async function getTransaction(hash: string) {
   return retry(() => rpc.getTransaction(hash));
 }
 
+/**
+ * Fetch a transaction from Horizon REST API (fallback for RPC NOT_FOUND).
+ * Maps Horizon fields to the same shape used by the RPC result.
+ */
+export async function getTransactionFromHorizon(hash: string) {
+  const axios = (await import('axios')).default;
+  const { data } = await axios.get(`${config.horizonUrl}/transactions/${hash}`);
+  return {
+    status: data.successful ? 'SUCCESS' : 'FAILED',
+    sourceAccount: data.source_account as string,
+    feeCharged: String(data.fee_charged ?? ''),
+    envelopeXdr: {
+      toXDR: (enc: string) => enc === 'base64' ? data.envelope_xdr : data.envelope_xdr,
+    },
+  };
+}
+
 export function getRpcWebsocketUrl(): string {
   return config.stellarRpcWsUrl;
 }


### PR DESCRIPTION
- add getTransactionFromHorizon(hash) in rpc.ts using axios against config.horizonUrl
- maps Horizon fields (source_account, fee_charged, envelope_xdr) to RPC shape
- indexer.ts falls back to Horizon when RPC getTransaction() throws (NOT_FOUND or any error)

closes #222 