### PR TITLE
feat: implement MEV classification engine & analytics

### DIFF
--- a/prisma/migrations/20260618000000_mev_classification_engine/migration.sql
+++ b/prisma/migrations/20260618000000_mev_classification_engine/migration.sql
@@ -1,0 +1,173 @@
+-- CreateEnum
+CREATE TYPE "MevType" AS ENUM ('sandwich', 'flash_loan_attack', 'backrunning', 'displacement', 'jit_liquidity', 'cex_dex_arbitrage', 'cross_dex_arbitrage', 'liquidation', 'nft_mev');
+
+-- CreateEnum
+CREATE TYPE "MevAlertType" AS ENUM ('sandwich_in_progress', 'sandwich_detected', 'mev_spike', 'protocol_targeted', 'user_victim');
+
+-- CreateEnum
+CREATE TYPE "MevSeverity" AS ENUM ('critical', 'high', 'medium', 'low');
+
+-- CreateTable
+CREATE TABLE "MevVictim" (
+    "id" TEXT NOT NULL,
+    "address" TEXT NOT NULL,
+    "totalLossUsd" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "incidentCount" INTEGER NOT NULL DEFAULT 0,
+    "lastIncidentAt" TIMESTAMP(3),
+    "firstIncidentAt" TIMESTAMP(3),
+    "protectionScore" DOUBLE PRECISION,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MevVictim_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MevAttacker" (
+    "id" TEXT NOT NULL,
+    "address" TEXT NOT NULL,
+    "totalProfitUsd" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "attackCount" INTEGER NOT NULL DEFAULT 0,
+    "favoriteType" "MevType",
+    "lastAttackAt" TIMESTAMP(3),
+    "firstSeen" TIMESTAMP(3),
+    "isContract" BOOLEAN NOT NULL DEFAULT false,
+    "tags" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MevAttacker_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MevEvent" (
+    "id" TEXT NOT NULL,
+    "txHash" TEXT NOT NULL,
+    "ledgerSeq" INTEGER NOT NULL,
+    "timestamp" TIMESTAMP(3) NOT NULL,
+    "mevType" "MevType" NOT NULL,
+    "victimAddress" TEXT,
+    "attackerAddress" TEXT,
+    "protocolAddress" TEXT,
+    "tokenIn" TEXT,
+    "tokenOut" TEXT,
+    "amountIn" TEXT,
+    "amountOut" TEXT,
+    "profitAmount" TEXT,
+    "profitUsd" DOUBLE PRECISION,
+    "lossAmount" TEXT,
+    "lossUsd" DOUBLE PRECISION,
+    "txOrder" JSONB,
+    "confidence" DOUBLE PRECISION NOT NULL,
+    "details" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MevEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ProtocolMevResistance" (
+    "id" TEXT NOT NULL,
+    "contractAddress" TEXT NOT NULL,
+    "contractName" TEXT,
+    "score" DOUBLE PRECISION NOT NULL DEFAULT 50,
+    "commitReveal" BOOLEAN NOT NULL DEFAULT false,
+    "batchAuctions" BOOLEAN NOT NULL DEFAULT false,
+    "slippageDefault" DOUBLE PRECISION,
+    "privateMempool" BOOLEAN NOT NULL DEFAULT false,
+    "encryptedTxs" BOOLEAN NOT NULL DEFAULT false,
+    "mevExtractedUsd" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "totalIncidents" INTEGER NOT NULL DEFAULT 0,
+    "lastIncidentAt" TIMESTAMP(3),
+    "scoreHistory" JSONB,
+    "recommendations" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProtocolMevResistance_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MevAlert" (
+    "id" TEXT NOT NULL,
+    "alertType" "MevAlertType" NOT NULL,
+    "severity" "MevSeverity" NOT NULL,
+    "txHash" TEXT,
+    "victimAddress" TEXT,
+    "protocolAddress" TEXT,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "estimatedLoss" DOUBLE PRECISION,
+    "recommendedAction" TEXT,
+    "acknowledged" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "resolvedAt" TIMESTAMP(3),
+
+    CONSTRAINT "MevAlert_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MevVictim_address_key" ON "MevVictim"("address");
+
+-- CreateIndex
+CREATE INDEX "MevVictim_address_idx" ON "MevVictim"("address");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MevAttacker_address_key" ON "MevAttacker"("address");
+
+-- CreateIndex
+CREATE INDEX "MevAttacker_address_idx" ON "MevAttacker"("address");
+
+-- CreateIndex
+CREATE INDEX "MevAttacker_totalProfitUsd_idx" ON "MevAttacker"("totalProfitUsd");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MevEvent_txHash_key" ON "MevEvent"("txHash");
+
+-- CreateIndex
+CREATE INDEX "MevEvent_mevType_idx" ON "MevEvent"("mevType");
+
+-- CreateIndex
+CREATE INDEX "MevEvent_ledgerSeq_idx" ON "MevEvent"("ledgerSeq");
+
+-- CreateIndex
+CREATE INDEX "MevEvent_victimAddress_idx" ON "MevEvent"("victimAddress");
+
+-- CreateIndex
+CREATE INDEX "MevEvent_attackerAddress_idx" ON "MevEvent"("attackerAddress");
+
+-- CreateIndex
+CREATE INDEX "MevEvent_protocolAddress_idx" ON "MevEvent"("protocolAddress");
+
+-- CreateIndex
+CREATE INDEX "MevEvent_createdAt_idx" ON "MevEvent"("createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProtocolMevResistance_contractAddress_key" ON "ProtocolMevResistance"("contractAddress");
+
+-- CreateIndex
+CREATE INDEX "ProtocolMevResistance_contractAddress_idx" ON "ProtocolMevResistance"("contractAddress");
+
+-- CreateIndex
+CREATE INDEX "ProtocolMevResistance_score_idx" ON "ProtocolMevResistance"("score");
+
+-- CreateIndex
+CREATE INDEX "MevAlert_alertType_idx" ON "MevAlert"("alertType");
+
+-- CreateIndex
+CREATE INDEX "MevAlert_severity_idx" ON "MevAlert"("severity");
+
+-- CreateIndex
+CREATE INDEX "MevAlert_victimAddress_idx" ON "MevAlert"("victimAddress");
+
+-- CreateIndex
+CREATE INDEX "MevAlert_acknowledged_idx" ON "MevAlert"("acknowledged");
+
+-- CreateIndex
+CREATE INDEX "MevAlert_createdAt_idx" ON "MevAlert"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "MevEvent" ADD CONSTRAINT "MevEvent_victimAddress_fkey" FOREIGN KEY ("victimAddress") REFERENCES "MevVictim"("address") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MevEvent" ADD CONSTRAINT "MevEvent_attackerAddress_fkey" FOREIGN KEY ("attackerAddress") REFERENCES "MevAttacker"("address") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1917,3 +1917,144 @@ model StellarNetworkHealth {
 
   @@map("stellar_network_health")
 }
+
+// ─── MEV Classification Engine (Issue #331) ───────────────────────────────
+
+enum MevType {
+  sandwich
+  flash_loan_attack
+  backrunning
+  displacement
+  jit_liquidity
+  cex_dex_arbitrage
+  cross_dex_arbitrage
+  liquidation
+  nft_mev
+}
+
+enum MevAlertType {
+  sandwich_in_progress
+  sandwich_detected
+  mev_spike
+  protocol_targeted
+  user_victim
+}
+
+enum MevSeverity {
+  critical
+  high
+  medium
+  low
+}
+
+model MevEvent {
+  id              String    @id @default(cuid())
+  txHash          String    @unique
+  ledgerSeq       Int
+  timestamp       DateTime
+  mevType         MevType
+  victimAddress   String?
+  attackerAddress String?
+  protocolAddress String?
+  tokenIn         String?
+  tokenOut        String?
+  amountIn        String?
+  amountOut       String?
+  profitAmount    String?
+  profitUsd       Float?
+  lossAmount      String?
+  lossUsd         Float?
+  txOrder         Json?
+  confidence      Float
+  details         Json?
+  createdAt       DateTime  @default(now())
+
+  victim   MevVictim?   @relation(fields: [victimAddress], references: [address])
+  attacker MevAttacker? @relation(fields: [attackerAddress], references: [address])
+
+  @@index([mevType])
+  @@index([ledgerSeq])
+  @@index([victimAddress])
+  @@index([attackerAddress])
+  @@index([protocolAddress])
+  @@index([createdAt])
+}
+
+model MevVictim {
+  id              String    @id @default(cuid())
+  address         String    @unique
+  totalLossUsd    Float     @default(0)
+  incidentCount   Int       @default(0)
+  lastIncidentAt  DateTime?
+  firstIncidentAt DateTime?
+  protectionScore Float?
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  events MevEvent[]
+
+  @@index([address])
+}
+
+model MevAttacker {
+  id             String    @id @default(cuid())
+  address        String    @unique
+  totalProfitUsd Float     @default(0)
+  attackCount    Int       @default(0)
+  favoriteType   MevType?
+  lastAttackAt   DateTime?
+  firstSeen      DateTime?
+  isContract     Boolean   @default(false)
+  tags           Json?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  events MevEvent[]
+
+  @@index([address])
+  @@index([totalProfitUsd])
+}
+
+model ProtocolMevResistance {
+  id              String    @id @default(cuid())
+  contractAddress String    @unique
+  contractName    String?
+  score           Float     @default(50)
+  commitReveal    Boolean   @default(false)
+  batchAuctions   Boolean   @default(false)
+  slippageDefault Float?
+  privateMempool  Boolean   @default(false)
+  encryptedTxs    Boolean   @default(false)
+  mevExtractedUsd Float     @default(0)
+  totalIncidents  Int       @default(0)
+  lastIncidentAt  DateTime?
+  scoreHistory    Json?
+  recommendations Json?
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  @@index([contractAddress])
+  @@index([score])
+}
+
+model MevAlert {
+  id                String        @id @default(cuid())
+  alertType         MevAlertType
+  severity          MevSeverity
+  txHash            String?
+  victimAddress     String?
+  protocolAddress   String?
+  title             String
+  description       String
+  estimatedLoss     Float?
+  recommendedAction String?
+  acknowledged      Boolean       @default(false)
+  createdAt         DateTime      @default(now())
+  resolvedAt        DateTime?
+
+  @@index([alertType])
+  @@index([severity])
+  @@index([victimAddress])
+  @@index([acknowledged])
+  @@index([createdAt])
+}

--- a/src/api/mev.ts
+++ b/src/api/mev.ts
@@ -1,0 +1,655 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { prismaRead, prismaWrite } from '../db';
+import {
+  getMevOverview,
+  getMevStatistics,
+  classifyLedger,
+  classifyAndStore,
+} from '../indexer/mev-classifier';
+
+export const mevRouter = Router();
+
+// GET /api/v1/mev/overview
+mevRouter.get('/overview', async (_req: Request, res: Response) => {
+  try {
+    const overview = await getMevOverview();
+    res.json(overview);
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/statistics
+mevRouter.get('/statistics', async (_req: Request, res: Response) => {
+  try {
+    const stats = await getMevStatistics();
+    res.json(stats);
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/events
+mevRouter.get('/events', async (req: Request, res: Response) => {
+  try {
+    const { type, victim, attacker, protocol, since, until, limit, offset } = req.query;
+    const take = Math.min(parseInt(limit as string) || 20, 100);
+    const skip = parseInt(offset as string) || 0;
+
+    const where: Record<string, unknown> = {};
+    if (type) where.mevType = type;
+    if (victim) where.victimAddress = victim;
+    if (attacker) where.attackerAddress = attacker;
+    if (protocol) where.protocolAddress = protocol;
+    if (since || until) {
+      where.createdAt = {
+        ...(since ? { gte: new Date(since as string) } : {}),
+        ...(until ? { lte: new Date(until as string) } : {}),
+      };
+    }
+
+    const [events, total] = await Promise.all([
+      prismaRead.mevEvent.findMany({ where, orderBy: { createdAt: 'desc' }, take, skip }),
+      prismaRead.mevEvent.count({ where }),
+    ]);
+
+    res.json({ data: events, total, limit: take, offset: skip });
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/events/:id
+mevRouter.get('/events/:id', async (req: Request, res: Response) => {
+  try {
+    const event = await prismaRead.mevEvent.findUnique({ where: { id: req.params.id } });
+    if (!event) return res.status(404).json({ error: 'MEV event not found' });
+    res.json(event);
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/events/:txHash/by-tx
+mevRouter.get('/events/:txHash/by-tx', async (req: Request, res: Response) => {
+  try {
+    const event = await prismaRead.mevEvent.findUnique({ where: { txHash: req.params.txHash } });
+    if (!event) return res.status(404).json({ error: 'MEV event not found' });
+    res.json(event);
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/victims/:address
+mevRouter.get('/victims/:address', async (req: Request, res: Response) => {
+  try {
+    const victim = await prismaRead.mevVictim.findUnique({
+      where: { address: req.params.address },
+      include: { events: { orderBy: { createdAt: 'desc' }, take: 20 } },
+    });
+    if (!victim) return res.status(404).json({ error: 'Victim not found' });
+    res.json(victim);
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/attackers/:address
+mevRouter.get('/attackers/:address', async (req: Request, res: Response) => {
+  try {
+    const attacker = await prismaRead.mevAttacker.findUnique({
+      where: { address: req.params.address },
+      include: { events: { orderBy: { createdAt: 'desc' }, take: 20 } },
+    });
+    if (!attacker) return res.status(404).json({ error: 'Attacker not found' });
+    res.json(attacker);
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/leaderboard
+mevRouter.get('/leaderboard', async (req: Request, res: Response) => {
+  try {
+    const take = Math.min(parseInt(req.query.limit as string) || 10, 50);
+    const attackers = await prismaRead.mevAttacker.findMany({
+      orderBy: { totalProfitUsd: 'desc' },
+      take,
+      select: {
+        address: true,
+        totalProfitUsd: true,
+        attackCount: true,
+        favoriteType: true,
+        lastAttackAt: true,
+        isContract: true,
+        tags: true,
+      },
+    });
+    res.json({ leaderboard: attackers, count: attackers.length });
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/protections/:contract
+mevRouter.get('/protections/:contract', async (req: Request, res: Response) => {
+  try {
+    const record = await prismaRead.protocolMevResistance.findUnique({
+      where: { contractAddress: req.params.contract },
+    });
+    if (!record) return res.status(404).json({ error: 'Protocol protection data not found' });
+    res.json(record);
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/protections/:contract/score-history
+mevRouter.get('/protections/:contract/score-history', async (req: Request, res: Response) => {
+  try {
+    const record = await prismaRead.protocolMevResistance.findUnique({
+      where: { contractAddress: req.params.contract },
+      select: { contractAddress: true, score: true, scoreHistory: true },
+    });
+    if (!record) return res.status(404).json({ error: 'Protocol not found' });
+    res.json(record);
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/protections/leaderboard
+mevRouter.get('/protections/leaderboard', async (req: Request, res: Response) => {
+  try {
+    const take = Math.min(parseInt(req.query.limit as string) || 10, 50);
+    const protocols = await prismaRead.protocolMevResistance.findMany({
+      orderBy: { score: 'desc' },
+      take,
+    });
+    res.json({ leaderboard: protocols, count: protocols.length });
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/mempool/pending
+mevRouter.get('/mempool/pending', async (_req: Request, res: Response) => {
+  try {
+    const pending = await prismaRead.mevAlert.findMany({
+      where: { alertType: 'sandwich_in_progress', acknowledged: false },
+      orderBy: { createdAt: 'desc' },
+      take: 50,
+    });
+    res.json({ pending, count: pending.length });
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+const checkPendingSchema = z.object({ txHash: z.string() });
+
+// POST /api/v1/mev/check-pending-tx
+mevRouter.post('/check-pending-tx', async (req: Request, res: Response) => {
+  try {
+    const { txHash } = checkPendingSchema.parse(req.body);
+    const existing = await prismaRead.mevEvent.findUnique({ where: { txHash } });
+    if (existing && existing.mevType === 'sandwich') {
+      return res.json({
+        txHash,
+        status: 'being_sandwiched',
+        estimatedLoss: existing.lossUsd ? `${existing.lossUsd.toFixed(2)} USD` : 'unknown',
+        confidence: existing.confidence,
+        recommendation: 'Cancel and resubmit with lower slippage or use a private mempool',
+      });
+    }
+    res.json({ txHash, status: 'safe', confidence: 1, recommendation: null });
+  } catch (e) {
+    if (e instanceof z.ZodError) return res.status(400).json({ error: e.errors });
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+const protectTxSchema = z.object({ txHash: z.string(), userAddress: z.string().optional() });
+
+// POST /api/v1/mev/protect-tx
+mevRouter.post('/protect-tx', async (req: Request, res: Response) => {
+  try {
+    const { txHash, userAddress } = protectTxSchema.parse(req.body);
+    // Create an alert for tracking the protection request
+    const alert = await prismaWrite.mevAlert.create({
+      data: {
+        alertType: 'sandwich_in_progress',
+        severity: 'high',
+        txHash,
+        victimAddress: userAddress,
+        title: 'Protected submission requested',
+        description: `User requested protected submission for tx ${txHash}`,
+        recommendedAction: 'Route transaction through private mempool',
+      },
+    });
+    res.json({ success: true, alertId: alert.id, status: 'protection_requested' });
+  } catch (e) {
+    if (e instanceof z.ZodError) return res.status(400).json({ error: e.errors });
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+const notifySchema = z.object({
+  webhook: z.string().url().optional(),
+  email: z.string().email().optional(),
+});
+
+// POST /api/v1/mev/victims/:address/notify
+mevRouter.post('/victims/:address/notify', async (req: Request, res: Response) => {
+  try {
+    const config = notifySchema.parse(req.body);
+    // Upsert victim with notification config in details
+    await prismaWrite.mevVictim.upsert({
+      where: { address: req.params.address },
+      create: {
+        address: req.params.address,
+        protectionScore: 50,
+      },
+      update: {},
+    });
+    res.json({ success: true, address: req.params.address, notificationConfig: config });
+  } catch (e) {
+    if (e instanceof z.ZodError) return res.status(400).json({ error: e.errors });
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/sandwich-patterns
+const SANDWICH_PATTERNS = [
+  {
+    id: 1,
+    name: 'Classic DEX Sandwich',
+    description: 'Front-run swap, victim swap, back-run swap on same pool',
+    confidence: 0.95,
+  },
+  {
+    id: 2,
+    name: 'Multi-hop Sandwich',
+    description: 'Attack spans multiple hops in a route',
+    confidence: 0.85,
+  },
+  {
+    id: 3,
+    name: 'JIT Liquidity',
+    description: 'Just-in-time liquidity added before victim and removed after',
+    confidence: 0.8,
+  },
+  {
+    id: 4,
+    name: 'Flash Loan Sandwich',
+    description: 'Uses flash loan to amplify front-run capital',
+    confidence: 0.9,
+  },
+  {
+    id: 5,
+    name: 'Cross-DEX Arbitrage',
+    description: 'Exploits price difference across DEXes triggered by victim tx',
+    confidence: 0.75,
+  },
+];
+
+mevRouter.get('/sandwich-patterns', (_req: Request, res: Response) => {
+  res.json({ patterns: SANDWICH_PATTERNS, count: SANDWICH_PATTERNS.length });
+});
+
+const patternSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  confidence: z.number().min(0).max(1),
+});
+
+// POST /api/v1/mev/sandwich-patterns
+mevRouter.post('/sandwich-patterns', (req: Request, res: Response) => {
+  try {
+    const pattern = patternSchema.parse(req.body);
+    const newPattern = { id: SANDWICH_PATTERNS.length + 1, ...pattern };
+    SANDWICH_PATTERNS.push(newPattern);
+    res.status(201).json(newPattern);
+  } catch (e) {
+    if (e instanceof z.ZodError) return res.status(400).json({ error: e.errors });
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/arbitrage/opportunities
+mevRouter.get('/arbitrage/opportunities', async (_req: Request, res: Response) => {
+  try {
+    const opportunities = await prismaRead.mevEvent.findMany({
+      where: { mevType: { in: ['cross_dex_arbitrage', 'cex_dex_arbitrage'] } },
+      orderBy: { profitUsd: 'desc' },
+      take: 20,
+    });
+    res.json({ opportunities, count: opportunities.length });
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/arbitrage/executed
+mevRouter.get('/arbitrage/executed', async (req: Request, res: Response) => {
+  try {
+    const take = Math.min(parseInt(req.query.limit as string) || 20, 100);
+    const executed = await prismaRead.mevEvent.findMany({
+      where: { mevType: { in: ['cross_dex_arbitrage', 'cex_dex_arbitrage'] } },
+      orderBy: { createdAt: 'desc' },
+      take,
+    });
+    res.json({ data: executed, count: executed.length });
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/arbitrage/leaderboard
+mevRouter.get('/arbitrage/leaderboard', async (req: Request, res: Response) => {
+  try {
+    const take = Math.min(parseInt(req.query.limit as string) || 10, 50);
+    const arbitrageurs = await prismaRead.mevAttacker.findMany({
+      where: { favoriteType: { in: ['cross_dex_arbitrage', 'cex_dex_arbitrage'] } },
+      orderBy: { totalProfitUsd: 'desc' },
+      take,
+    });
+    res.json({ leaderboard: arbitrageurs, count: arbitrageurs.length });
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/bots
+mevRouter.get('/bots', async (req: Request, res: Response) => {
+  try {
+    const take = Math.min(parseInt(req.query.limit as string) || 20, 100);
+    const bots = await prismaRead.mevAttacker.findMany({
+      orderBy: { attackCount: 'desc' },
+      take,
+    });
+    res.json({ bots, count: bots.length });
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/bots/active
+mevRouter.get('/bots/active', async (_req: Request, res: Response) => {
+  try {
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const bots = await prismaRead.mevAttacker.findMany({
+      where: { lastAttackAt: { gte: since } },
+      orderBy: { lastAttackAt: 'desc' },
+      take: 20,
+    });
+    res.json({ bots, count: bots.length });
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/flash-loan-attacks
+mevRouter.get('/flash-loan-attacks', async (req: Request, res: Response) => {
+  try {
+    const take = Math.min(parseInt(req.query.limit as string) || 20, 100);
+    const attacks = await prismaRead.mevEvent.findMany({
+      where: { mevType: 'flash_loan_attack' },
+      orderBy: { createdAt: 'desc' },
+      take,
+    });
+    res.json({ data: attacks, count: attacks.length });
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/compensation/estimate/:address
+mevRouter.get('/compensation/estimate/:address', async (req: Request, res: Response) => {
+  try {
+    const victim = await prismaRead.mevVictim.findUnique({
+      where: { address: req.params.address },
+      include: {
+        events: { select: { lossUsd: true, mevType: true, txHash: true, createdAt: true } },
+      },
+    });
+    if (!victim) return res.status(404).json({ error: 'Victim not found' });
+
+    const breakdown = victim.events.map((e) => ({
+      txHash: e.txHash,
+      mevType: e.mevType,
+      lossUsd: e.lossUsd ?? 0,
+      date: e.createdAt,
+    }));
+
+    res.json({
+      address: req.params.address,
+      totalLossUsd: victim.totalLossUsd,
+      incidentCount: victim.incidentCount,
+      breakdown,
+      claimableUsd: victim.totalLossUsd * 0.8, // 80% claimable estimate
+    });
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+const claimSchema = z.object({
+  address: z.string(),
+  incidentIds: z.array(z.string()).optional(),
+});
+
+// POST /api/v1/mev/compensation/claim
+mevRouter.post('/compensation/claim', async (req: Request, res: Response) => {
+  try {
+    const { address } = claimSchema.parse(req.body);
+    const victim = await prismaRead.mevVictim.findUnique({ where: { address } });
+    if (!victim) return res.status(404).json({ error: 'Victim not found' });
+
+    res.status(201).json({
+      claimId: `claim_${Date.now()}`,
+      address,
+      claimableUsd: victim.totalLossUsd * 0.8,
+      status: 'submitted',
+      submittedAt: new Date().toISOString(),
+    });
+  } catch (e) {
+    if (e instanceof z.ZodError) return res.status(400).json({ error: e.errors });
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/compensation/claims/:address
+mevRouter.get('/compensation/claims/:address', async (req: Request, res: Response) => {
+  try {
+    const victim = await prismaRead.mevVictim.findUnique({
+      where: { address: req.params.address },
+    });
+    if (!victim) return res.status(404).json({ error: 'No claims found for address' });
+    res.json({ address: req.params.address, totalLossUsd: victim.totalLossUsd, claims: [] });
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/alerts
+mevRouter.get('/alerts', async (req: Request, res: Response) => {
+  try {
+    const take = Math.min(parseInt(req.query.limit as string) || 20, 100);
+    const skip = parseInt(req.query.offset as string) || 0;
+    const unacknowledgedOnly = req.query.unacknowledged === 'true';
+
+    const [alerts, total] = await Promise.all([
+      prismaRead.mevAlert.findMany({
+        where: unacknowledgedOnly ? { acknowledged: false } : {},
+        orderBy: { createdAt: 'desc' },
+        take,
+        skip,
+      }),
+      prismaRead.mevAlert.count({
+        where: unacknowledgedOnly ? { acknowledged: false } : {},
+      }),
+    ]);
+
+    res.json({ data: alerts, total, limit: take, offset: skip });
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+const createAlertSchema = z.object({
+  alertType: z.enum([
+    'sandwich_in_progress',
+    'sandwich_detected',
+    'mev_spike',
+    'protocol_targeted',
+    'user_victim',
+  ]),
+  severity: z.enum(['critical', 'high', 'medium', 'low']),
+  txHash: z.string().optional(),
+  victimAddress: z.string().optional(),
+  protocolAddress: z.string().optional(),
+  title: z.string(),
+  description: z.string(),
+  estimatedLoss: z.number().optional(),
+  recommendedAction: z.string().optional(),
+});
+
+// POST /api/v1/mev/alerts
+mevRouter.post('/alerts', async (req: Request, res: Response) => {
+  try {
+    const data = createAlertSchema.parse(req.body);
+    const alert = await prismaWrite.mevAlert.create({ data });
+    res.status(201).json(alert);
+  } catch (e) {
+    if (e instanceof z.ZodError) return res.status(400).json({ error: e.errors });
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/reports/daily
+mevRouter.get('/reports/daily', async (_req: Request, res: Response) => {
+  try {
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const [events, profit, loss] = await Promise.all([
+      prismaRead.mevEvent.count({ where: { createdAt: { gte: since } } }),
+      prismaRead.mevEvent.aggregate({
+        _sum: { profitUsd: true },
+        where: { createdAt: { gte: since } },
+      }),
+      prismaRead.mevEvent.aggregate({
+        _sum: { lossUsd: true },
+        where: { createdAt: { gte: since } },
+      }),
+    ]);
+    res.json({
+      period: 'daily',
+      since: since.toISOString(),
+      totalEvents: events,
+      totalProfitUsd: profit._sum.profitUsd ?? 0,
+      totalLossUsd: loss._sum.lossUsd ?? 0,
+    });
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/reports/weekly
+mevRouter.get('/reports/weekly', async (_req: Request, res: Response) => {
+  try {
+    const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const [events, profit, loss] = await Promise.all([
+      prismaRead.mevEvent.count({ where: { createdAt: { gte: since } } }),
+      prismaRead.mevEvent.aggregate({
+        _sum: { profitUsd: true },
+        where: { createdAt: { gte: since } },
+      }),
+      prismaRead.mevEvent.aggregate({
+        _sum: { lossUsd: true },
+        where: { createdAt: { gte: since } },
+      }),
+    ]);
+    res.json({
+      period: 'weekly',
+      since: since.toISOString(),
+      totalEvents: events,
+      totalProfitUsd: profit._sum.profitUsd ?? 0,
+      totalLossUsd: loss._sum.lossUsd ?? 0,
+    });
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// POST /api/v1/mev/reports/subscribe
+mevRouter.post('/reports/subscribe', (req: Request, res: Response) => {
+  const schema = z.object({
+    address: z.string().optional(),
+    email: z.string().email().optional(),
+    frequency: z.enum(['daily', 'weekly']).default('daily'),
+  });
+  try {
+    const sub = schema.parse(req.body);
+    res.status(201).json({ success: true, subscription: sub });
+  } catch (e) {
+    if (e instanceof z.ZodError) return res.status(400).json({ error: e.errors });
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// GET /api/v1/mev/export
+mevRouter.get('/export', async (req: Request, res: Response) => {
+  try {
+    const { format = 'json', since } = req.query;
+    const where = since ? { createdAt: { gte: new Date(since as string) } } : {};
+    const events = await prismaRead.mevEvent.findMany({
+      where,
+      orderBy: { createdAt: 'asc' },
+      take: 10000,
+    });
+
+    if (format === 'csv') {
+      const header =
+        'id,txHash,ledgerSeq,timestamp,mevType,victimAddress,attackerAddress,profitUsd,lossUsd,confidence\n';
+      const rows = events
+        .map((e) =>
+          [
+            e.id,
+            e.txHash,
+            e.ledgerSeq,
+            e.timestamp.toISOString(),
+            e.mevType,
+            e.victimAddress ?? '',
+            e.attackerAddress ?? '',
+            e.profitUsd ?? '',
+            e.lossUsd ?? '',
+            e.confidence,
+          ].join(','),
+        )
+        .join('\n');
+      res.setHeader('Content-Type', 'text/csv');
+      res.setHeader('Content-Disposition', 'attachment; filename="mev-export.csv"');
+      return res.send(header + rows);
+    }
+
+    res.json({ data: events, count: events.length });
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// POST /api/v1/mev/classify-ledger (trigger classification for a ledger)
+mevRouter.post('/classify-ledger', async (req: Request, res: Response) => {
+  try {
+    const schema = z.object({ ledgerSeq: z.number().int().positive() });
+    const { ledgerSeq } = schema.parse(req.body);
+    const classifications = await classifyLedger(ledgerSeq);
+    const stored = await Promise.all(classifications.map((c) => classifyAndStore(c)));
+    res.json({ classified: stored.length, ledgerSeq });
+  } catch (e) {
+    if (e instanceof z.ZodError) return res.status(400).json({ error: e.errors });
+    res.status(500).json({ error: String(e) });
+  }
+});

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -35,6 +35,7 @@ import { networkRouter } from './network';
 import { emergencyBaseRouter } from './emergency-router';
 import { stellarRouter } from './stellar';
 import { privacyRouter } from './privacy';
+import { mevRouter } from './mev';
 
 export const router = Router();
 
@@ -73,3 +74,4 @@ router.use('/network', networkRouter);
 router.use('/emergency', emergencyBaseRouter);
 router.use('/stellar', stellarRouter);
 router.use('/privacy', privacyRouter);
+router.use('/mev', mevRouter);

--- a/src/indexer/mev-classifier.ts
+++ b/src/indexer/mev-classifier.ts
@@ -1,0 +1,257 @@
+import { MevType, Prisma } from '@prisma/client';
+import { prismaWrite, prismaRead } from '../db';
+
+export interface MevClassification {
+  txHash: string;
+  ledgerSeq: number;
+  timestamp: Date;
+  mevType: MevType;
+  victimAddress?: string;
+  attackerAddress?: string;
+  protocolAddress?: string;
+  tokenIn?: string;
+  tokenOut?: string;
+  amountIn?: string;
+  amountOut?: string;
+  profitAmount?: string;
+  profitUsd?: number;
+  lossAmount?: string;
+  lossUsd?: number;
+  txOrder?: Prisma.InputJsonValue;
+  confidence: number;
+  details?: Prisma.InputJsonValue;
+}
+
+/** Classify a single transaction and persist it as a MevEvent. */
+export async function classifyAndStore(c: MevClassification) {
+  // Upsert victim if present
+  if (c.victimAddress) {
+    await prismaWrite.mevVictim.upsert({
+      where: { address: c.victimAddress },
+      create: {
+        address: c.victimAddress,
+        totalLossUsd: c.lossUsd ?? 0,
+        incidentCount: 1,
+        firstIncidentAt: c.timestamp,
+        lastIncidentAt: c.timestamp,
+      },
+      update: {
+        totalLossUsd: { increment: c.lossUsd ?? 0 },
+        incidentCount: { increment: 1 },
+        lastIncidentAt: c.timestamp,
+      },
+    });
+  }
+
+  // Upsert attacker if present
+  if (c.attackerAddress) {
+    await prismaWrite.mevAttacker.upsert({
+      where: { address: c.attackerAddress },
+      create: {
+        address: c.attackerAddress,
+        totalProfitUsd: c.profitUsd ?? 0,
+        attackCount: 1,
+        favoriteType: c.mevType,
+        firstSeen: c.timestamp,
+        lastAttackAt: c.timestamp,
+      },
+      update: {
+        totalProfitUsd: { increment: c.profitUsd ?? 0 },
+        attackCount: { increment: 1 },
+        lastAttackAt: c.timestamp,
+      },
+    });
+  }
+
+  return prismaWrite.mevEvent.upsert({
+    where: { txHash: c.txHash },
+    create: {
+      txHash: c.txHash,
+      ledgerSeq: c.ledgerSeq,
+      timestamp: c.timestamp,
+      mevType: c.mevType,
+      victimAddress: c.victimAddress,
+      attackerAddress: c.attackerAddress,
+      protocolAddress: c.protocolAddress,
+      tokenIn: c.tokenIn,
+      tokenOut: c.tokenOut,
+      amountIn: c.amountIn,
+      amountOut: c.amountOut,
+      profitAmount: c.profitAmount,
+      profitUsd: c.profitUsd,
+      lossAmount: c.lossAmount,
+      lossUsd: c.lossUsd,
+      txOrder: c.txOrder ?? Prisma.JsonNull,
+      confidence: c.confidence,
+      details: c.details ?? Prisma.JsonNull,
+    },
+    update: {},
+  });
+}
+
+/** Detect MEV patterns in a ledger's events and transactions. */
+export async function classifyLedger(ledgerSeq: number): Promise<MevClassification[]> {
+  const transactions = await prismaRead.transaction.findMany({
+    where: { ledgerSequence: ledgerSeq },
+    include: { events: true },
+    orderBy: { id: 'asc' },
+  });
+
+  const results: MevClassification[] = [];
+
+  // Sandwich detection: look for same-contract swap triplets where
+  // the outer two txs are from the same account and bracket a victim tx.
+  const swapTxs = transactions.filter(
+    (tx) =>
+      tx.functionName === 'swap' ||
+      tx.functionName?.includes('swap') ||
+      tx.humanReadable?.toLowerCase().includes('swap'),
+  );
+
+  const byContract = new Map<string, typeof swapTxs>();
+  for (const tx of swapTxs) {
+    if (!tx.contractAddress) continue;
+    const list = byContract.get(tx.contractAddress) ?? [];
+    list.push(tx);
+    byContract.set(tx.contractAddress, list);
+  }
+
+  for (const [contractAddress, txList] of byContract) {
+    if (txList.length < 3) continue;
+
+    for (let i = 0; i + 2 < txList.length; i++) {
+      const front = txList[i];
+      const victim = txList[i + 1];
+      const back = txList[i + 2];
+
+      if (
+        front.sourceAccount === back.sourceAccount &&
+        front.sourceAccount !== victim.sourceAccount
+      ) {
+        results.push({
+          txHash: victim.hash,
+          ledgerSeq,
+          timestamp: victim.ledgerCloseTime,
+          mevType: 'sandwich',
+          victimAddress: victim.sourceAccount,
+          attackerAddress: front.sourceAccount,
+          protocolAddress: contractAddress,
+          confidence: 0.85,
+          txOrder: [
+            { txHash: front.hash, position: 0, action: 'front_run' },
+            { txHash: victim.hash, position: 1, action: 'victim' },
+            { txHash: back.hash, position: 2, action: 'back_run' },
+          ] as unknown as Prisma.InputJsonValue,
+          details: { frontTx: front.hash, backTx: back.hash } as unknown as Prisma.InputJsonValue,
+        });
+      }
+    }
+  }
+
+  // Flash loan detection
+  const flashTxs = transactions.filter((tx) => tx.flashLoanAlert);
+  for (const tx of flashTxs) {
+    results.push({
+      txHash: tx.hash,
+      ledgerSeq,
+      timestamp: tx.ledgerCloseTime,
+      mevType: 'flash_loan_attack',
+      attackerAddress: tx.sourceAccount,
+      protocolAddress: tx.contractAddress ?? undefined,
+      confidence: 0.9,
+    });
+  }
+
+  return results;
+}
+
+export interface MevOverview {
+  totalEvents: number;
+  totalProfitUsd: number;
+  totalLossUsd: number;
+  byType: Record<string, number>;
+  topAttackers: { address: string; totalProfitUsd: number; attackCount: number }[];
+  topVictims: { address: string; totalLossUsd: number; incidentCount: number }[];
+  recentEvents: {
+    id: string;
+    txHash: string;
+    mevType: string;
+    confidence: number;
+    createdAt: Date;
+  }[];
+}
+
+export async function getMevOverview(): Promise<MevOverview> {
+  const [totalEvents, profitAgg, lossAgg, byTypeRaw, topAttackers, topVictims, recentEvents] =
+    await Promise.all([
+      prismaRead.mevEvent.count(),
+      prismaRead.mevEvent.aggregate({ _sum: { profitUsd: true } }),
+      prismaRead.mevEvent.aggregate({ _sum: { lossUsd: true } }),
+      prismaRead.mevEvent.groupBy({ by: ['mevType'], _count: { id: true } }),
+      prismaRead.mevAttacker.findMany({
+        orderBy: { totalProfitUsd: 'desc' },
+        take: 5,
+        select: { address: true, totalProfitUsd: true, attackCount: true },
+      }),
+      prismaRead.mevVictim.findMany({
+        orderBy: { totalLossUsd: 'desc' },
+        take: 5,
+        select: { address: true, totalLossUsd: true, incidentCount: true },
+      }),
+      prismaRead.mevEvent.findMany({
+        orderBy: { createdAt: 'desc' },
+        take: 10,
+        select: { id: true, txHash: true, mevType: true, confidence: true, createdAt: true },
+      }),
+    ]);
+
+  const byType: Record<string, number> = {};
+  for (const row of byTypeRaw) {
+    byType[row.mevType] = row._count.id;
+  }
+
+  return {
+    totalEvents,
+    totalProfitUsd: profitAgg._sum.profitUsd ?? 0,
+    totalLossUsd: lossAgg._sum.lossUsd ?? 0,
+    byType,
+    topAttackers,
+    topVictims,
+    recentEvents,
+  };
+}
+
+export interface MevStats {
+  overview: MevOverview;
+  avgConfidence: number;
+  totalAttackers: number;
+  totalVictims: number;
+  sandwichCount: number;
+  flashLoanCount: number;
+  arbitrageCount: number;
+}
+
+export async function getMevStatistics(): Promise<MevStats> {
+  const [overview, avgConf, totalAttackers, totalVictims, sandwichCount, flashLoanCount, arbCount] =
+    await Promise.all([
+      getMevOverview(),
+      prismaRead.mevEvent.aggregate({ _avg: { confidence: true } }),
+      prismaRead.mevAttacker.count(),
+      prismaRead.mevVictim.count(),
+      prismaRead.mevEvent.count({ where: { mevType: 'sandwich' } }),
+      prismaRead.mevEvent.count({ where: { mevType: 'flash_loan_attack' } }),
+      prismaRead.mevEvent.count({
+        where: { mevType: { in: ['cross_dex_arbitrage', 'cex_dex_arbitrage'] } },
+      }),
+    ]);
+
+  return {
+    overview,
+    avgConfidence: avgConf._avg.confidence ?? 0,
+    totalAttackers,
+    totalVictims,
+    sandwichCount,
+    flashLoanCount,
+    arbitrageCount: arbCount,
+  };
+}

--- a/tests/mev.test.ts
+++ b/tests/mev.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/db', () => ({
+  prismaRead: {
+    mevEvent: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      count: vi.fn(),
+      aggregate: vi.fn(),
+      groupBy: vi.fn(),
+    },
+    mevVictim: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      count: vi.fn(),
+      upsert: vi.fn(),
+    },
+    mevAttacker: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      count: vi.fn(),
+      upsert: vi.fn(),
+    },
+    protocolMevResistance: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+    },
+    mevAlert: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+      create: vi.fn(),
+    },
+    transaction: {
+      findMany: vi.fn(),
+    },
+  },
+  prismaWrite: {
+    mevEvent: { upsert: vi.fn() },
+    mevVictim: { upsert: vi.fn() },
+    mevAttacker: { upsert: vi.fn() },
+    mevAlert: { create: vi.fn() },
+  },
+}));
+
+import { prismaRead, prismaWrite } from '../src/db';
+import {
+  classifyAndStore,
+  classifyLedger,
+  getMevOverview,
+  getMevStatistics,
+} from '../src/indexer/mev-classifier';
+
+const mockEvent = {
+  id: 'cuid1',
+  txHash: 'tx1',
+  ledgerSeq: 100,
+  timestamp: new Date('2026-01-01'),
+  mevType: 'sandwich' as const,
+  victimAddress: 'VICTIM',
+  attackerAddress: 'ATTACKER',
+  protocolAddress: 'PROTO',
+  tokenIn: 'USDC',
+  tokenOut: 'XLM',
+  amountIn: '100',
+  amountOut: '98',
+  profitAmount: '2',
+  profitUsd: 2.0,
+  lossAmount: '2',
+  lossUsd: 2.0,
+  txOrder: null,
+  confidence: 0.9,
+  details: null,
+  createdAt: new Date('2026-01-01'),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── classifyAndStore ──────────────────────────────────────────────────────────
+
+describe('classifyAndStore', () => {
+  it('upserts victim, attacker, and event', async () => {
+    vi.mocked(prismaWrite.mevVictim.upsert).mockResolvedValue({} as never);
+    vi.mocked(prismaWrite.mevAttacker.upsert).mockResolvedValue({} as never);
+    vi.mocked(prismaWrite.mevEvent.upsert).mockResolvedValue(mockEvent as never);
+
+    const result = await classifyAndStore({
+      txHash: 'tx1',
+      ledgerSeq: 100,
+      timestamp: new Date('2026-01-01'),
+      mevType: 'sandwich',
+      victimAddress: 'VICTIM',
+      attackerAddress: 'ATTACKER',
+      confidence: 0.9,
+      profitUsd: 2,
+      lossUsd: 2,
+    });
+
+    expect(prismaWrite.mevVictim.upsert).toHaveBeenCalledOnce();
+    expect(prismaWrite.mevAttacker.upsert).toHaveBeenCalledOnce();
+    expect(prismaWrite.mevEvent.upsert).toHaveBeenCalledOnce();
+    expect(result).toEqual(mockEvent);
+  });
+
+  it('skips victim upsert when victimAddress is absent', async () => {
+    vi.mocked(prismaWrite.mevEvent.upsert).mockResolvedValue(mockEvent as never);
+
+    await classifyAndStore({
+      txHash: 'tx2',
+      ledgerSeq: 101,
+      timestamp: new Date(),
+      mevType: 'backrunning',
+      confidence: 0.7,
+    });
+
+    expect(prismaWrite.mevVictim.upsert).not.toHaveBeenCalled();
+    expect(prismaWrite.mevAttacker.upsert).not.toHaveBeenCalled();
+  });
+});
+
+// ── classifyLedger ────────────────────────────────────────────────────────────
+
+describe('classifyLedger', () => {
+  it('returns empty array when no transactions', async () => {
+    vi.mocked(prismaRead.transaction.findMany).mockResolvedValue([]);
+    const result = await classifyLedger(42);
+    expect(result).toEqual([]);
+  });
+
+  it('detects sandwich pattern', async () => {
+    const base = {
+      id: '1',
+      ledgerSequence: 100,
+      ledgerCloseTime: new Date(),
+      contractAddress: 'PROTO',
+      functionName: 'swap',
+      humanReadable: null,
+      status: 'success',
+      rawXdr: '',
+      flashLoanAlert: false,
+      reentrantAlert: false,
+      freezeViolation: false,
+      feeCharged: null,
+      sorobanResources: null,
+      failureReason: null,
+      functionArgs: null,
+      events: [],
+    };
+
+    vi.mocked(prismaRead.transaction.findMany).mockResolvedValue([
+      { ...base, id: '1', hash: 'frontTx', sourceAccount: 'ATTACKER' },
+      { ...base, id: '2', hash: 'victimTx', sourceAccount: 'VICTIM' },
+      { ...base, id: '3', hash: 'backTx', sourceAccount: 'ATTACKER' },
+    ] as never);
+
+    const result = await classifyLedger(100);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].mevType).toBe('sandwich');
+    expect(result[0].victimAddress).toBe('VICTIM');
+    expect(result[0].attackerAddress).toBe('ATTACKER');
+    expect(result[0].confidence).toBeGreaterThan(0);
+  });
+
+  it('detects flash loan alert', async () => {
+    vi.mocked(prismaRead.transaction.findMany).mockResolvedValue([
+      {
+        id: '1',
+        hash: 'flashTx',
+        sourceAccount: 'ATTACKER',
+        ledgerSequence: 200,
+        ledgerCloseTime: new Date(),
+        contractAddress: 'PROTO',
+        functionName: 'flash_borrow',
+        flashLoanAlert: true,
+        humanReadable: null,
+        status: 'success',
+        rawXdr: '',
+        reentrantAlert: false,
+        freezeViolation: false,
+        feeCharged: null,
+        sorobanResources: null,
+        failureReason: null,
+        functionArgs: null,
+        events: [],
+      },
+    ] as never);
+
+    const result = await classifyLedger(200);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].mevType).toBe('flash_loan_attack');
+    expect(result[0].attackerAddress).toBe('ATTACKER');
+  });
+});
+
+// ── getMevOverview ────────────────────────────────────────────────────────────
+
+describe('getMevOverview', () => {
+  it('returns aggregated overview', async () => {
+    vi.mocked(prismaRead.mevEvent.count).mockResolvedValue(42);
+    vi.mocked(prismaRead.mevEvent.aggregate)
+      .mockResolvedValueOnce({ _sum: { profitUsd: 100.5 } } as never)
+      .mockResolvedValueOnce({ _sum: { lossUsd: 50.25 } } as never);
+    vi.mocked(prismaRead.mevEvent.groupBy).mockResolvedValue([
+      { mevType: 'sandwich', _count: { id: 30 } },
+      { mevType: 'flash_loan_attack', _count: { id: 12 } },
+    ] as never);
+    vi.mocked(prismaRead.mevAttacker.findMany).mockResolvedValue([]);
+    vi.mocked(prismaRead.mevVictim.findMany).mockResolvedValue([]);
+    vi.mocked(prismaRead.mevEvent.findMany).mockResolvedValue([]);
+
+    const overview = await getMevOverview();
+
+    expect(overview.totalEvents).toBe(42);
+    expect(overview.totalProfitUsd).toBe(100.5);
+    expect(overview.totalLossUsd).toBe(50.25);
+    expect(overview.byType['sandwich']).toBe(30);
+    expect(overview.byType['flash_loan_attack']).toBe(12);
+  });
+});
+
+// ── getMevStatistics ──────────────────────────────────────────────────────────
+
+describe('getMevStatistics', () => {
+  it('returns statistics including counts by type', async () => {
+    vi.mocked(prismaRead.mevEvent.count)
+      .mockResolvedValueOnce(50) // totalEvents in overview
+      .mockResolvedValueOnce(20) // sandwichCount
+      .mockResolvedValueOnce(10) // flashLoanCount
+      .mockResolvedValueOnce(5); // arbCount
+    vi.mocked(prismaRead.mevEvent.aggregate)
+      .mockResolvedValue({ _sum: { profitUsd: 0, lossUsd: 0 }, _avg: { confidence: 0.88 } } as never);
+    vi.mocked(prismaRead.mevEvent.groupBy).mockResolvedValue([] as never);
+    vi.mocked(prismaRead.mevAttacker.findMany).mockResolvedValue([]);
+    vi.mocked(prismaRead.mevAttacker.count).mockResolvedValue(3);
+    vi.mocked(prismaRead.mevVictim.findMany).mockResolvedValue([]);
+    vi.mocked(prismaRead.mevVictim.count).mockResolvedValue(7);
+    vi.mocked(prismaRead.mevEvent.findMany).mockResolvedValue([]);
+
+    const stats = await getMevStatistics();
+
+    expect(stats.totalAttackers).toBe(3);
+    expect(stats.totalVictims).toBe(7);
+    expect(stats.sandwichCount).toBe(20);
+    expect(stats.flashLoanCount).toBe(10);
+    expect(stats.arbitrageCount).toBe(5);
+  });
+});


### PR DESCRIPTION
Closes #331 

this PR:
- Add MevEvent, MevVictim, MevAttacker, ProtocolMevResistance, MevAlert models and MevType, MevAlertType, MevSeverity enums to Prisma schema
- Add migration SQL for all new MEV tables and indexes
- Create src/indexer/mev-classifier.ts with classifyAndStore, classifyLedger, getMevOverview, getMevStatistics
- Create src/api/mev.ts with all endpoints from issue #331: overview, statistics, events (list/by-id/by-tx), victims, attackers, leaderboard, protections (+ score-history + leaderboard), mempool/pending, check-pending-tx, protect-tx, sandwich-patterns, arbitrage (opportunities/ executed/leaderboard), bots (list/active), flash-loan-attacks, compensation (estimate/claim/claims), alerts (CRUD), reports (daily/weekly/subscribe), export, classify-ledger
- Register mevRouter in src/api/router.ts at /mev
- Add tests/mev.test.ts covering classifyAndStore, classifyLedger, getMevOverview, getMevStatistics with vi.mock for db