### PR TITLE
feat: Contract Governance Intelligence — Upgrade Detection, WASM Diffing & Decentralization Scoring

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,7 +48,10 @@ model Contract {
   @@index([address])
 }
 
-// WASM bytecode upgrade history for contract version lineage
+// WASM bytecode upgrade history for contract version lineage.
+// Also carries the Contract Governance Intelligence layer: who upgraded,
+// how the code changed (WASM diff), how decentralised the upgrade authority
+// is, and whether the upgrade looks suspicious.
 model WasmUpgradeHistory {
   id              String   @id @default(cuid())
   contractAddress String
@@ -59,10 +62,35 @@ model WasmUpgradeHistory {
   transactionHash String?  // tx that triggered the upgrade
   createdAt       DateTime @default(now())
 
+  // ── Phase 1: upgrade provenance ──────────────────────────────────────────
+  upgrader                  String?  // account that authorised the upgrade
+  upgraderAccountAgeLedgers Int?     // age (in ledgers) of the upgrader account at upgrade time
+
+  // ── Phase 3: WASM diff classification ────────────────────────────────────
+  changeClassification String?  // "minor" | "moderate" | "major" | "critical"
+  changeSummary        String?  // natural-language description of the change
+  diffStats            Json?    // { opcodeChurn, addedOpcodes, removedOpcodes, addedFunctions, removedFunctions, ... }
+  criticalFnChanges    String[] // critical functions added/removed/changed by this upgrade
+
+  // ── Phase 2: governance analysis ─────────────────────────────────────────
+  governanceType       String?  // "single_key" | "multisig" | "timelock" | "dao" | "unknown"
+  signerCount          Int?     // number of signers on the upgrader authority
+  threshold            Int?     // signature weight / threshold required
+  timelockSeconds      Int?     // enforced delay before the upgrade could execute, if any
+  daoProposalId        String?  // correlated governance proposal id, if any
+  decentralizationScore Int?    // 0-100 decentralisation methodology score
+
+  // ── Phase 4: suspicious activity ─────────────────────────────────────────
+  suspiciousFlags String[] // machine-readable flags e.g. "post_vuln_upgrade", "new_account_upgrader"
+  isSuspicious    Boolean  @default(false)
+  riskLevel       String?  // "none" | "low" | "medium" | "high" | "critical"
+
   contract Contract @relation(fields: [contractAddress], references: [address])
 
   @@index([contractAddress, ledgerSequence])
   @@index([ledgerSequence])
+  @@index([isSuspicious])
+  @@index([changeClassification])
 }
 
 model Transaction {

--- a/src/indexer/eventIngestor.ts
+++ b/src/indexer/eventIngestor.ts
@@ -11,6 +11,7 @@ import { processYieldEvent } from './yield-distribution';
 import { processYieldOpportunityEvent } from './yield-optimizer';
 import { dispatchWebhooks } from '../webhooks/dispatcher';
 import { maybeActivateFromTransferEvent } from './sac-account-activator';
+import { handleUpgradeEvent, looksLikeUpgrade } from './upgrade-detector';
 
 /**
  * Parse DiagnosticEvents from a raw TransactionMeta XDR (base64).
@@ -211,6 +212,31 @@ async function storeEvent(event: LedgerEvent): Promise<number> {
   dispatchWebhooks({ ...broadcastPayload, topicSymbol }).catch((err) =>
     console.error('[webhook] dispatch error:', err),
   );
+
+  // Contract Governance Intelligence: detect WASM upgrades and record them with
+  // diff classification, governance/decentralisation analysis, and
+  // suspicious-activity flags. Gated by a cheap symbol check so the contract
+  // lookup only runs for upgrade-looking events. Non-blocking — never lets an
+  // upgrade failure stall the broadcast/governance pipeline.
+  if (looksLikeUpgrade(eventType, topicSymbol)) {
+    prisma.contract
+      .findUnique({ where: { address: event.contractId }, select: { wasmHash: true } })
+      .then((contract) =>
+        handleUpgradeEvent({
+          contractAddress: event.contractId,
+          eventType,
+          topicSymbol,
+          decoded: decoded as Record<string, unknown> | null,
+          topics: event.topics,
+          transactionHash: event.transactionHash,
+          sourceAccount: txExists.sourceAccount,
+          ledgerSequence: event.ledgerSequence,
+          ledgerCloseTime: event.ledgerCloseTime,
+          previousHash: contract?.wasmHash ?? null,
+        }),
+      )
+      .catch((err) => console.error('[upgrade-governance] processing error:', err));
+  }
 
   // Track governance-related events and proposals
   import('./governance').then(({ processGovernanceEvent }) =>

--- a/src/indexer/upgrade-detector.ts
+++ b/src/indexer/upgrade-detector.ts
@@ -1,0 +1,132 @@
+/**
+ * Upgrade detection (Phase 1) — recognise contract WASM upgrades from indexed
+ * events, extract the upgrader and previous/new WASM hashes, best-effort fetch
+ * the bytecode for diffing, and hand off to the governance-intelligence
+ * orchestrator. Wired into the event ingestion pipeline.
+ */
+
+import { xdr } from '@stellar/stellar-sdk';
+import { rpc } from './rpc';
+import { recordUpgradeWithIntelligence } from './upgrade-governance';
+
+/** Event topic symbols / types that signal a contract code upgrade. */
+const UPGRADE_SYMBOLS = new Set<string>([
+  'upgrade',
+  'upgraded',
+  'set_wasm',
+  'update_wasm',
+  'wasm_updated',
+  'code_updated',
+  'contract_upgraded',
+  'migrate',
+  'migrated',
+]);
+
+/**
+ * Cheap gate used by the ingestion pipeline to decide whether an event is worth
+ * the contract lookup + full upgrade-handling path. Exported so callers can
+ * avoid that work for the overwhelming majority of non-upgrade events.
+ */
+export function looksLikeUpgrade(eventType: string | null, topicSymbol: string | null): boolean {
+  const symbol = (topicSymbol ?? eventType ?? '').toLowerCase();
+  if (!symbol) return false;
+  return UPGRADE_SYMBOLS.has(symbol) || symbol.includes('upgrade') || symbol.includes('wasm');
+}
+
+function asString(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim() !== '') return value.trim();
+  if (Buffer.isBuffer(value)) return value.toString('hex');
+  return undefined;
+}
+
+/** Pull the new WASM hash out of decoded event fields, normalising to hex. */
+function extractNewHash(decoded: Record<string, unknown>, topics: string[]): string | undefined {
+  const candidate =
+    asString(decoded.new_wasm_hash) ??
+    asString(decoded.newWasmHash) ??
+    asString(decoded.wasm_hash) ??
+    asString(decoded.wasmHash) ??
+    asString(decoded.new_hash) ??
+    asString(decoded.newHash) ??
+    asString(decoded.hash) ??
+    asString((decoded.data as Record<string, unknown> | undefined)?.wasm_hash);
+  if (candidate) return candidate.replace(/^0x/, '').toLowerCase();
+  return undefined;
+}
+
+/** Pull the upgrading authority out of decoded event fields. */
+function extractUpgrader(decoded: Record<string, unknown>, sourceAccount: string): string {
+  return (
+    asString(decoded.admin) ??
+    asString(decoded.caller) ??
+    asString(decoded.by) ??
+    asString(decoded.sender) ??
+    asString(decoded.from) ??
+    asString(decoded.authority) ??
+    sourceAccount
+  );
+}
+
+/**
+ * Fetch contract WASM bytecode by its hash from the live ledger. Returns null
+ * when the code entry is unavailable (evicted/archived) or on any RPC error —
+ * the diff is optional and must never block upgrade recording.
+ */
+export async function fetchWasmByHash(hashHex: string): Promise<Buffer | null> {
+  try {
+    const hash = Buffer.from(hashHex, 'hex');
+    if (hash.length !== 32) return null;
+    const key = xdr.LedgerKey.contractCode(new xdr.LedgerKeyContractCode({ hash }));
+    const response = await rpc.getLedgerEntries(key);
+    const entry = response.entries?.[0];
+    if (!entry) return null;
+    const code = (entry.val as xdr.LedgerEntryData).contractCode().code();
+    return Buffer.from(code);
+  } catch {
+    return null;
+  }
+}
+
+export interface UpgradeEventInput {
+  contractAddress: string;
+  eventType: string | null;
+  topicSymbol: string | null;
+  decoded: Record<string, unknown> | null;
+  topics: string[];
+  transactionHash: string;
+  sourceAccount: string;
+  ledgerSequence: number;
+  ledgerCloseTime: Date;
+  previousHash?: string | null;
+}
+
+/**
+ * Handle a single decoded event: if it is an upgrade and carries a new WASM
+ * hash, fetch the relevant bytecode and record the upgrade with full
+ * governance intelligence. No-op for non-upgrade events.
+ */
+export async function handleUpgradeEvent(input: UpgradeEventInput): Promise<void> {
+  if (!looksLikeUpgrade(input.eventType, input.topicSymbol)) return;
+  const decoded = input.decoded ?? {};
+  const newWasmHash = extractNewHash(decoded, input.topics);
+  if (!newWasmHash) return;
+
+  const upgrader = extractUpgrader(decoded, input.sourceAccount);
+
+  // Best-effort bytecode fetch for the WASM diff. Only diff when we can read
+  // both versions; a partial fetch still records the upgrade without a diff.
+  const newWasm = await fetchWasmByHash(newWasmHash);
+  const previousWasm = input.previousHash ? await fetchWasmByHash(input.previousHash) : null;
+  const canDiff = Boolean(newWasm && (input.previousHash ? previousWasm : true));
+
+  await recordUpgradeWithIntelligence({
+    contractAddress: input.contractAddress,
+    newWasmHash,
+    ledgerSequence: input.ledgerSequence,
+    ledgerCloseTime: input.ledgerCloseTime,
+    transactionHash: input.transactionHash,
+    upgrader,
+    previousWasm: canDiff ? previousWasm : undefined,
+    newWasm: canDiff ? newWasm : undefined,
+  });
+}

--- a/src/indexer/upgrade-governance.ts
+++ b/src/indexer/upgrade-governance.ts
@@ -1,0 +1,430 @@
+/**
+ * Contract Governance Intelligence — governance analysis, decentralisation
+ * scoring, suspicious-activity detection, and persistence (Phases 2 & 4).
+ *
+ * Pure functions (`analyzeGovernance`, `computeDecentralizationScore`,
+ * `detectSuspiciousActivity`) hold the methodology and are unit-tested in
+ * isolation. The DB-backed gatherers and `recordUpgradeWithIntelligence`
+ * orchestrator wire those into the live indexing path.
+ */
+
+import { prismaWrite, prismaRead } from '../db';
+import { diffWasm, type WasmDiff } from './wasm-diff';
+
+/** Approximate Stellar ledger close interval, used to convert ages → ledgers. */
+const LEDGER_SECONDS = 5;
+/** Upgraders younger than ~1 day of ledgers are treated as "newly created". */
+const NEW_ACCOUNT_LEDGERS = Math.round((24 * 3600) / LEDGER_SECONDS); // 17,280
+/** A vulnerability disclosed within this window before an upgrade is "same-day". */
+const VULN_WINDOW_MS = 24 * 3600 * 1000;
+
+export type GovernanceType = 'single_key' | 'multisig' | 'timelock' | 'dao' | 'unknown';
+export type RiskLevel = 'none' | 'low' | 'medium' | 'high' | 'critical';
+
+// ── Phase 2: governance analysis ──────────────────────────────────────────────
+
+export interface GovernanceSignals {
+  /** Number of signers on the authority that executed the upgrade. */
+  signerCount?: number;
+  /** Signature weight / threshold required to act. */
+  threshold?: number;
+  hasTimelock?: boolean;
+  /** Enforced delay (seconds) before the upgrade could execute. */
+  timelockSeconds?: number;
+  /** Correlated on-chain governance proposal id, if the upgrade was voted on. */
+  daoProposalId?: string | null;
+  /** Number of votes recorded on the correlated proposal. */
+  daoVotes?: number;
+}
+
+export interface GovernanceAnalysis {
+  governanceType: GovernanceType;
+  isMultisig: boolean;
+  signerCount: number;
+  threshold: number;
+  hasTimelock: boolean;
+  timelockSeconds: number;
+  daoProposalId: string | null;
+  daoVotes: number;
+}
+
+/**
+ * Resolve the governance posture of an upgrade from raw signals. The primary
+ * `governanceType` is the strongest decentralisation indicator present:
+ * dao > timelock > multisig > single_key > unknown.
+ */
+export function analyzeGovernance(signals: GovernanceSignals): GovernanceAnalysis {
+  const signerCount = signals.signerCount ?? 0;
+  const threshold = signals.threshold ?? 0;
+  const timelockSeconds = signals.timelockSeconds ?? 0;
+  const hasTimelock = Boolean(signals.hasTimelock || timelockSeconds > 0);
+  const daoProposalId = signals.daoProposalId ?? null;
+  const daoVotes = signals.daoVotes ?? 0;
+  const isMultisig = signerCount > 1;
+
+  let governanceType: GovernanceType;
+  if (daoProposalId) governanceType = 'dao';
+  else if (hasTimelock) governanceType = 'timelock';
+  else if (isMultisig) governanceType = 'multisig';
+  else if (signerCount === 1) governanceType = 'single_key';
+  else governanceType = 'unknown';
+
+  return {
+    governanceType,
+    isMultisig,
+    signerCount,
+    threshold,
+    hasTimelock,
+    timelockSeconds,
+    daoProposalId,
+    daoVotes,
+  };
+}
+
+// ── Decentralisation score (0-100) ────────────────────────────────────────────
+
+/**
+ * Human-readable description of how the decentralisation score is composed.
+ * Surfaced verbatim by the API so consumers can audit the methodology.
+ */
+export const DECENTRALIZATION_METHODOLOGY = {
+  scale: '0 (fully centralised single key) to 100 (broadly decentralised, vote-gated, time-delayed)',
+  components: [
+    {
+      name: 'Authority distribution',
+      max: 45,
+      detail:
+        'single key = 5; multisig = 15 + 5 per additional signer (cap 35) + 10 when threshold covers ≥50% of signers; unknown authority = 0.',
+    },
+    {
+      name: 'Timelock delay',
+      max: 25,
+      detail: 'present = 10, plus 5 per day of enforced delay (cap 25).',
+    },
+    {
+      name: 'DAO vote correlation',
+      max: 30,
+      detail: 'upgrade tied to a passed proposal = 15, plus 1 per 10 votes recorded (cap 30).',
+    },
+  ],
+} as const;
+
+/** Compute a 0-100 decentralisation score from a resolved governance analysis. */
+export function computeDecentralizationScore(analysis: GovernanceAnalysis): number {
+  let authority = 0;
+  if (analysis.signerCount === 1) {
+    authority = 5;
+  } else if (analysis.signerCount > 1) {
+    authority = 15 + Math.min(20, (analysis.signerCount - 1) * 5);
+    const coverage = analysis.threshold > 0 ? analysis.threshold / analysis.signerCount : 0;
+    if (coverage >= 0.5) authority += 10;
+    authority = Math.min(45, authority);
+  }
+
+  let timelock = 0;
+  if (analysis.hasTimelock) {
+    const days = analysis.timelockSeconds / (24 * 3600);
+    timelock = Math.min(25, 10 + Math.floor(days * 5));
+  }
+
+  let dao = 0;
+  if (analysis.daoProposalId) {
+    dao = Math.min(30, 15 + Math.floor(analysis.daoVotes / 10));
+  }
+
+  return Math.max(0, Math.min(100, authority + timelock + dao));
+}
+
+// ── Phase 4: suspicious activity ──────────────────────────────────────────────
+
+/** Critical functions whose change is treated as an access-control change. */
+const ACCESS_CONTROL_FUNCTIONS = new Set<string>([
+  'set_admin',
+  'set_administrator',
+  'transfer_admin',
+  'transfer_ownership',
+  'set_owner',
+  'set_authority',
+  'renounce_ownership',
+  'add_signer',
+  'remove_signer',
+  'set_threshold',
+  'upgrade',
+]);
+
+export interface SuspiciousContext {
+  /** When the upgrade executed. Used for midnight-timing detection. */
+  upgradeTime: Date;
+  /** Age (in ledgers) of the upgrader account at upgrade time, if known. */
+  upgraderAccountAgeLedgers?: number | null;
+  /** A vulnerability advisory for this contract disclosed shortly before the upgrade. */
+  recentVulnerability?: { id: string; title: string; publishedAt: Date | null } | null;
+  /** Critical functions changed by this upgrade (from the WASM diff). */
+  criticalFnChanges: string[];
+  governanceType: GovernanceType;
+}
+
+export interface SuspiciousResult {
+  flags: string[];
+  isSuspicious: boolean;
+  riskLevel: RiskLevel;
+}
+
+const FLAG_WEIGHTS: Record<string, number> = {
+  post_vuln_upgrade: 3,
+  critical_acl_change: 3,
+  new_account_upgrader: 2,
+  single_key_critical: 2,
+  midnight_upgrade: 1,
+};
+
+/**
+ * Flag suspicious upgrade patterns and roll the flags up into a risk level.
+ * Detects: same-day-after-vulnerability, newly-created upgrader account,
+ * unusual (midnight UTC) timing, and critical access-control changes —
+ * especially when pushed by a single key.
+ */
+export function detectSuspiciousActivity(ctx: SuspiciousContext): SuspiciousResult {
+  const flags: string[] = [];
+
+  if (ctx.recentVulnerability) flags.push('post_vuln_upgrade');
+
+  if (
+    ctx.upgraderAccountAgeLedgers != null &&
+    ctx.upgraderAccountAgeLedgers >= 0 &&
+    ctx.upgraderAccountAgeLedgers < NEW_ACCOUNT_LEDGERS
+  ) {
+    flags.push('new_account_upgrader');
+  }
+
+  const hourUtc = ctx.upgradeTime.getUTCHours();
+  if (hourUtc >= 0 && hourUtc < 4) flags.push('midnight_upgrade');
+
+  const aclChange = ctx.criticalFnChanges.some((fn) => ACCESS_CONTROL_FUNCTIONS.has(fn));
+  if (aclChange) flags.push('critical_acl_change');
+
+  if (aclChange && ctx.governanceType === 'single_key') flags.push('single_key_critical');
+
+  const score = flags.reduce((sum, flag) => sum + (FLAG_WEIGHTS[flag] ?? 1), 0);
+  let riskLevel: RiskLevel;
+  if (score === 0) riskLevel = 'none';
+  else if (score <= 1) riskLevel = 'low';
+  else if (score <= 3) riskLevel = 'medium';
+  else if (score <= 5) riskLevel = 'high';
+  else riskLevel = 'critical';
+
+  return { flags, isSuspicious: flags.length > 0, riskLevel };
+}
+
+// ── DB-backed signal gatherers ────────────────────────────────────────────────
+
+/**
+ * Gather governance signals for a contract upgrade from indexed on-chain data:
+ * multisig configuration (SignerSnapshot / StellarAccount) and DAO vote
+ * correlation (GovernanceProposal/Vote linked to the upgrade tx).
+ */
+export async function gatherGovernanceSignals(
+  contractAddress: string,
+  upgrader: string | undefined,
+  transactionHash: string | undefined,
+): Promise<GovernanceSignals> {
+  const signals: GovernanceSignals = {};
+
+  // Multisig: prefer the latest signer snapshot for the contract itself.
+  const snapshot = await prismaRead.signerSnapshot.findFirst({
+    where: { contractAddress },
+    orderBy: { ledgerSequence: 'desc' },
+    select: { signers: true, highThreshold: true },
+  });
+  if (snapshot) {
+    const signers = Array.isArray(snapshot.signers) ? (snapshot.signers as unknown[]) : [];
+    signals.signerCount = signers.length;
+    signals.threshold = snapshot.highThreshold;
+  } else if (upgrader) {
+    // Fall back to the upgrader's account-level signer configuration.
+    const account = await prismaRead.stellarAccount.findUnique({
+      where: { address: upgrader },
+      select: { numSigners: true, thresholds: true },
+    });
+    if (account) {
+      signals.signerCount = account.numSigners;
+      const thresholds = account.thresholds as Record<string, unknown> | null;
+      const high = thresholds && typeof thresholds.high === 'number' ? thresholds.high : undefined;
+      if (typeof high === 'number') signals.threshold = high;
+    }
+  }
+
+  // DAO correlation: a governance proposal executed by this upgrade tx, or the
+  // most recently executed proposal for the contract.
+  const proposal = transactionHash
+    ? await prismaRead.governanceProposal.findFirst({
+        where: { contractAddress, executionTxHash: transactionHash },
+        select: { proposalId: true },
+      })
+    : null;
+  const correlated =
+    proposal ??
+    (await prismaRead.governanceProposal.findFirst({
+      where: { contractAddress, status: 'executed' },
+      orderBy: { updatedAt: 'desc' },
+      select: { proposalId: true },
+    }));
+  if (correlated) {
+    signals.daoProposalId = correlated.proposalId;
+    signals.daoVotes = await prismaRead.governanceVote.count({
+      where: { contractAddress, proposalId: correlated.proposalId },
+    });
+  }
+
+  return signals;
+}
+
+/**
+ * Gather suspicious-activity context: recent vulnerability disclosures for the
+ * contract and the upgrader account's age.
+ */
+export async function gatherSuspiciousContext(
+  contractAddress: string,
+  upgrader: string | undefined,
+  upgradeTime: Date,
+): Promise<Pick<SuspiciousContext, 'recentVulnerability' | 'upgraderAccountAgeLedgers'>> {
+  const windowStart = new Date(upgradeTime.getTime() - VULN_WINDOW_MS);
+
+  const advisory = await prismaRead.threatAdvisory.findFirst({
+    where: {
+      affectedContracts: { has: contractAddress },
+      createdAt: { gte: windowStart, lte: upgradeTime },
+    },
+    orderBy: { createdAt: 'desc' },
+    select: { id: true, title: true, publishedAt: true },
+  });
+
+  let upgraderAccountAgeLedgers: number | null = null;
+  if (upgrader) {
+    const account = await prismaRead.stellarAccount.findUnique({
+      where: { address: upgrader },
+      select: { firstSeen: true, createdAt: true },
+    });
+    const since = account?.firstSeen ?? account?.createdAt ?? null;
+    if (since) {
+      const ageSeconds = Math.max(0, (upgradeTime.getTime() - since.getTime()) / 1000);
+      upgraderAccountAgeLedgers = Math.floor(ageSeconds / LEDGER_SECONDS);
+    }
+  }
+
+  return { recentVulnerability: advisory ?? null, upgraderAccountAgeLedgers };
+}
+
+// ── Orchestrator ──────────────────────────────────────────────────────────────
+
+export interface RecordUpgradeInput {
+  contractAddress: string;
+  newWasmHash: string;
+  ledgerSequence: number;
+  ledgerCloseTime: Date;
+  transactionHash?: string;
+  upgrader?: string;
+  /** Optional bytecode for the previous version (enables the WASM diff). */
+  previousWasm?: Buffer | null;
+  /** Optional bytecode for the new version (enables the WASM diff). */
+  newWasm?: Buffer | null;
+}
+
+/**
+ * Detect and record a WASM upgrade with the full governance-intelligence
+ * layer: diff classification, governance analysis, decentralisation score, and
+ * suspicious-activity flags. Idempotent — returns null when the hash is
+ * unchanged (no real upgrade) or the contract is unknown.
+ */
+export async function recordUpgradeWithIntelligence(input: RecordUpgradeInput) {
+  const {
+    contractAddress,
+    newWasmHash,
+    ledgerSequence,
+    ledgerCloseTime,
+    transactionHash,
+    upgrader,
+  } = input;
+
+  const contract = await prismaWrite.contract.findUnique({
+    where: { address: contractAddress },
+    select: { wasmHash: true },
+  });
+  // Contract must be known (FK target) and the hash must have actually changed.
+  if (!contract) return null;
+  const previousHash = contract.wasmHash ?? null;
+  if (previousHash === newWasmHash) return null;
+
+  // Phase 3: WASM diff (only when bytecode is available; otherwise hash-only).
+  let diff: WasmDiff | null = null;
+  if (input.newWasm) {
+    diff = diffWasm(input.previousWasm ?? null, input.newWasm);
+  }
+  const criticalFnChanges = diff?.functions.criticalChanges ?? [];
+
+  // Phase 2: governance analysis + decentralisation score.
+  const signals = await gatherGovernanceSignals(contractAddress, upgrader, transactionHash);
+  const governance = analyzeGovernance(signals);
+  const decentralizationScore = computeDecentralizationScore(governance);
+
+  // Phase 4: suspicious-activity detection.
+  const suspiciousCtx = await gatherSuspiciousContext(contractAddress, upgrader, ledgerCloseTime);
+  const suspicious = detectSuspiciousActivity({
+    upgradeTime: ledgerCloseTime,
+    criticalFnChanges,
+    governanceType: governance.governanceType,
+    ...suspiciousCtx,
+  });
+
+  const record = await prismaWrite.wasmUpgradeHistory.create({
+    data: {
+      contractAddress,
+      previousHash,
+      newHash: newWasmHash,
+      ledgerSequence,
+      ledgerCloseTime,
+      transactionHash,
+      upgrader,
+      upgraderAccountAgeLedgers: suspiciousCtx.upgraderAccountAgeLedgers ?? undefined,
+      changeClassification: diff?.severity,
+      changeSummary: diff?.summary,
+      diffStats: diff
+        ? ({
+            opcodeChurn: diff.opcodes.churn,
+            previousInstructions: diff.opcodes.previousTotal,
+            newInstructions: diff.opcodes.newTotal,
+            addedOpcodes: diff.opcodes.addedOpcodes,
+            removedOpcodes: diff.opcodes.removedOpcodes,
+            addedFunctions: diff.functions.added,
+            removedFunctions: diff.functions.removed,
+            signatureChangedFunctions: diff.functions.signatureChanged,
+          } as object)
+        : undefined,
+      criticalFnChanges,
+      governanceType: governance.governanceType,
+      signerCount: governance.signerCount || undefined,
+      threshold: governance.threshold || undefined,
+      timelockSeconds: governance.timelockSeconds || undefined,
+      daoProposalId: governance.daoProposalId ?? undefined,
+      decentralizationScore,
+      suspiciousFlags: suspicious.flags,
+      isSuspicious: suspicious.isSuspicious,
+      riskLevel: suspicious.riskLevel,
+    },
+  });
+
+  // Advance the contract's current WASM hash so the next change diffs cleanly.
+  await prismaWrite.contract.update({
+    where: { address: contractAddress },
+    data: { wasmHash: newWasmHash },
+  });
+
+  if (suspicious.isSuspicious) {
+    console.warn(
+      `[upgrade-governance] suspicious upgrade on ${contractAddress} at ledger ${ledgerSequence}: ` +
+        `${suspicious.riskLevel} risk [${suspicious.flags.join(', ')}]`,
+    );
+  }
+
+  return record;
+}

--- a/src/indexer/wasm-diff.ts
+++ b/src/indexer/wasm-diff.ts
@@ -1,0 +1,276 @@
+/**
+ * WASM Diff Engine — Contract Governance Intelligence (Phase 3).
+ *
+ * Produces an instruction-level diff between two contract WASM versions and
+ * classifies the change as minor / moderate / major / critical, plus a
+ * natural-language summary. The engine is split into pure functions that
+ * operate on already-extracted features (opcode indexes + function specs) so
+ * the classification logic is fully unit-testable without crafting binary
+ * WASM, and a `diffWasm` composer that wires the on-chain parsers in for the
+ * live indexing path.
+ */
+
+import { buildOpcodeIndex, type OpcodeIndex } from './wasm-decompiler';
+import { parseWasmSpec } from './wasm-spec';
+
+export type ChangeSeverity = 'minor' | 'moderate' | 'major' | 'critical';
+
+/**
+ * Functions whose addition, removal, or signature change carries
+ * access-control or value-movement risk. Changes touching these are always
+ * escalated to at least "major" and surfaced to the suspicious-activity layer.
+ */
+export const CRITICAL_FUNCTIONS = new Set<string>([
+  'upgrade',
+  'set_admin',
+  'set_administrator',
+  'transfer_admin',
+  'transfer_ownership',
+  'set_owner',
+  'set_authority',
+  'renounce_ownership',
+  'add_signer',
+  'remove_signer',
+  'set_threshold',
+  'mint',
+  'burn',
+  'clawback',
+  'pause',
+  'unpause',
+  'freeze',
+  'unfreeze',
+  'set_pause',
+  'withdraw',
+  'set_fee',
+  'migrate',
+  'initialize',
+  'init',
+]);
+
+/** A single contract function extracted from the WASM `contractspecv0` spec. */
+export interface ContractFn {
+  name: string;
+  /** Number of declared inputs — used to detect signature changes. */
+  inputCount: number;
+}
+
+export interface OpcodeDiff {
+  /** Opcodes present in the new version but not the old one. */
+  addedOpcodes: string[];
+  /** Opcodes present in the old version but gone from the new one. */
+  removedOpcodes: string[];
+  /** Total opcode count of the previous version. */
+  previousTotal: number;
+  /** Total opcode count of the new version. */
+  newTotal: number;
+  /**
+   * Fraction of instructions that changed (added/removed by frequency),
+   * 0 (identical) → 1 (completely rewritten).
+   */
+  churn: number;
+}
+
+export interface FunctionDiff {
+  added: string[];
+  removed: string[];
+  /** Functions whose input arity changed between versions. */
+  signatureChanged: string[];
+  /** Subset of the above touching access-control / value-movement functions. */
+  criticalChanges: string[];
+}
+
+export interface WasmDiff {
+  severity: ChangeSeverity;
+  summary: string;
+  opcodes: OpcodeDiff;
+  functions: FunctionDiff;
+  /** True when previousWasm was absent (initial deployment, not an upgrade). */
+  isInitial: boolean;
+}
+
+// ── Opcode diffing ────────────────────────────────────────────────────────────
+
+/**
+ * Diff two opcode indexes by frequency. Churn is the symmetric difference of
+ * opcode counts normalised by the larger program, so re-ordering identical
+ * instructions registers as no change while rewrites approach 1.
+ */
+export function diffOpcodes(previous: OpcodeIndex | null, next: OpcodeIndex): OpcodeDiff {
+  const prevFreq = previous?.frequency ?? {};
+  const nextFreq = next.frequency;
+
+  const prevOps = new Set(Object.keys(prevFreq));
+  const nextOps = new Set(Object.keys(nextFreq));
+
+  const addedOpcodes = [...nextOps].filter((op) => !prevOps.has(op)).sort();
+  const removedOpcodes = [...prevOps].filter((op) => !nextOps.has(op)).sort();
+
+  const allOps = new Set([...prevOps, ...nextOps]);
+  let changedBytes = 0;
+  for (const op of allOps) {
+    changedBytes += Math.abs((nextFreq[op] ?? 0) - (prevFreq[op] ?? 0));
+  }
+
+  const previousTotal = previous?.totalOpcodes ?? 0;
+  const newTotal = next.totalOpcodes;
+  const denom = Math.max(previousTotal, newTotal, 1);
+  const churn = Math.min(1, changedBytes / denom);
+
+  return { addedOpcodes, removedOpcodes, previousTotal, newTotal, churn };
+}
+
+// ── Function (spec) diffing ───────────────────────────────────────────────────
+
+/**
+ * Diff two contract function sets, flagging added/removed functions and
+ * signature (arity) changes, then isolating changes to critical functions.
+ */
+export function diffFunctions(previous: ContractFn[] | null, next: ContractFn[]): FunctionDiff {
+  const prevMap = new Map((previous ?? []).map((f) => [f.name, f]));
+  const nextMap = new Map(next.map((f) => [f.name, f]));
+
+  const added: string[] = [];
+  const removed: string[] = [];
+  const signatureChanged: string[] = [];
+
+  for (const [name, fn] of nextMap) {
+    const before = prevMap.get(name);
+    if (!before) added.push(name);
+    else if (before.inputCount !== fn.inputCount) signatureChanged.push(name);
+  }
+  for (const name of prevMap.keys()) {
+    if (!nextMap.has(name)) removed.push(name);
+  }
+
+  const criticalChanges = [...added, ...removed, ...signatureChanged]
+    .filter((name) => CRITICAL_FUNCTIONS.has(name))
+    .sort();
+
+  return {
+    added: added.sort(),
+    removed: removed.sort(),
+    signatureChanged: signatureChanged.sort(),
+    criticalChanges: [...new Set(criticalChanges)],
+  };
+}
+
+// ── Classification ────────────────────────────────────────────────────────────
+
+/**
+ * Classify the overall severity of a diff. Critical-function changes dominate;
+ * otherwise severity scales with opcode churn and function-set changes.
+ */
+export function classifyChange(opcodes: OpcodeDiff, functions: FunctionDiff): ChangeSeverity {
+  if (functions.criticalChanges.length > 0) return 'critical';
+
+  const fnChanges = functions.added.length + functions.removed.length + functions.signatureChanged.length;
+
+  // Removing public functions or large rewrites are major even without
+  // touching the critical set — they can break callers or hide new logic.
+  if (functions.removed.length > 0 || opcodes.churn >= 0.5 || fnChanges >= 5) return 'major';
+
+  if (opcodes.churn >= 0.15 || fnChanges >= 1 || opcodes.addedOpcodes.length > 0) return 'moderate';
+
+  return 'minor';
+}
+
+// ── Natural-language summary ──────────────────────────────────────────────────
+
+function joinList(items: string[], max = 5): string {
+  if (items.length <= max) return items.join(', ');
+  return `${items.slice(0, max).join(', ')} (+${items.length - max} more)`;
+}
+
+/** Render a human-readable summary of a diff for explorers and alerts. */
+export function summarizeChange(
+  severity: ChangeSeverity,
+  opcodes: OpcodeDiff,
+  functions: FunctionDiff,
+  isInitial: boolean,
+): string {
+  if (isInitial) {
+    return `Initial deployment — ${functions.added.length} function(s), ${opcodes.newTotal} instructions. No prior version to diff.`;
+  }
+
+  const parts: string[] = [];
+  const churnPct = Math.round(opcodes.churn * 100);
+  parts.push(`${severity.toUpperCase()} change: ~${churnPct}% of instructions modified`);
+
+  if (functions.criticalChanges.length) {
+    parts.push(`changes to critical function(s) ${joinList(functions.criticalChanges)}`);
+  }
+  if (functions.added.length) parts.push(`added ${joinList(functions.added)}`);
+  if (functions.removed.length) parts.push(`removed ${joinList(functions.removed)}`);
+  if (functions.signatureChanged.length) {
+    parts.push(`changed signature of ${joinList(functions.signatureChanged)}`);
+  }
+  if (opcodes.addedOpcodes.length) {
+    parts.push(`new instruction types ${joinList(opcodes.addedOpcodes)}`);
+  }
+  if (parts.length === 1) parts.push('no function-level or instruction-type changes detected');
+
+  return `${parts.join('; ')}.`;
+}
+
+// ── Composers ─────────────────────────────────────────────────────────────────
+
+/** Extract contract functions from a WASM binary's `contractspecv0` section. */
+export function extractFunctions(wasm: Buffer): ContractFn[] {
+  let entries;
+  try {
+    entries = parseWasmSpec(wasm);
+  } catch {
+    return [];
+  }
+
+  const fns: ContractFn[] = [];
+  for (const entry of entries) {
+    try {
+      if (entry.switch().name !== 'scSpecEntryFunctionV0') continue;
+      const fn = entry.functionV0();
+      const name = fn.name().toString();
+      const inputCount = fn.inputs().length;
+      if (name) fns.push({ name, inputCount });
+    } catch {
+      // Skip entries we cannot decode rather than failing the whole diff.
+    }
+  }
+  return fns;
+}
+
+/** Build an opcode index, tolerating malformed binaries. */
+function safeOpcodeIndex(wasm: Buffer | null): OpcodeIndex | null {
+  if (!wasm) return null;
+  try {
+    return buildOpcodeIndex(wasm);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Full diff between two contract WASM versions. `previousWasm` is null on the
+ * initial deployment. Returns a classified, summarised diff ready to persist.
+ */
+export function diffWasm(previousWasm: Buffer | null, newWasm: Buffer): WasmDiff {
+  const isInitial = previousWasm === null;
+
+  const prevIndex = safeOpcodeIndex(previousWasm);
+  const nextIndex = safeOpcodeIndex(newWasm) ?? {
+    distinctOpcodes: [],
+    totalOpcodes: 0,
+    frequency: {},
+    sequence: [],
+  };
+
+  const opcodes = diffOpcodes(prevIndex, nextIndex);
+  const functions = diffFunctions(
+    previousWasm ? extractFunctions(previousWasm) : null,
+    extractFunctions(newWasm),
+  );
+
+  const severity = isInitial ? 'major' : classifyChange(opcodes, functions);
+  const summary = summarizeChange(severity, opcodes, functions, isInitial);
+
+  return { severity, summary, opcodes, functions, isInitial };
+}

--- a/tests/contract-governance.test.ts
+++ b/tests/contract-governance.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect } from 'vitest';
+import {
+  diffOpcodes,
+  diffFunctions,
+  classifyChange,
+  summarizeChange,
+  type ContractFn,
+} from '../src/indexer/wasm-diff';
+import type { OpcodeIndex } from '../src/indexer/wasm-decompiler';
+import {
+  analyzeGovernance,
+  computeDecentralizationScore,
+  detectSuspiciousActivity,
+} from '../src/indexer/upgrade-governance';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+// Build a synthetic OpcodeIndex from a mnemonic→count map so diff/classify
+// logic can be exercised without crafting binary WASM (the binary parsers are
+// covered separately in wasm-decompiler.test.ts / wasm-spec.test.ts).
+function index(frequency: Record<string, number>): OpcodeIndex {
+  const total = Object.values(frequency).reduce((a, b) => a + b, 0);
+  return {
+    distinctOpcodes: Object.keys(frequency),
+    totalOpcodes: total,
+    frequency,
+    sequence: [],
+  };
+}
+
+function fns(spec: Array<[string, number]>): ContractFn[] {
+  return spec.map(([name, inputCount]) => ({ name, inputCount }));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5+ real-world upgrade scenarios, each asserting the WASM-diff classification,
+// the governance/decentralisation methodology, and the suspicious-activity
+// risk roll-up end to end.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Scenario 1: DAO-governed bug-fix patch (healthy upgrade)', () => {
+  // A small, vote-gated, time-delayed patch touching no critical functions.
+  const prev = index({ 'local.get': 40, 'i32.add': 20, call: 10 });
+  const next = index({ 'local.get': 41, 'i32.add': 21, call: 10 });
+  const fnDiff = diffFunctions(fns([['transfer', 3], ['balance', 1]]), fns([['transfer', 3], ['balance', 1]]));
+  const opDiff = diffOpcodes(prev, next);
+
+  it('classifies as a minor change', () => {
+    expect(classifyChange(opDiff, fnDiff)).toBe('minor');
+    expect(fnDiff.criticalChanges).toHaveLength(0);
+  });
+
+  it('scores high on decentralisation (DAO + timelock + multisig)', () => {
+    const gov = analyzeGovernance({
+      signerCount: 5,
+      threshold: 3,
+      timelockSeconds: 2 * 24 * 3600,
+      daoProposalId: 'prop-42',
+      daoVotes: 120,
+    });
+    expect(gov.governanceType).toBe('dao');
+    expect(gov.isMultisig).toBe(true);
+    expect(computeDecentralizationScore(gov)).toBeGreaterThanOrEqual(80);
+  });
+
+  it('raises no suspicious flags', () => {
+    const res = detectSuspiciousActivity({
+      upgradeTime: new Date('2026-03-10T14:00:00Z'),
+      criticalFnChanges: [],
+      governanceType: 'dao',
+      upgraderAccountAgeLedgers: 5_000_000,
+      recentVulnerability: null,
+    });
+    expect(res.isSuspicious).toBe(false);
+    expect(res.riskLevel).toBe('none');
+  });
+});
+
+describe('Scenario 2: single-key admin takeover via set_admin (critical)', () => {
+  // A single EOA swaps the admin function and pushes it at 02:00 UTC.
+  const fnDiff = diffFunctions(
+    fns([['transfer', 3], ['set_admin', 1]]),
+    fns([['transfer', 3], ['set_admin', 2]]), // signature changed
+  );
+  const opDiff = diffOpcodes(index({ call: 50 }), index({ call: 70, 'i64.store': 10 }));
+
+  it('classifies as critical (touches access-control function)', () => {
+    expect(fnDiff.criticalChanges).toContain('set_admin');
+    expect(classifyChange(opDiff, fnDiff)).toBe('critical');
+  });
+
+  it('scores low on decentralisation (single key, no timelock/DAO)', () => {
+    const gov = analyzeGovernance({ signerCount: 1, threshold: 1 });
+    expect(gov.governanceType).toBe('single_key');
+    expect(computeDecentralizationScore(gov)).toBeLessThanOrEqual(10);
+  });
+
+  it('flags single-key critical ACL change at midnight → high/critical risk', () => {
+    const res = detectSuspiciousActivity({
+      upgradeTime: new Date('2026-03-10T02:00:00Z'),
+      criticalFnChanges: ['set_admin'],
+      governanceType: 'single_key',
+      upgraderAccountAgeLedgers: 9_000_000,
+      recentVulnerability: null,
+    });
+    expect(res.flags).toEqual(
+      expect.arrayContaining(['critical_acl_change', 'single_key_critical', 'midnight_upgrade']),
+    );
+    expect(res.isSuspicious).toBe(true);
+    expect(['high', 'critical']).toContain(res.riskLevel);
+  });
+});
+
+describe('Scenario 3: same-day upgrade right after a vulnerability disclosure', () => {
+  // Moderate code change, but the timing relative to a fresh advisory is the
+  // signal — even with a reasonable multisig.
+  const fnDiff = diffFunctions(
+    fns([['swap', 4], ['quote', 2]]),
+    fns([['swap', 4], ['quote', 2], ['repair', 1]]),
+  );
+  const opDiff = diffOpcodes(index({ call: 100, 'local.get': 80 }), index({ call: 130, 'local.get': 90 }));
+
+  it('classifies as moderate (new non-critical function, modest churn)', () => {
+    expect(fnDiff.criticalChanges).toHaveLength(0);
+    expect(classifyChange(opDiff, fnDiff)).toBe('moderate');
+  });
+
+  it('flags post-vulnerability timing as suspicious', () => {
+    const res = detectSuspiciousActivity({
+      upgradeTime: new Date('2026-04-01T15:00:00Z'),
+      criticalFnChanges: [],
+      governanceType: 'multisig',
+      upgraderAccountAgeLedgers: 2_000_000,
+      recentVulnerability: { id: 'adv-9', title: 'Reentrancy in swap', publishedAt: new Date('2026-04-01T09:00:00Z') },
+    });
+    expect(res.flags).toContain('post_vuln_upgrade');
+    expect(res.isSuspicious).toBe(true);
+    expect(['medium', 'high', 'critical']).toContain(res.riskLevel);
+  });
+});
+
+describe('Scenario 4: brand-new account performs a full contract rewrite', () => {
+  // High opcode churn + functions removed, executed by a <1-day-old account.
+  const prev = index({ 'local.get': 100, 'i32.add': 100, call: 50 });
+  const next = index({ 'f64.mul': 120, 'memory.grow': 60, call: 20 });
+  const opDiff = diffOpcodes(prev, next);
+  const fnDiff = diffFunctions(
+    fns([['deposit', 2], ['withdraw', 2], ['legacy_claim', 1]]),
+    fns([['deposit', 2], ['withdraw', 2]]), // legacy_claim removed
+  );
+
+  it('classifies as major (large rewrite, public function removed)', () => {
+    expect(opDiff.churn).toBeGreaterThanOrEqual(0.5);
+    expect(fnDiff.removed).toContain('legacy_claim');
+    // withdraw is in the critical set but unchanged here; no critical change.
+    expect(classifyChange(opDiff, fnDiff)).toBe('major');
+  });
+
+  it('flags newly-created upgrader account', () => {
+    const res = detectSuspiciousActivity({
+      upgradeTime: new Date('2026-04-05T13:00:00Z'),
+      criticalFnChanges: [],
+      governanceType: 'single_key',
+      upgraderAccountAgeLedgers: 500, // ~40 min old, well under the 1-day threshold
+      recentVulnerability: null,
+    });
+    expect(res.flags).toContain('new_account_upgrader');
+    expect(res.isSuspicious).toBe(true);
+  });
+});
+
+describe('Scenario 5: well-governed multisig timelocked upgrade adding a feature', () => {
+  // Moderate change behind a 3-of-5 multisig with a 1-day timelock, no DAO.
+  const opDiff = diffOpcodes(index({ call: 200, 'local.get': 150 }), index({ call: 230, 'local.get': 150, 'i32.eqz': 5 }));
+  const fnDiff = diffFunctions(
+    fns([['stake', 2], ['unstake', 1]]),
+    fns([['stake', 2], ['unstake', 1], ['claim_rewards', 1]]),
+  );
+
+  it('classifies as moderate', () => {
+    expect(classifyChange(opDiff, fnDiff)).toBe('moderate');
+  });
+
+  it('scores mid/high decentralisation (multisig + timelock, no DAO)', () => {
+    const gov = analyzeGovernance({ signerCount: 5, threshold: 3, timelockSeconds: 24 * 3600 });
+    expect(gov.governanceType).toBe('timelock');
+    const score = computeDecentralizationScore(gov);
+    expect(score).toBeGreaterThanOrEqual(45);
+    expect(score).toBeLessThan(80); // no DAO component
+  });
+
+  it('raises no suspicious flags during business hours', () => {
+    const res = detectSuspiciousActivity({
+      upgradeTime: new Date('2026-04-10T16:30:00Z'),
+      criticalFnChanges: [],
+      governanceType: 'timelock',
+      upgraderAccountAgeLedgers: 3_000_000,
+      recentVulnerability: null,
+    });
+    expect(res.isSuspicious).toBe(false);
+  });
+});
+
+describe('Scenario 6: initial deployment is summarised, not diffed', () => {
+  // previous == null path: churn is measured against an empty baseline.
+  const opDiff = diffOpcodes(null, index({ call: 10, 'local.get': 30 }));
+  const fnDiff = diffFunctions(null, fns([['initialize', 1], ['transfer', 3]]));
+
+  it('treats every opcode/function as added', () => {
+    expect(opDiff.previousTotal).toBe(0);
+    expect(opDiff.churn).toBe(1);
+    expect(fnDiff.added).toEqual(['initialize', 'transfer']);
+    expect(fnDiff.removed).toHaveLength(0);
+  });
+
+  it('renders an initial-deployment summary', () => {
+    const summary = summarizeChange('major', opDiff, fnDiff, true);
+    expect(summary).toMatch(/Initial deployment/);
+    expect(summary).toMatch(/2 function/);
+  });
+});
+
+// ── Methodology guardrails ──────────────────────────────────────────────────
+
+describe('Decentralisation score methodology bounds', () => {
+  it('clamps to 0..100 and orders postures correctly', () => {
+    const single = computeDecentralizationScore(analyzeGovernance({ signerCount: 1, threshold: 1 }));
+    const multisig = computeDecentralizationScore(analyzeGovernance({ signerCount: 5, threshold: 3 }));
+    const timelocked = computeDecentralizationScore(
+      analyzeGovernance({ signerCount: 5, threshold: 3, timelockSeconds: 3 * 24 * 3600 }),
+    );
+    const dao = computeDecentralizationScore(
+      analyzeGovernance({ signerCount: 9, threshold: 6, timelockSeconds: 7 * 24 * 3600, daoProposalId: 'p', daoVotes: 300 }),
+    );
+
+    for (const s of [single, multisig, timelocked, dao]) {
+      expect(s).toBeGreaterThanOrEqual(0);
+      expect(s).toBeLessThanOrEqual(100);
+    }
+    expect(single).toBeLessThan(multisig);
+    expect(multisig).toBeLessThan(timelocked);
+    expect(timelocked).toBeLessThan(dao);
+  });
+
+  it('treats an unknown authority (0 signers) as fully centralised-unknown', () => {
+    const gov = analyzeGovernance({});
+    expect(gov.governanceType).toBe('unknown');
+    expect(computeDecentralizationScore(gov)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Contract Governance Intelligence** for Soroban contracts: upgrade detection wired into the indexer, WASM diffing, governance/decentralization scoring, and suspicious-activity alerting — across all four phases of the task.

Most of the algorithmic layer existed but was **dead code** (never invoked, unproven). This PR closes the two remaining gaps required by the acceptance criteria:

1. **Wires upgrade detection into the ingestion pipeline.** `eventIngestor` now dispatches upgrade-looking events (gated by a cheap symbol check via `looksLikeUpgrade`, so the contract lookup only runs for plausible upgrades) to `handleUpgradeEvent` → `recordUpgradeWithIntelligence`, non-blocking. Without this, no upgrades were actually detected/indexed at runtime.
2. **Adds 6 real upgrade-scenario tests** plus decentralization-methodology guardrails (`tests/contract-governance.test.ts`, 17 assertions).

## Phases

- **Phase 1 — Detection:** recognise WASM upgrades from indexed events, extract upgrader + previous/new WASM hash, best-effort bytecode fetch, store with full metadata.
- **Phase 2 — Governance:** single-key / multisig / timelock / DAO classification, signer + threshold + timelock + DAO-vote correlation, documented **0–100 decentralization score** (`DECENTRALIZATION_METHODOLOGY`).
- **Phase 3 — WASM Diff:** instruction-level opcode churn + function/signature diff, **minor / moderate / major / critical** classification, natural-language summary.
- **Phase 4 — Suspicious activity:** post-vulnerability timing, newly-created upgrader account, midnight (UTC) upgrades, critical access-control changes → weighted **risk level**.

## Scenarios covered by tests

1. DAO-governed bug-fix patch (healthy) → minor, score ≥80, no flags
2. Single-key `set_admin` takeover at 02:00 UTC → critical, score ≤10, high/critical risk
3. Same-day upgrade after a vulnerability disclosure → moderate, `post_vuln_upgrade`
4. Brand-new account performs a full rewrite → major, `new_account_upgrader`
5. Well-governed 3-of-5 multisig + timelock feature add → moderate, mid/high score, no flags
6. Initial deployment → summarised, not diffed

Plus methodology guardrails asserting score bounds and posture ordering (single < multisig < timelock < dao).

## Acceptance criteria

- [x] All upgrades detected and indexed (now wired into `eventIngestor`)
- [x] Governance identifies multi-sig vs single-key
- [x] WASM diff classifies changes correctly
- [x] Decentralization score methodology (documented + bounds-tested)
- [x] Suspicious upgrades detected and alerted
- [x] 5+ real upgrade scenarios analyzed (6 included)
- [x] `npm run build` passes

## Notes

- `WasmUpgradeHistory` schema is extended with provenance, diff, governance, and suspicious-activity fields. This table is managed via **`prisma db push`** (no prior migration history), so apply the schema delta with `npm run prisma:push` on deploy.
- Unrelated `package-lock.json` churn (an `fsevents` `dev: true` marker) was intentionally left out to keep the diff focused.

## Test plan

- `npm run build` → exit 0
- `npx vitest run tests/contract-governance.test.ts` → 17 passed

Closes #284 