### PR TITLE
Docs core five

### DIFF
--- a/src/api/contracts.ts
+++ b/src/api/contracts.ts
@@ -5,6 +5,13 @@ import { fetchContractSpec } from '../indexer/wasm-spec';
 import { abiRouter } from './abi';
 import { validateAddressParam, isValidStellarAddress } from '../middleware/sanitize';
 
+/**
+ * @swagger
+ * tags:
+ *   name: Contracts
+ *   description: Registered and indexed Soroban contracts, ABI metadata, and simulation
+ */
+
 export const contractRouter = Router();
 
 const abiSchema = z.object({
@@ -54,6 +61,40 @@ export async function getContractFunctionStats(address: string, since?: Date) {
   }));
 }
 
+/**
+ * @swagger
+ * /api/v1/contracts:
+ *   get:
+ *     summary: List all indexed contracts
+ *     tags: [Contracts]
+ *     responses:
+ *       200:
+ *         description: All contracts, newest first (summary fields only)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 description: Contract summary (subset of the full Contract record)
+ *                 properties:
+ *                   address: { type: string }
+ *                   name: { type: string, nullable: true }
+ *                   description: { type: string, nullable: true }
+ *                   isToken: { type: boolean }
+ *                   tokenSymbol: { type: string, nullable: true }
+ *               example:
+ *                 - address: CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5
+ *                   name: USD Coin
+ *                   description: USDC stablecoin token contract
+ *                   isToken: true
+ *                   tokenSymbol: USDC
+ *                 - address: CSWAP5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5
+ *                   name: StellarSwap Router
+ *                   description: AMM router contract
+ *                   isToken: false
+ *                   tokenSymbol: null
+ */
 // GET /contracts
 contractRouter.get('/', async (_req: Request, res: Response) => {
   const contracts = await prismaRead.contract.findMany({
@@ -63,6 +104,63 @@ contractRouter.get('/', async (_req: Request, res: Response) => {
   res.json(contracts);
 });
 
+/**
+ * @swagger
+ * /api/v1/contracts/{address}/stats:
+ *   get:
+ *     summary: Per-function call statistics for a contract
+ *     tags: [Contracts]
+ *     parameters:
+ *       - in: path
+ *         name: address
+ *         required: true
+ *         schema: { type: string }
+ *         description: Contract address
+ *       - in: query
+ *         name: since
+ *         schema: { type: string, format: date-time }
+ *         description: Only count calls at or after this ISO-8601 timestamp
+ *     responses:
+ *       200:
+ *         description: Function call counts, ordered by call count descending
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   functionName: { type: string }
+ *                   callCount: { type: integer, description: 'Number of calls to this function' }
+ *                   lastCalledAt:
+ *                     type: string
+ *                     format: date-time
+ *                     nullable: true
+ *                     description: Ledger close time of the most recent call
+ *               example:
+ *                 - functionName: swap
+ *                   callCount: 1543
+ *                   lastCalledAt: '2026-06-19T07:24:26.000Z'
+ *                 - functionName: add_liquidity
+ *                   callCount: 211
+ *                   lastCalledAt: '2026-06-18T22:10:00.000Z'
+ *       400:
+ *         description: Invalid query parameters
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Error'
+ *               example: { error: 'since must be a valid ISO-8601 datetime' }
+ *       404:
+ *         description: Contract not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Error'
+ *               example: { error: 'Contract not found' }
+ */
 // GET /contracts/:address/stats
 contractRouter.get('/:address/stats', validateAddressParam('address'), async (req: Request, res: Response) => {
   try {
@@ -82,6 +180,57 @@ contractRouter.get('/:address/stats', validateAddressParam('address'), async (re
   }
 });
 
+/**
+ * @swagger
+ * /api/v1/contracts/{address}:
+ *   get:
+ *     summary: Get a contract with its 10 most recent transactions and events
+ *     tags: [Contracts]
+ *     parameters:
+ *       - in: path
+ *         name: address
+ *         required: true
+ *         schema: { type: string }
+ *         description: Contract address
+ *     responses:
+ *       200:
+ *         description: The full contract record plus recent activity
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Contract'
+ *                 - type: object
+ *                   properties:
+ *                     transactions:
+ *                       type: array
+ *                       description: Up to 10 most recent transactions (summary fields)
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           hash: { type: string, example: '3389e9f0f1a4e32477b1c0d9e8a6f5b4c3d2e1f0a9b8c7d6e5f40312233445566' }
+ *                           functionName: { type: string, nullable: true, example: transfer }
+ *                           humanReadable: { type: string, nullable: true, example: 'GBZX...transferred 100 USDC' }
+ *                           ledgerSequence: { type: integer, example: 3168075 }
+ *                     events:
+ *                       type: array
+ *                       description: Up to 10 most recent events (summary fields)
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           id: { type: string, example: '3389e9f0f1a4e32477b1c0d9e8a6f5b4c3d2e1f0a9b8c7d6e5f40312233445566-AAAADwAAAAh0cmFuc2Zlcg==' }
+ *                           eventType: { type: string, example: transfer }
+ *                           decoded: { type: object, nullable: true, example: { from: 'GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI', amount: '1000000000' } }
+ *                           ledgerSequence: { type: integer, example: 3168075 }
+ *       404:
+ *         description: Contract not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Error'
+ *               example: { error: 'Contract not found' }
+ */
 // GET /contracts/:address
 contractRouter.get('/:address', validateAddressParam('address'), async (req: Request, res: Response) => {
   const contract = await prismaRead.contract.findUnique({
@@ -95,6 +244,44 @@ contractRouter.get('/:address', validateAddressParam('address'), async (req: Req
   res.json(contract);
 });
 
+/**
+ * @swagger
+ * /api/v1/contracts:
+ *   post:
+ *     summary: Register or update contract ABI metadata
+ *     tags: [Contracts]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [address]
+ *             properties:
+ *               address: { type: string, description: 'Stellar contract address (validated)' }
+ *               name: { type: string, maxLength: 256 }
+ *               description: { type: string, maxLength: 2048 }
+ *               abi: { type: object, description: 'ABI metadata (functions, events, types)' }
+ *             example:
+ *               address: CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5
+ *               name: USD Coin
+ *               description: USDC stablecoin token contract
+ *               abi: { functions: [{ name: transfer, inputs: [{ name: to, type: Address }, { name: amount, type: i128 }] }] }
+ *     responses:
+ *       201:
+ *         description: The created or updated contract
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/Contract' }
+ *       400:
+ *         description: Invalid request body
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Error'
+ *               example: { error: 'address is required' }
+ */
 // POST /contracts — register ABI metadata
 contractRouter.post('/', async (req: Request, res: Response) => {
   try {
@@ -119,9 +306,50 @@ import { analyzeSimulationFailure } from '../indexer/revert-analyzer';
 import { config } from '../config';
 
 /**
- * GET /contracts/:address/simulate/functions
- * Lists functions that can be simulated for a registered contract.
- * Combines ABI metadata with on-chain contract spec (WASM).
+ * @swagger
+ * /api/v1/contracts/{address}/simulate/functions:
+ *   get:
+ *     summary: List simulatable functions for a contract
+ *     description: Combines registered ABI metadata with the on-chain contract spec (WASM).
+ *     tags: [Contracts]
+ *     parameters:
+ *       - in: path
+ *         name: address
+ *         required: true
+ *         schema: { type: string }
+ *         description: Contract address
+ *     responses:
+ *       200:
+ *         description: Merged list of callable functions
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 address: { type: string, example: CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5 }
+ *                 name: { type: string, nullable: true, example: 'USD Coin' }
+ *                 isToken: { type: boolean, example: true }
+ *                 functions:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       name: { type: string, example: transfer }
+ *                       inputs:
+ *                         type: array
+ *                         items: { type: object }
+ *                         description: Function input descriptors
+ *                         example: [{ name: to, type: Address }, { name: amount, type: i128 }]
+ *                       simulatable: { type: boolean, example: true }
+ *                 wasmSpecAvailable: { type: boolean, description: 'Whether an on-chain WASM spec was found', example: true }
+ *       404:
+ *         description: Contract not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Error'
+ *               example: { error: 'Contract not found' }
  */
 contractRouter.get('/:address/simulate/functions', validateAddressParam('address'), async (req: Request, res: Response) => {
   const { address } = req.params;
@@ -169,9 +397,114 @@ contractRouter.get('/:address/simulate/functions', validateAddressParam('address
 });
 
 /**
- * POST /contracts/:address/simulate/:functionName
- * Quick simulation of a specific function by providing args as JSON array.
- * Body: { args: [...ScVal JSON], txEnvelope?: "base64-xdr" }
+ * @swagger
+ * /api/v1/contracts/{address}/simulate/{functionName}:
+ *   post:
+ *     summary: Simulate a contract function call
+ *     description: >-
+ *       Simulates a function invocation against the Soroban RPC using a provided
+ *       transaction envelope, returning an execution trace and (on failure) a
+ *       revert analysis.
+ *     tags: [Contracts]
+ *     parameters:
+ *       - in: path
+ *         name: address
+ *         required: true
+ *         schema: { type: string }
+ *         description: Contract address
+ *       - in: path
+ *         name: functionName
+ *         required: true
+ *         schema: { type: string }
+ *         description: Name of the function to simulate
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [txEnvelope]
+ *             properties:
+ *               txEnvelope:
+ *                 type: string
+ *                 description: Base64-encoded TransactionEnvelope XDR invoking the function (required)
+ *               args:
+ *                 type: array
+ *                 items: { type: object }
+ *                 description: Optional ScVal JSON arguments (informational; the envelope is authoritative)
+ *             example:
+ *               txEnvelope: AAAAAgAAAAAjbb31xRk1h0AAAGQAA8AAAAAAAAAAAAAAAE=
+ *               args: []
+ *     responses:
+ *       200:
+ *         description: Simulation succeeded
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 contract: { type: string, example: CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5 }
+ *                 function: { type: string, example: swap }
+ *                 status: { type: string, enum: [success, failed], example: success }
+ *                 trace: { $ref: '#/components/schemas/SimulationTrace' }
+ *                 revertAnalysis: { type: object, nullable: true, description: 'Always null on success', example: null }
+ *       422:
+ *         description: Simulation executed but the function reverted/failed
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 contract: { type: string, example: CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5 }
+ *                 function: { type: string, example: swap }
+ *                 status: { type: string, enum: [success, failed], example: failed }
+ *                 trace: { $ref: '#/components/schemas/SimulationTrace' }
+ *                 revertAnalysis: { $ref: '#/components/schemas/RevertAnalysis' }
+ *               example:
+ *                 contract: CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5
+ *                 function: swap
+ *                 status: failed
+ *                 trace:
+ *                   steps: []
+ *                   totalGas: 0
+ *                   totalMemory: 0
+ *                   callGraph: { nodes: [], edges: [] }
+ *                   events: []
+ *                   success: false
+ *                   error: 'HostError: Error(Contract, #3)'
+ *                 revertAnalysis:
+ *                   errorType: contract_error
+ *                   message: 'Contract call failed: insufficient balance'
+ *                   detail: 'Error(Contract, #3)'
+ *                   callStack:
+ *                     - { depth: 0, contractId: CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5, function: swap }
+ *                   suggestedFixes:
+ *                     - 'Ensure the account has sufficient balance before calling swap.'
+ *       400:
+ *         description: Missing txEnvelope or invalid transaction XDR
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error: { type: string, example: 'txEnvelope (base64 XDR) is required.' }
+ *                 hint: { type: string, description: 'Present when txEnvelope is missing', example: 'Simulate swap on CALLD... by constructing a TransactionEnvelope XDR.' }
+ *                 detail: { type: string, description: 'Present when the XDR is invalid', example: 'Invalid transaction XDR' }
+ *               example:
+ *                 error: txEnvelope (base64 XDR) is required. Build a transaction calling the function and pass the XDR.
+ *                 hint: Simulate swap on CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5 by constructing a TransactionEnvelope XDR that invokes this function.
+ *       502:
+ *         description: RPC simulation failed
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error: { type: string, example: 'RPC simulation failed' }
+ *                 detail: { type: string, example: 'timeout' }
+ *               example:
+ *                 error: RPC simulation failed
+ *                 detail: timeout
  */
 contractRouter.post('/:address/simulate/:functionName', validateAddressParam('address'), async (req: Request, res: Response) => {
   const { address, functionName } = req.params;

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -2,6 +2,13 @@ import { Router, Request, Response } from 'express';
 import { prismaRead as prisma } from '../db';
 import { z } from 'zod';
 
+/**
+ * @swagger
+ * tags:
+ *   name: Events
+ *   description: Decoded Soroban contract events
+ */
+
 export const eventRouter = Router();
 
 const paginationSchema = z.object({
@@ -9,6 +16,89 @@ const paginationSchema = z.object({
   limit: z.coerce.number().min(1).max(100).default(20),
 });
 
+/**
+ * @swagger
+ * /api/v1/events:
+ *   get:
+ *     summary: List decoded contract events
+ *     tags: [Events]
+ *     parameters:
+ *       - in: query
+ *         name: contract
+ *         schema: { type: string }
+ *         description: Filter by contract address (exact match)
+ *       - in: query
+ *         name: type
+ *         schema: { type: string }
+ *         description: Filter by event type (e.g. transfer, swap, mint, burn, custom)
+ *       - in: query
+ *         name: topic
+ *         schema: { type: string }
+ *         description: Filter by decoded first-topic symbol (e.g. "transfer", "mint_pass")
+ *       - in: query
+ *         name: page
+ *         schema: { type: integer, minimum: 1, default: 1 }
+ *         description: 1-based page number (offset pagination)
+ *       - in: query
+ *         name: limit
+ *         schema: { type: integer, minimum: 1, maximum: 100, default: 20 }
+ *         description: Page size
+ *     responses:
+ *       200:
+ *         description: Paginated list of events (summary fields only)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     description: Event summary (subset of the full Event record)
+ *                     properties:
+ *                       id: { type: string }
+ *                       transactionHash: { type: string }
+ *                       contractAddress: { type: string }
+ *                       eventType: { type: string, description: 'transfer | swap | mint | burn | custom' }
+ *                       topicSymbol: { type: string, nullable: true }
+ *                       decoded: { type: object, nullable: true, description: 'Human-readable decoded event payload' }
+ *                       ledgerSequence: { type: integer }
+ *                       ledgerCloseTime: { type: string, format: date-time }
+ *                 total: { type: integer, description: 'Total number of events matching the filter' }
+ *                 page: { type: integer }
+ *                 limit: { type: integer }
+ *               example:
+ *                 data:
+ *                   - id: '3389e9f0f1a4e32477b1c0d9e8a6f5b4c3d2e1f0a9b8c7d6e5f40312233445566-AAAADwAAAAh0cmFuc2Zlcg=='
+ *                     transactionHash: '3389e9f0f1a4e32477b1c0d9e8a6f5b4c3d2e1f0a9b8c7d6e5f40312233445566'
+ *                     contractAddress: CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5
+ *                     eventType: transfer
+ *                     topicSymbol: transfer
+ *                     decoded: { from: 'GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI', amount: '1000000000' }
+ *                     ledgerSequence: 3168075
+ *                     ledgerCloseTime: '2026-06-19T07:24:26.000Z'
+ *                   - id: '3389e9f0f1a4e32477b1c0d9e8a6f5b4c3d2e1f0a9b8c7d6e5f40312233445566-AAAADwAAAARzd2Fw'
+ *                     transactionHash: '3389e9f0f1a4e32477b1c0d9e8a6f5b4c3d2e1f0a9b8c7d6e5f40312233445566'
+ *                     contractAddress: CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5
+ *                     eventType: swap
+ *                     topicSymbol: swap
+ *                     decoded: { amount_in: '1000000000', amount_out: '987000000' }
+ *                     ledgerSequence: 3168074
+ *                     ledgerCloseTime: '2026-06-19T07:23:20.000Z'
+ *                 total: 1543
+ *                 page: 1
+ *                 limit: 20
+ *       400:
+ *         description: Invalid query parameters
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Error'
+ *               example:
+ *                 error: limit must be less than or equal to 100
+ */
 // GET /events?contract=&type=&topic=&page=1
 eventRouter.get('/', async (req: Request, res: Response) => {
   try {
@@ -48,6 +138,35 @@ eventRouter.get('/', async (req: Request, res: Response) => {
   }
 });
 
+/**
+ * @swagger
+ * /api/v1/events/{id}:
+ *   get:
+ *     summary: Get a single event by ID
+ *     tags: [Events]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *         description: Unique event identifier
+ *     responses:
+ *       200:
+ *         description: The full event record
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Event'
+ *       404:
+ *         description: Event not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Error'
+ *               example:
+ *                 error: Event not found
+ */
 // GET /events/:id
 eventRouter.get('/:id', async (req: Request, res: Response) => {
   const event = await prisma.event.findUnique({ where: { id: req.params.id } });

--- a/src/api/tokens.ts
+++ b/src/api/tokens.ts
@@ -5,8 +5,31 @@ import { validateAddressParam } from '../middleware/sanitize';
 import { rpc } from '../indexer/rpc';
 import { config } from '../config';
 
+/**
+ * @swagger
+ * tags:
+ *   name: Tokens
+ *   description: SEP-41 token contracts, transfers, and balances
+ */
+
 export const tokenRouter = Router();
 
+/**
+ * @swagger
+ * /api/v1/tokens:
+ *   get:
+ *     summary: List all SEP-41 tokens
+ *     description: Returns every contract flagged as a token, sorted by symbol.
+ *     tags: [Tokens]
+ *     responses:
+ *       200:
+ *         description: List of tokens (summary fields only)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items: { $ref: '#/components/schemas/Token' }
+ */
 // GET /tokens — list all SEP-41 tokens
 tokenRouter.get('/', async (_req: Request, res: Response) => {
   const tokens = await prisma.contract.findMany({
@@ -22,6 +45,44 @@ tokenRouter.get('/', async (_req: Request, res: Response) => {
   res.json(tokens);
 });
 
+/**
+ * @swagger
+ * /api/v1/tokens/{address}:
+ *   get:
+ *     summary: Get a single token by contract address
+ *     description: Returns the full contract record for a contract flagged as a token.
+ *     tags: [Tokens]
+ *     parameters:
+ *       - in: path
+ *         name: address
+ *         required: true
+ *         schema: { type: string }
+ *         description: Token contract address
+ *     responses:
+ *       200:
+ *         description: The full contract record for this token
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/Contract' }
+ *       400:
+ *         description: Invalid Stellar address
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Error'
+ *               example:
+ *                 error: 'Invalid Stellar address: GBADDRESS'
+ *       404:
+ *         description: Contract is not a registered token
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Error'
+ *               example:
+ *                 error: 'Token not found'
+ */
 // GET /tokens/:address
 tokenRouter.get('/:address', validateAddressParam('address'), async (req: Request, res: Response) => {
   const token = await prisma.contract.findFirst({
@@ -31,6 +92,51 @@ tokenRouter.get('/:address', validateAddressParam('address'), async (req: Reques
   res.json(token);
 });
 
+/**
+ * @swagger
+ * /api/v1/tokens/{address}/transfers:
+ *   get:
+ *     summary: List recent transfer events for a token
+ *     description: Returns up to 50 of the most recent transfer events for this token, newest first.
+ *     tags: [Tokens]
+ *     parameters:
+ *       - in: path
+ *         name: address
+ *         required: true
+ *         schema: { type: string }
+ *         description: Token contract address
+ *     responses:
+ *       200:
+ *         description: Up to 50 transfer events (summary fields only)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 description: Transfer event summary (subset of the full Event record)
+ *                 properties:
+ *                   id: { type: string }
+ *                   transactionHash: { type: string }
+ *                   decoded: { type: object, nullable: true, description: 'Decoded transfer payload (from, to, amount)' }
+ *                   ledgerSequence: { type: integer }
+ *                   ledgerCloseTime: { type: string, format: date-time }
+ *               example:
+ *                 - id: '3389e9f0f1a4e32477b1c0d9e8a6f5b4c3d2e1f0a9b8c7d6e5f40312233445566-AAAADwAAAAh0cmFuc2Zlcg=='
+ *                   transactionHash: '3389e9f0f1a4e32477b1c0d9e8a6f5b4c3d2e1f0a9b8c7d6e5f40312233445566'
+ *                   decoded: { from: 'GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI', to: 'CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5', amount: '1000000000' }
+ *                   ledgerSequence: 3168075
+ *                   ledgerCloseTime: '2026-06-19T07:24:26.000Z'
+ *       400:
+ *         description: Invalid Stellar address
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Error'
+ *               example:
+ *                 error: 'Invalid Stellar address: GBADDRESS'
+ */
 // GET /tokens/:address/transfers
 tokenRouter.get('/:address/transfers', validateAddressParam('address'), async (req: Request, res: Response) => {
   const events = await prisma.event.findMany({
@@ -43,13 +149,75 @@ tokenRouter.get('/:address/transfers', validateAddressParam('address'), async (r
 });
 
 /**
- * GET /tokens/:address/balance/:account
- * Query the current balance of an account for a given token contract.
- * Calls SEP-41 balance(address) via Soroban RPC simulateTransaction.
- *
- * Returns: { address, account, balance, symbol, decimals }
- * Returns 404 if the contract is not a registered token.
- * Returns 502 if RPC simulation fails.
+ * @swagger
+ * /api/v1/tokens/{address}/balance/{account}:
+ *   get:
+ *     summary: Get an account's token balance
+ *     description: >-
+ *       Reads the current balance by calling the SEP-41 `balance(address)` function
+ *       through a Soroban RPC simulation. The balance is returned in raw base units;
+ *       apply `decimals` to get the display value.
+ *     tags: [Tokens]
+ *     parameters:
+ *       - in: path
+ *         name: address
+ *         required: true
+ *         schema: { type: string }
+ *         description: Token contract address
+ *       - in: path
+ *         name: account
+ *         required: true
+ *         schema: { type: string }
+ *         description: Account address (G...) to read the balance for
+ *     responses:
+ *       200:
+ *         description: The account's current token balance
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 address: { type: string, description: 'Token contract address' }
+ *                 account: { type: string, description: 'Account the balance was read for' }
+ *                 balance: { type: string, description: 'Raw balance in base units; apply decimals to get the display value' }
+ *                 symbol: { type: string, nullable: true }
+ *                 decimals: { type: integer, nullable: true }
+ *               example:
+ *                 address: CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5
+ *                 account: GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI
+ *                 balance: '1000000000'
+ *                 symbol: USDC
+ *                 decimals: 7
+ *       400:
+ *         description: Invalid Stellar address (contract or account)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Error'
+ *               example:
+ *                 error: 'Invalid Stellar address: GBADDRESS'
+ *       404:
+ *         description: Contract is not a registered token
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Error'
+ *               example:
+ *                 error: 'Token not found'
+ *       502:
+ *         description: Soroban RPC simulation failed or returned an unusable response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error: { type: string }
+ *                 detail: { type: string, description: 'Underlying RPC error or reason' }
+ *               example:
+ *                 error: RPC simulation failed
+ *                 detail: 'HostError: Error(Contract, #5)'
  */
 tokenRouter.get('/:address/balance/:account', validateAddressParam('address'), validateAddressParam('account'), async (req: Request, res: Response) => {
   const { address, account } = req.params;

--- a/src/api/transactions.ts
+++ b/src/api/transactions.ts
@@ -3,6 +3,13 @@ import { prismaRead as prisma } from '../db';
 import { getBn254ExemptionByTx } from '../indexer/bn254-tracker';
 import { z } from 'zod';
 
+/**
+ * @swagger
+ * tags:
+ *   name: Transactions
+ *   description: Indexed Soroban transactions with human-readable decoding
+ */
+
 export const transactionRouter = Router();
 
 const TX_SELECT = {
@@ -35,6 +42,89 @@ const listSchema = z.object({
   ledgerMax: z.coerce.number().int().min(0).optional(),
 });
 
+/**
+ * @swagger
+ * /api/v1/transactions:
+ *   get:
+ *     summary: List indexed transactions (cursor- or offset-paginated)
+ *     tags: [Transactions]
+ *     parameters:
+ *       - in: query
+ *         name: cursor
+ *         schema: { type: integer, minimum: 0 }
+ *         description: >-
+ *           Ledger sequence cursor (preferred for large datasets). When set,
+ *           returns rows with ledgerSequence < cursor in descending order and the
+ *           response uses the cursor envelope.
+ *       - in: query
+ *         name: page
+ *         schema: { type: integer, minimum: 1, default: 1 }
+ *         description: 1-based page number (offset pagination; ignored when cursor is set)
+ *       - in: query
+ *         name: limit
+ *         schema: { type: integer, minimum: 1, maximum: 100, default: 20 }
+ *         description: Page size
+ *       - in: query
+ *         name: contract
+ *         schema: { type: string }
+ *         description: Filter by contract address (exact match)
+ *       - in: query
+ *         name: account
+ *         schema: { type: string }
+ *         description: Filter by source account
+ *       - in: query
+ *         name: status
+ *         schema: { type: string }
+ *         description: Filter by status (success | failed)
+ *       - in: query
+ *         name: ledgerMin
+ *         schema: { type: integer, minimum: 0 }
+ *         description: Inclusive lower bound on ledger sequence
+ *       - in: query
+ *         name: ledgerMax
+ *         schema: { type: integer, minimum: 0 }
+ *         description: Inclusive upper bound on ledger sequence
+ *     responses:
+ *       200:
+ *         description: >-
+ *           Paginated transactions. Returns the cursor envelope when `cursor` is
+ *           supplied, otherwise the offset envelope.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               oneOf:
+ *                 - title: CursorPage
+ *                   type: object
+ *                   properties:
+ *                     data:
+ *                       type: array
+ *                       items: { $ref: '#/components/schemas/Transaction' }
+ *                     nextCursor:
+ *                       type: integer
+ *                       nullable: true
+ *                       description: ledgerSequence to pass as the next `cursor`, or null when there are no more rows
+ *                       example: 3168074
+ *                     hasNext: { type: boolean, example: true }
+ *                 - title: OffsetPage
+ *                   type: object
+ *                   properties:
+ *                     data:
+ *                       type: array
+ *                       items: { $ref: '#/components/schemas/Transaction' }
+ *                     total: { type: integer, description: 'Total transactions matching the filter', example: 1543 }
+ *                     page: { type: integer, example: 1 }
+ *                     limit: { type: integer, example: 20 }
+ *                     pages: { type: integer, description: 'Total number of pages (ceil(total / limit))', example: 78 }
+ *       400:
+ *         description: Invalid query parameters
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Error'
+ *               example:
+ *                 error: limit must be less than or equal to 100
+ */
 // GET /transactions
 // Cursor mode:  ?cursor=<ledger>&limit=20&contract=...
 // Offset mode:  ?page=2&limit=20&contract=...
@@ -91,6 +181,62 @@ transactionRouter.get('/', async (req: Request, res: Response) => {
   }
 });
 
+/**
+ * @swagger
+ * /api/v1/transactions/{hash}:
+ *   get:
+ *     summary: Get a single transaction by hash
+ *     tags: [Transactions]
+ *     parameters:
+ *       - in: path
+ *         name: hash
+ *         required: true
+ *         schema: { type: string }
+ *         description: Transaction hash
+ *     responses:
+ *       200:
+ *         description: The transaction, its decoded events, and an optional ZK gas-exemption summary
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Transaction'
+ *                 - type: object
+ *                   properties:
+ *                     events:
+ *                       type: array
+ *                       items: { $ref: '#/components/schemas/Event' }
+ *                       description: Full decoded events emitted by this transaction
+ *                     bn254GasExemption:
+ *                       type: object
+ *                       nullable: true
+ *                       description: >-
+ *                         CAP-0080 BN254 host-function gas-exemption summary, or null when
+ *                         the transaction used no host-accelerated ZK operations.
+ *                       properties:
+ *                         bn254Ops:
+ *                           type: array
+ *                           items: { type: string }
+ *                           description: 'Detected BN254 op types, e.g. ["bn254_add", "bn254_pairing_check"]'
+ *                           example: ['bn254_pairing_check', 'bn254_multiscalar_mul']
+ *                         opCount: { type: integer, example: 2 }
+ *                         feeCharged: { type: string, nullable: true, description: 'Actual fee charged (stroops)', example: '100' }
+ *                         estimatedWasmFee: { type: string, nullable: true, description: 'Estimated equivalent Wasm fee (stroops)', example: '385' }
+ *                         stroopSavings: { type: string, nullable: true, description: 'Net stroops saved', example: '285' }
+ *                         savingsPct: { type: number, nullable: true, description: 'Savings percentage (e.g. 74.0)', example: 74.0 }
+ *                         cpuInstructions: { type: integer, example: 24500000 }
+ *                         msmComplexity: { type: integer, description: 'Multi-scalar multiplication complexity factor', example: 8 }
+ *                         humanReadable: { type: string, example: 'Saved 74% in processing fees via host ZK acceleration (bn254_pairing_check, bn254_multiscalar_mul)' }
+ *       404:
+ *         description: Transaction not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Error'
+ *               example:
+ *                 error: Transaction not found
+ */
 // GET /transactions/:hash
 transactionRouter.get('/:hash', async (req: Request, res: Response) => {
   const tx = await prisma.transaction.findUnique({

--- a/src/api/wallets.ts
+++ b/src/api/wallets.ts
@@ -5,6 +5,13 @@ import { validateAddressParam } from '../middleware/sanitize';
 import axios from 'axios';
 import { config } from '../config';
 
+/**
+ * @swagger
+ * tags:
+ *   name: Wallets
+ *   description: Per-account activity - Soroban transactions, events, and unified history
+ */
+
 export const walletRouter = Router();
 
 const paginationSchema = z.object({
@@ -12,73 +19,291 @@ const paginationSchema = z.object({
   limit: z.coerce.number().min(1).max(100).default(20),
 });
 
+/**
+ * @swagger
+ * /api/v1/wallets/{address}/transactions:
+ *   get:
+ *     summary: List a wallet's Soroban transactions (offset-paginated)
+ *     description: Transactions where this address is the source account, newest first.
+ *     tags: [Wallets]
+ *     parameters:
+ *       - in: path
+ *         name: address
+ *         required: true
+ *         schema: { type: string }
+ *         description: Stellar account address (G...) whose transactions to list
+ *       - in: query
+ *         name: page
+ *         schema: { type: integer, minimum: 1, default: 1 }
+ *         description: 1-based page number (offset pagination)
+ *       - in: query
+ *         name: limit
+ *         schema: { type: integer, minimum: 1, maximum: 100, default: 20 }
+ *         description: Page size
+ *     responses:
+ *       200:
+ *         description: Paginated transactions for the wallet (summary fields only)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     description: Transaction summary (subset of the full Transaction record)
+ *                     properties:
+ *                       hash: { type: string }
+ *                       ledgerSequence: { type: integer }
+ *                       ledgerCloseTime: { type: string, format: date-time }
+ *                       contractAddress: { type: string, nullable: true }
+ *                       functionName: { type: string, nullable: true }
+ *                       status: { type: string, description: 'success | failed' }
+ *                       humanReadable: { type: string, nullable: true }
+ *                 total: { type: integer, description: 'Total transactions sourced by this wallet' }
+ *                 page: { type: integer }
+ *                 limit: { type: integer }
+ *               example:
+ *                 data:
+ *                   - hash: '3389e9f0f1a4e32477b1c0d9e8a6f5b4c3d2e1f0a9b8c7d6e5f40312233445566'
+ *                     ledgerSequence: 3168075
+ *                     ledgerCloseTime: '2026-06-19T07:24:26.000Z'
+ *                     contractAddress: CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5
+ *                     functionName: swap
+ *                     status: success
+ *                     humanReadable: 'GBZX...swapped 100 USDC for 98.7 XLM on StellarSwap'
+ *                 total: 42
+ *                 page: 1
+ *                 limit: 20
+ *       400:
+ *         description: Invalid Stellar address or query parameters
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Error'
+ *               example:
+ *                 error: 'Invalid Stellar address: GBADDRESS'
+ */
 // GET /wallets/:address/transactions
-walletRouter.get('/:address/transactions', validateAddressParam('address'), async (req: Request, res: Response) => {
-  try {
-    const { page, limit } = paginationSchema.parse(req.query);
-    const skip = (page - 1) * limit;
+walletRouter.get(
+  '/:address/transactions',
+  validateAddressParam('address'),
+  async (req: Request, res: Response) => {
+    try {
+      const { page, limit } = paginationSchema.parse(req.query);
+      const skip = (page - 1) * limit;
 
-    const [transactions, total] = await Promise.all([
-      prisma.transaction.findMany({
-        where: { sourceAccount: req.params.address },
-        orderBy: { ledgerSequence: 'desc' },
-        skip,
-        take: limit,
-        select: {
-          hash: true,
-          ledgerSequence: true,
-          ledgerCloseTime: true,
-          contractAddress: true,
-          functionName: true,
-          status: true,
-          humanReadable: true,
-        },
-      }),
-      prisma.transaction.count({ where: { sourceAccount: req.params.address } }),
-    ]);
+      const [transactions, total] = await Promise.all([
+        prisma.transaction.findMany({
+          where: { sourceAccount: req.params.address },
+          orderBy: { ledgerSequence: 'desc' },
+          skip,
+          take: limit,
+          select: {
+            hash: true,
+            ledgerSequence: true,
+            ledgerCloseTime: true,
+            contractAddress: true,
+            functionName: true,
+            status: true,
+            humanReadable: true,
+          },
+        }),
+        prisma.transaction.count({ where: { sourceAccount: req.params.address } }),
+      ]);
 
-    res.json({ data: transactions, total, page, limit });
-  } catch (e) {
-    res.status(400).json({ error: String(e) });
-  }
-});
+      res.json({ data: transactions, total, page, limit });
+    } catch (e) {
+      res.status(400).json({ error: String(e) });
+    }
+  },
+);
 
+/**
+ * @swagger
+ * /api/v1/wallets/{address}/events:
+ *   get:
+ *     summary: List events involving a wallet (offset-paginated)
+ *     description: >-
+ *       Full event records whose decoded payload references this address as either
+ *       `from` or `to`, newest first.
+ *     tags: [Wallets]
+ *     parameters:
+ *       - in: path
+ *         name: address
+ *         required: true
+ *         schema: { type: string }
+ *         description: Stellar account address (G...) referenced in the event payload
+ *       - in: query
+ *         name: page
+ *         schema: { type: integer, minimum: 1, default: 1 }
+ *         description: 1-based page number (offset pagination)
+ *       - in: query
+ *         name: limit
+ *         schema: { type: integer, minimum: 1, maximum: 100, default: 20 }
+ *         description: Page size
+ *     responses:
+ *       200:
+ *         description: Paginated full event records involving the wallet
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items: { $ref: '#/components/schemas/Event' }
+ *                 total: { type: integer, description: 'Total events involving this wallet', example: 17 }
+ *                 page: { type: integer, example: 1 }
+ *                 limit: { type: integer, example: 20 }
+ *       400:
+ *         description: Invalid Stellar address or query parameters
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Error'
+ *               example:
+ *                 error: 'Invalid Stellar address: GBADDRESS'
+ */
 // GET /wallets/:address/events — events involving this address
-walletRouter.get('/:address/events', validateAddressParam('address'), async (req: Request, res: Response) => {
-  try {
-    const { page, limit } = paginationSchema.parse(req.query);
-    const skip = (page - 1) * limit;
-    const address = req.params.address;
+walletRouter.get(
+  '/:address/events',
+  validateAddressParam('address'),
+  async (req: Request, res: Response) => {
+    try {
+      const { page, limit } = paginationSchema.parse(req.query);
+      const skip = (page - 1) * limit;
+      const address = req.params.address;
 
-    // Fetch events where decoded JSON contains this address as from/to
-    const [events, total] = await Promise.all([
-      prisma.event.findMany({
-        where: {
-          OR: [
-            { decoded: { path: ['from'], equals: address } },
-            { decoded: { path: ['to'], equals: address } },
-          ],
-        },
-        orderBy: { ledgerSequence: 'desc' },
-        skip,
-        take: limit,
-      }),
-      prisma.event.count({
-        where: {
-          OR: [
-            { decoded: { path: ['from'], equals: address } },
-            { decoded: { path: ['to'], equals: address } },
-          ],
-        },
-      }),
-    ]);
+      // Fetch events where decoded JSON contains this address as from/to
+      const [events, total] = await Promise.all([
+        prisma.event.findMany({
+          where: {
+            OR: [
+              { decoded: { path: ['from'], equals: address } },
+              { decoded: { path: ['to'], equals: address } },
+            ],
+          },
+          orderBy: { ledgerSequence: 'desc' },
+          skip,
+          take: limit,
+        }),
+        prisma.event.count({
+          where: {
+            OR: [
+              { decoded: { path: ['from'], equals: address } },
+              { decoded: { path: ['to'], equals: address } },
+            ],
+          },
+        }),
+      ]);
 
-    res.json({ data: events, total, page, limit });
-  } catch (e) {
-    res.status(400).json({ error: String(e) });
-  }
-});
+      res.json({ data: events, total, page, limit });
+    } catch (e) {
+      res.status(400).json({ error: String(e) });
+    }
+  },
+);
 
+/**
+ * @swagger
+ * /api/v1/wallets/{address}/history:
+ *   get:
+ *     summary: Unified Soroban + classic Stellar history for a wallet
+ *     description: >-
+ *       Merges indexed Soroban transactions with classic Horizon operations for the
+ *       account into a single timeline, sorted newest first, then paginated. Each item
+ *       is tagged `type: soroban | classic`; fields not applicable to a given type are
+ *       null. If Horizon is unavailable the classic half is silently omitted.
+ *     tags: [Wallets]
+ *     parameters:
+ *       - in: path
+ *         name: address
+ *         required: true
+ *         schema: { type: string }
+ *         description: Stellar account address (G...) whose history to assemble
+ *       - in: query
+ *         name: page
+ *         schema: { type: integer, minimum: 1, default: 1 }
+ *         description: 1-based page number applied to the merged timeline
+ *       - in: query
+ *         name: limit
+ *         schema: { type: integer, minimum: 1, maximum: 100, default: 20 }
+ *         description: Page size
+ *     responses:
+ *       200:
+ *         description: Paginated unified history items
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     description: Unified history item (Soroban transaction or classic Horizon operation)
+ *                     properties:
+ *                       type: { type: string, enum: [soroban, classic] }
+ *                       timestamp: { type: string, format: date-time }
+ *                       hash: { type: string }
+ *                       ledgerSequence: { type: integer, nullable: true, description: 'Null for classic operations' }
+ *                       status: { type: string, description: 'success | failed' }
+ *                       contractAddress: { type: string, nullable: true, description: 'Soroban only' }
+ *                       functionName: { type: string, nullable: true, description: 'Soroban only' }
+ *                       humanReadable: { type: string, nullable: true, description: 'Soroban only' }
+ *                       operationType: { type: string, nullable: true, description: 'Classic only, e.g. payment, create_account' }
+ *                       amount: { type: string, nullable: true, description: 'Classic only' }
+ *                       asset: { type: string, nullable: true, description: 'Classic only; "XLM" for native' }
+ *                       from: { type: string, nullable: true, description: 'Classic only' }
+ *                       to: { type: string, nullable: true, description: 'Classic only' }
+ *                 total: { type: integer, description: 'Size of the merged timeline before pagination' }
+ *                 page: { type: integer }
+ *                 limit: { type: integer }
+ *               example:
+ *                 data:
+ *                   - type: soroban
+ *                     timestamp: '2026-06-19T07:24:26.000Z'
+ *                     hash: '3389e9f0f1a4e32477b1c0d9e8a6f5b4c3d2e1f0a9b8c7d6e5f40312233445566'
+ *                     ledgerSequence: 3168075
+ *                     status: success
+ *                     contractAddress: CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5
+ *                     functionName: swap
+ *                     humanReadable: 'GBZX...swapped 100 USDC for 98.7 XLM on StellarSwap'
+ *                     operationType: null
+ *                     amount: null
+ *                     asset: null
+ *                     from: null
+ *                     to: null
+ *                   - type: classic
+ *                     timestamp: '2026-06-19T07:20:00.000Z'
+ *                     hash: '9f0a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f'
+ *                     ledgerSequence: null
+ *                     status: success
+ *                     contractAddress: null
+ *                     functionName: null
+ *                     humanReadable: null
+ *                     operationType: payment
+ *                     amount: '100.0000000'
+ *                     asset: XLM
+ *                     from: GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI
+ *                     to: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN
+ *                 total: 134
+ *                 page: 1
+ *                 limit: 20
+ *       400:
+ *         description: Invalid query parameters
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Error'
+ *               example:
+ *                 error: 'limit must be less than or equal to 100'
+ */
 // GET /wallets/:address/history — unified Soroban + classic Stellar history
 walletRouter.get('/:address/history', async (req: Request, res: Response) => {
   try {
@@ -105,7 +330,7 @@ walletRouter.get('/:address/history', async (req: Request, res: Response) => {
     ]);
 
     // Normalise into a unified shape
-    const sorobanItems = sorobanTxs.map(tx => ({
+    const sorobanItems = sorobanTxs.map((tx) => ({
       type: 'soroban' as const,
       timestamp: tx.ledgerCloseTime,
       hash: tx.hash,

--- a/src/indexer/swaggerSpec.ts
+++ b/src/indexer/swaggerSpec.ts
@@ -225,6 +225,17 @@ const options: swaggerJsdoc.Options = {
             updatedAt: { type: 'string', format: 'date-time', example: '2026-06-19T07:24:26.000Z' },
           },
         },
+        // Token summary: the token-specific fields of a Contract, as returned by
+        // GET /tokens. Field types follow the Contract model in prisma/schema.prisma.
+        Token: {
+          type: 'object',
+          properties: {
+            address: { type: 'string', example: 'CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5' },
+            tokenName: { type: 'string', nullable: true, example: 'USD Coin' },
+            tokenSymbol: { type: 'string', nullable: true, example: 'USDC' },
+            tokenDecimals: { type: 'integer', nullable: true, example: 7 },
+          },
+        },
         // Soroban simulation execution trace (TraceResult from trace-engine.ts).
         SimulationTrace: {
           type: 'object',

--- a/src/indexer/swaggerSpec.ts
+++ b/src/indexer/swaggerSpec.ts
@@ -9,6 +9,9 @@ const options: swaggerJsdoc.Options = {
       version: '1.0.0',
       description: 'Human-readable Soroban contract explorer. Decodes raw XDR into plain English.',
     },
+    // TODO(#251): `servers` base is already /api/v1, but route @swagger paths
+    // also include /api/v1 (matching alerts.ts), so rendered URLs are duplicated.
+    // Kept consistent for now — raise with maintainers before changing either side.
     servers: [{ url: '/api/v1', description: 'API v1' }],
     components: {
       securitySchemes: {
@@ -45,6 +48,316 @@ const options: swaggerJsdoc.Options = {
             topicSymbol: { type: 'string', nullable: true },
             active: { type: 'boolean' },
             createdAt: { type: 'string', format: 'date-time' },
+          },
+        },
+        // Shared error envelope returned by route handlers, e.g. { error: "..." }.
+        Error: {
+          type: 'object',
+          properties: {
+            error: {
+              type: 'string',
+              description: 'Human-readable error message',
+              // Neutral fallback; each error response overrides this with a
+              // response-level example reflecting that endpoint's real message.
+              example: 'Bad request',
+            },
+          },
+        },
+        // Core entity: a decoded Soroban contract event (full record).
+        Event: {
+          type: 'object',
+          properties: {
+            id: {
+              type: 'string',
+              example: '3389e9f0f1a4e32477b1c0d9e8a6f5b4c3d2e1f0a9b8c7d6e5f40312233445566-AAAADwAAAAh0cmFuc2Zlcg==',
+            },
+            transactionHash: {
+              type: 'string',
+              example: '3389e9f0f1a4e32477b1c0d9e8a6f5b4c3d2e1f0a9b8c7d6e5f40312233445566',
+            },
+            contractAddress: {
+              type: 'string',
+              example: 'CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5',
+            },
+            eventType: {
+              type: 'string',
+              description: 'transfer | swap | mint | burn | custom',
+              example: 'transfer',
+            },
+            topicSymbol: {
+              type: 'string',
+              nullable: true,
+              description: 'First topic decoded as a symbol (e.g. "transfer", "mint_pass")',
+              example: 'transfer',
+            },
+            topics: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Raw event topics (base64-encoded XDR)',
+              example: ['AAAADwAAAAh0cmFuc2Zlcg==', 'AAAAEgAAAAAAAAAAjbb31xRk1h0='],
+            },
+            data: {
+              type: 'object',
+              description: 'Raw event data, wrapped as { raw: <base64-encoded XDR> }',
+              properties: { raw: { type: 'string', example: 'AAAACgAAAAAAAAAAAAAAADuaygA=' } },
+              example: { raw: 'AAAACgAAAAAAAAAAAAAAADuaygA=' },
+            },
+            decoded: {
+              type: 'object',
+              nullable: true,
+              description: 'Human-readable decoded event payload',
+              example: {
+                from: 'GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI',
+                to: 'CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5',
+                amount: '1000000000',
+              },
+            },
+            ledgerSequence: { type: 'integer', example: 3168075 },
+            ledgerCloseTime: { type: 'string', format: 'date-time', example: '2026-06-19T07:24:26.000Z' },
+            compacted: {
+              type: 'boolean',
+              description: 'True once the event is rolled into a SettlementBatchSummary (#220)',
+              example: false,
+            },
+            createdAt: { type: 'string', format: 'date-time', example: '2026-06-19T07:24:27.000Z' },
+          },
+        },
+        // Core entity: an indexed Soroban transaction, as projected by the API
+        // handler's `select` (TX_SELECT). Field types follow the Transaction model
+        // in prisma/schema.prisma; columns the handler omits (id, rawXdr,
+        // flashLoanAlert, reentrantAlert, createdAt) are intentionally excluded so
+        // that $ref-ing this schema from both routes stays accurate.
+        Transaction: {
+          type: 'object',
+          properties: {
+            hash: {
+              type: 'string',
+              example: '3389e9f0f1a4e32477b1c0d9e8a6f5b4c3d2e1f0a9b8c7d6e5f40312233445566',
+            },
+            ledgerSequence: { type: 'integer', example: 3168075 },
+            ledgerCloseTime: { type: 'string', format: 'date-time', example: '2026-06-19T07:24:26.000Z' },
+            sourceAccount: {
+              type: 'string',
+              example: 'GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI',
+            },
+            contractAddress: {
+              type: 'string',
+              nullable: true,
+              example: 'CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5',
+            },
+            functionName: { type: 'string', nullable: true, example: 'swap' },
+            functionArgs: {
+              type: 'object',
+              nullable: true,
+              description: 'Decoded function arguments (key/value map)',
+              example: { amount: '1000000000', token_in: 'USDC', token_out: 'XLM' },
+            },
+            status: { type: 'string', description: 'success | failed', example: 'success' },
+            humanReadable: {
+              type: 'string',
+              nullable: true,
+              description: 'Plain-English summary, e.g. "Address X swapped 100 USDC → 98.7 XLM"',
+              example: 'GBZX...swapped 100 USDC for 98.7 XLM on StellarSwap',
+            },
+            feeCharged: {
+              type: 'string',
+              nullable: true,
+              description: 'Fee charged, in stroops',
+              example: '100',
+            },
+            sorobanResources: {
+              type: 'object',
+              nullable: true,
+              description: '#48: CPU, memory, and ledger footprint metrics',
+              example: { cpuInstructions: 24500000, memoryBytes: 1048576, readBytes: 4096, writeBytes: 512 },
+            },
+            failureReason: {
+              type: 'string',
+              nullable: true,
+              description: '#49: human-readable failure explanation',
+              example: null,
+            },
+            freezeViolation: {
+              type: 'boolean',
+              description: 'CAP-0077: transaction touches a consensus-frozen ledger key',
+              example: false,
+            },
+          },
+        },
+        // Core entity: a registered/indexed Soroban contract (full record).
+        // Field types follow the Contract model in prisma/schema.prisma.
+        Contract: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', example: 'clz9q1x4t0000s6h2abcd1234' },
+            address: { type: 'string', example: 'CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5' },
+            name: { type: 'string', nullable: true, example: 'USD Coin' },
+            description: { type: 'string', nullable: true, example: 'USDC stablecoin token contract' },
+            abi: {
+              type: 'object',
+              nullable: true,
+              description: 'ABI-like metadata: functions, events, types',
+              example: {
+                functions: [
+                  { name: 'transfer', inputs: [{ name: 'to', type: 'Address' }, { name: 'amount', type: 'i128' }] },
+                ],
+              },
+            },
+            functionSignatures: {
+              type: 'array',
+              nullable: true,
+              items: { type: 'object' },
+              description: 'Decoded function signatures, e.g. [{ name, inputs, outputs }]',
+              example: [{ name: 'transfer', inputs: ['Address', 'i128'], outputs: [] }],
+            },
+            isToken: { type: 'boolean', example: true },
+            tokenSymbol: { type: 'string', nullable: true, example: 'USDC' },
+            tokenName: { type: 'string', nullable: true, example: 'USD Coin' },
+            tokenDecimals: { type: 'integer', nullable: true, example: 7 },
+            wasmHash: {
+              type: 'string',
+              nullable: true,
+              description: 'Fuzzy hash of compiled Wasm bytecode for similarity detection',
+              example: 'e5f40312233445566778899aabbccddeeff00112233445566778899aabbccddee',
+            },
+            isVerified: { type: 'boolean', example: true },
+            createdAt: { type: 'string', format: 'date-time', example: '2026-06-19T07:24:26.000Z' },
+            updatedAt: { type: 'string', format: 'date-time', example: '2026-06-19T07:24:26.000Z' },
+          },
+        },
+        // Soroban simulation execution trace (TraceResult from trace-engine.ts).
+        SimulationTrace: {
+          type: 'object',
+          properties: {
+            steps: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  seq: { type: 'integer', example: 0 },
+                  depth: { type: 'integer', example: 0 },
+                  type: {
+                    type: 'string',
+                    enum: ['host_function', 'event', 'state_change'],
+                    example: 'host_function',
+                  },
+                  function: { type: 'string', example: 'swap' },
+                  args: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        type: { type: 'string', example: 'i128' },
+                        value: { example: '1000000000' },
+                      },
+                    },
+                    example: [{ type: 'i128', value: '1000000000' }],
+                  },
+                  gasUsed: { type: 'integer', example: 24500000 },
+                  memUsed: { type: 'integer', example: 1048576 },
+                  stateChanges: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        key: {
+                          type: 'string',
+                          example: 'Balance(GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI)',
+                        },
+                        before: { example: '0' },
+                        after: { example: '1000000000' },
+                        changeType: { type: 'string', enum: ['write', 'read', 'delete'], example: 'write' },
+                      },
+                    },
+                    example: [
+                      { key: 'Balance(GBZX...)', before: '0', after: '1000000000', changeType: 'write' },
+                    ],
+                  },
+                  returnValue: {
+                    type: 'object',
+                    nullable: true,
+                    properties: {
+                      type: { type: 'string', example: 'i128' },
+                      value: { example: '987000000' },
+                    },
+                    example: { type: 'i128', value: '987000000' },
+                  },
+                  error: { type: 'string', nullable: true, example: null },
+                },
+              },
+            },
+            totalGas: { type: 'integer', example: 24500000 },
+            totalMemory: { type: 'integer', example: 1048576 },
+            callGraph: {
+              type: 'object',
+              properties: {
+                nodes: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      id: { type: 'string', example: 'node-0' },
+                      contract: {
+                        type: 'string',
+                        example: 'CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5',
+                      },
+                      function: { type: 'string', example: 'swap' },
+                      gas: { type: 'integer', example: 24500000 },
+                      depth: { type: 'integer', example: 0 },
+                    },
+                  },
+                },
+                edges: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      from: { type: 'string', example: 'node-0' },
+                      to: { type: 'string', example: 'node-1' },
+                      type: { type: 'string', enum: ['call', 'return'], example: 'call' },
+                    },
+                  },
+                },
+              },
+            },
+            events: { type: 'array', items: { type: 'object' }, example: [] },
+            success: { type: 'boolean', example: true },
+            error: { type: 'string', nullable: true, example: null },
+          },
+        },
+        // Simulation failure analysis (RevertAnalysis from revert-analyzer.ts).
+        RevertAnalysis: {
+          type: 'object',
+          properties: {
+            errorType: {
+              type: 'string',
+              enum: ['panic', 'contract_error', 'resource_limit', 'auth_error', 'wasm_error', 'storage_error', 'unknown'],
+              example: 'contract_error',
+            },
+            message: { type: 'string', example: 'Contract call failed: insufficient balance' },
+            detail: { type: 'string', nullable: true, example: 'Error(Contract, #3)' },
+            callStack: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  depth: { type: 'integer', example: 0 },
+                  contractId: {
+                    type: 'string',
+                    example: 'CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5',
+                  },
+                  function: { type: 'string', example: 'swap' },
+                },
+              },
+              example: [
+                { depth: 0, contractId: 'CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5', function: 'swap' },
+              ],
+            },
+            suggestedFixes: {
+              type: 'array',
+              items: { type: 'string' },
+              example: ['Ensure the account has sufficient balance before calling swap.'],
+            },
           },
         },
       },


### PR DESCRIPTION
## Phase 1: core five (transactions, events, contracts, wallets, tokens)

Part of #251. Adds @swagger docs to the five core route files, following the existing alerts.ts pattern.

Schemas come from each handler's real output and are checked against the Prisma models, so they match what the API actually returns. Examples use realistic Soroban values. Error responses only document what a handler can actually return.

Shared schemas (Transaction, Event, Contract, Token, Error, etc.) live in swaggerSpec.ts and are reused via $ref.

Remaining Phase 1 files come in follow-up PRs, heavy ones next (privacy, mev, schedule, tip, network). Verified at /api/docs; npm run build passes.