### PR TITLE
docs(#251): add swagger for tip.ts (22 routes) and 6 new components

### DIFF
--- a/src/api/tip.ts
+++ b/src/api/tip.ts
@@ -19,6 +19,13 @@ import {
 } from '../tip/analytics';
 
 const db = new PrismaClient();
+
+/**
+ * @swagger
+ * tags:
+ *   name: Threat Intelligence
+ *   description: Advisories, review workflow, subscriptions, webhooks, RSS/JSON feeds, analytics, and source management
+ */
 export const tipRouter = Router();
 
 // ─── Schemas ──────────────────────────────────────────────────────────────────
@@ -68,6 +75,63 @@ const WebhookSchema = z.object({
 
 // ─── Advisories ──────────────────────────────────────────────────────────────
 
+/**
+ * @swagger
+ * /api/v1/tip/advisories:
+ *   get:
+ *     summary: List threat advisories
+ *     description: Paginated advisories, optionally filtered by severity, status, or keyword.
+ *     tags: [Threat Intelligence]
+ *     parameters:
+ *       - in: query
+ *         name: severity
+ *         schema: { type: string, enum: [critical, high, medium, low, info] }
+ *         description: Filter by severity level
+ *       - in: query
+ *         name: status
+ *         schema: { type: string, enum: [open, under_review, resolved, disputed] }
+ *         description: Filter by advisory status
+ *       - in: query
+ *         name: search
+ *         schema: { type: string }
+ *         description: Case-insensitive substring match on title and description
+ *       - in: query
+ *         name: page
+ *         schema: { type: integer, default: 1 }
+ *       - in: query
+ *         name: limit
+ *         schema: { type: integer, default: 20 }
+ *     responses:
+ *       200:
+ *         description: Paginated advisory list
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 items:
+ *                   type: array
+ *                   items:
+ *                     allOf:
+ *                       - $ref: '#/components/schemas/ThreatAdvisory'
+ *                       - type: object
+ *                         properties:
+ *                           source:
+ *                             type: object
+ *                             nullable: true
+ *                             properties:
+ *                               name: { type: string, example: NVD_CVE }
+ *                 total: { type: integer, example: 42 }
+ *                 page: { type: integer, example: 1 }
+ *                 limit: { type: integer, example: 20 }
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Database connection failed' }
+ */
 tipRouter.get(
   '/advisories',
   asyncHandler(async (req: Request, res: Response) => {
@@ -103,6 +167,50 @@ tipRouter.get(
   }),
 );
 
+/**
+ * @swagger
+ * /api/v1/tip/advisories/{id}:
+ *   get:
+ *     summary: Get a threat advisory by id
+ *     description: Returns the advisory with its source, review history, and community comments.
+ *     tags: [Threat Intelligence]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       200:
+ *         description: Advisory with related records
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/ThreatAdvisory' }]
+ *               example:
+ *                 id: clz9q1x4t0000s6h2advis001
+ *                 title: Reentrancy in transfer hook
+ *                 severity: high
+ *                 status: open
+ *                 affectedContracts: [CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5]
+ *                 affectedChains: [stellar]
+ *                 tags: [reentrancy, community]
+ *                 createdAt: '2026-06-19T07:24:26.000Z'
+ *                 updatedAt: '2026-06-19T07:24:27.000Z'
+ *       404:
+ *         description: Advisory not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Not found' }
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Database connection failed' }
+ */
 tipRouter.get(
   '/advisories/:id',
   asyncHandler(async (req: Request, res: Response) => {
@@ -115,6 +223,63 @@ tipRouter.get(
   }),
 );
 
+/**
+ * @swagger
+ * /api/v1/tip/advisories:
+ *   post:
+ *     summary: Submit a new threat advisory
+ *     tags: [Threat Intelligence]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [title, description, severity]
+ *             properties:
+ *               title: { type: string, minLength: 3, example: 'Reentrancy in transfer hook' }
+ *               description: { type: string, minLength: 10, example: 'A reentrancy vulnerability allows double-spend via malicious token hook.' }
+ *               severity: { type: string, enum: [critical, high, medium, low, info], example: high }
+ *               cvssScore: { type: number, minimum: 0, maximum: 10, example: 8.1 }
+ *               affectedContracts:
+ *                 type: array
+ *                 items: { type: string }
+ *                 example: [CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5]
+ *               affectedChains:
+ *                 type: array
+ *                 items: { type: string }
+ *                 example: [stellar]
+ *               mitigations:
+ *                 type: array
+ *                 items: { type: string }
+ *                 example: ['Upgrade to patched version >= 1.2.1']
+ *               tags:
+ *                 type: array
+ *                 items: { type: string }
+ *                 example: [reentrancy, token]
+ *               externalUrl: { type: string, format: uri, example: 'https://nvd.nist.gov/vuln/detail/CVE-2026-1234' }
+ *     responses:
+ *       201:
+ *         description: Advisory created; notifications dispatched
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 id: { type: string, example: clz9q1x4t0000s6h2advis001 }
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ZodFlattenedError' }
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Database connection failed' }
+ */
 tipRouter.post(
   '/advisories',
   asyncHandler(async (req: Request, res: Response) => {
@@ -136,6 +301,56 @@ tipRouter.post(
   }),
 );
 
+/**
+ * @swagger
+ * /api/v1/tip/advisories/{id}:
+ *   patch:
+ *     summary: Update an advisory's status, severity, mitigations, or resolved timestamp
+ *     tags: [Threat Intelligence]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               status: { type: string, enum: [open, under_review, resolved, disputed] }
+ *               severity: { type: string, enum: [critical, high, medium, low, info] }
+ *               mitigations:
+ *                 type: array
+ *                 items: { type: string }
+ *                 example: ['Apply patch #42 from upstream']
+ *               resolvedAt: { type: string, format: date-time, example: '2026-06-19T07:24:26.000Z' }
+ *     responses:
+ *       200:
+ *         description: Updated advisory record
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/ThreatAdvisory' }]
+ *               example:
+ *                 id: clz9q1x4t0000s6h2advis001
+ *                 severity: high
+ *                 status: resolved
+ *                 updatedAt: '2026-06-19T07:24:27.000Z'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ZodFlattenedError' }
+ *       500:
+ *         description: Server error or advisory not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Record to update not found' }
+ */
 tipRouter.patch(
   '/advisories/:id',
   asyncHandler(async (req: Request, res: Response) => {
@@ -161,6 +376,28 @@ tipRouter.patch(
   }),
 );
 
+/**
+ * @swagger
+ * /api/v1/tip/advisories/{id}:
+ *   delete:
+ *     summary: Delete a threat advisory
+ *     tags: [Threat Intelligence]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       204:
+ *         description: Advisory deleted
+ *       500:
+ *         description: Server error or advisory not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Record to delete not found' }
+ */
 tipRouter.delete(
   '/advisories/:id',
   asyncHandler(async (req: Request, res: Response) => {
@@ -171,6 +408,58 @@ tipRouter.delete(
 
 // ─── Review workflow ──────────────────────────────────────────────────────────
 
+/**
+ * @swagger
+ * /api/v1/tip/advisories/{id}/reviews:
+ *   post:
+ *     summary: Submit a review decision for an advisory
+ *     description: An "approve" decision also advances the advisory status to "under_review".
+ *     tags: [Threat Intelligence]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [role, decision, reviewerKey]
+ *             properties:
+ *               role: { type: string, enum: [analyst, admin], example: analyst }
+ *               decision: { type: string, enum: [approve, reject, escalate], example: approve }
+ *               notes: { type: string, example: 'Confirmed exploitable on testnet.' }
+ *               reviewerKey: { type: string, example: sk_live_abc123 }
+ *     responses:
+ *       201:
+ *         description: Review created
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/ThreatReview' }]
+ *               example:
+ *                 id: clz9q1x4t0000s6h2review001
+ *                 advisoryId: clz9q1x4t0000s6h2advis001
+ *                 role: analyst
+ *                 decision: approve
+ *                 notes: Confirmed exploitable on testnet.
+ *                 reviewerKey: sk_live_abc123
+ *                 createdAt: '2026-06-19T07:24:26.000Z'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ZodFlattenedError' }
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Database connection failed' }
+ */
 tipRouter.post(
   '/advisories/:id/reviews',
   asyncHandler(async (req: Request, res: Response) => {
@@ -195,6 +484,54 @@ tipRouter.post(
 
 // ─── Comments ─────────────────────────────────────────────────────────────────
 
+/**
+ * @swagger
+ * /api/v1/tip/advisories/{id}/comments:
+ *   post:
+ *     summary: Post a community comment on an advisory
+ *     tags: [Threat Intelligence]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [body]
+ *             properties:
+ *               body: { type: string, example: 'Reproduced on testnet ledger 3168075.' }
+ *     responses:
+ *       201:
+ *         description: Comment created
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/ThreatComment' }]
+ *               example:
+ *                 id: clz9q1x4t0000s6h2comment01
+ *                 advisoryId: clz9q1x4t0000s6h2advis001
+ *                 authorKey: anonymous
+ *                 body: Reproduced on testnet ledger 3168075.
+ *                 createdAt: '2026-06-19T07:24:26.000Z'
+ *       400:
+ *         description: Missing or non-string body field
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'body required' }
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Database connection failed' }
+ */
 tipRouter.post(
   '/advisories/:id/comments',
   asyncHandler(async (req: Request, res: Response) => {
@@ -211,6 +548,30 @@ tipRouter.post(
 
 // ─── Correlator ───────────────────────────────────────────────────────────────
 
+/**
+ * @swagger
+ * /api/v1/tip/correlate:
+ *   post:
+ *     summary: Run advisory deduplication and correlation
+ *     description: Merges duplicate advisories and returns the number of records linked.
+ *     tags: [Threat Intelligence]
+ *     responses:
+ *       200:
+ *         description: Number of advisories linked by the correlator
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 linked: { type: integer, example: 3 }
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Correlator failed' }
+ */
 tipRouter.post(
   '/correlate',
   asyncHandler(async (_req: Request, res: Response) => {
@@ -219,6 +580,34 @@ tipRouter.post(
   }),
 );
 
+/**
+ * @swagger
+ * /api/v1/tip/advisories/{id}/rescore:
+ *   post:
+ *     summary: Recompute the severity score for an advisory
+ *     tags: [Threat Intelligence]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       200:
+ *         description: Newly computed severity
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 severity: { type: string, enum: [critical, high, medium, low, info], example: high }
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Rescore failed' }
+ */
 tipRouter.post(
   '/advisories/:id/rescore',
   asyncHandler(async (req: Request, res: Response) => {
@@ -229,6 +618,28 @@ tipRouter.post(
 
 // ─── Subscriptions ────────────────────────────────────────────────────────────
 
+/**
+ * @swagger
+ * /api/v1/tip/subscriptions:
+ *   get:
+ *     summary: List all TIP notification subscriptions
+ *     tags: [Threat Intelligence]
+ *     responses:
+ *       200:
+ *         description: All subscriptions
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items: { $ref: '#/components/schemas/TipSubscription' }
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Database connection failed' }
+ */
 tipRouter.get(
   '/subscriptions',
   asyncHandler(async (_req: Request, res: Response) => {
@@ -236,6 +647,62 @@ tipRouter.get(
   }),
 );
 
+/**
+ * @swagger
+ * /api/v1/tip/subscriptions:
+ *   post:
+ *     summary: Create or reactivate a TIP notification subscription
+ *     description: Upserts on (channel, target); reactivates an existing subscription if one exists.
+ *     tags: [Threat Intelligence]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [channel, target]
+ *             properties:
+ *               channel: { type: string, enum: [email, slack, discord, telegram], example: slack }
+ *               target: { type: string, minLength: 3, example: '#security-alerts' }
+ *               filters:
+ *                 type: object
+ *                 properties:
+ *                   severity:
+ *                     type: array
+ *                     items: { type: string }
+ *                     example: [critical, high]
+ *                   tags:
+ *                     type: array
+ *                     items: { type: string }
+ *                     example: [reentrancy]
+ *     responses:
+ *       201:
+ *         description: Subscription created or reactivated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/TipSubscription' }]
+ *               example:
+ *                 id: clz9q1x4t0000s6h2tipsub01
+ *                 channel: slack
+ *                 target: '#security-alerts'
+ *                 active: true
+ *                 filters: { severity: [critical, high] }
+ *                 createdAt: '2026-06-19T07:24:26.000Z'
+ *                 updatedAt: '2026-06-19T07:24:26.000Z'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ZodFlattenedError' }
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Database connection failed' }
+ */
 tipRouter.post(
   '/subscriptions',
   asyncHandler(async (req: Request, res: Response) => {
@@ -251,6 +718,28 @@ tipRouter.post(
   }),
 );
 
+/**
+ * @swagger
+ * /api/v1/tip/subscriptions/{id}:
+ *   delete:
+ *     summary: Delete a TIP subscription
+ *     tags: [Threat Intelligence]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       204:
+ *         description: Subscription deleted
+ *       500:
+ *         description: Server error or subscription not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Record to delete not found' }
+ */
 tipRouter.delete(
   '/subscriptions/:id',
   asyncHandler(async (req: Request, res: Response) => {
@@ -261,6 +750,35 @@ tipRouter.delete(
 
 // ─── Webhooks ─────────────────────────────────────────────────────────────────
 
+/**
+ * @swagger
+ * /api/v1/tip/webhooks:
+ *   get:
+ *     summary: List registered TIP webhooks
+ *     description: Returns id, url, events, and active status; secret is excluded.
+ *     tags: [Threat Intelligence]
+ *     responses:
+ *       200:
+ *         description: Webhook list
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id: { type: string, example: clz9q1x4t0000s6h2webhook1 }
+ *                   url: { type: string, format: uri, example: 'https://hooks.example.com/tip' }
+ *                   events: { type: array, items: { type: string }, example: [advisory.created] }
+ *                   active: { type: boolean, example: true }
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Database connection failed' }
+ */
 tipRouter.get(
   '/webhooks',
   asyncHandler(async (_req: Request, res: Response) => {
@@ -270,6 +788,51 @@ tipRouter.get(
   }),
 );
 
+/**
+ * @swagger
+ * /api/v1/tip/webhooks:
+ *   post:
+ *     summary: Register or update a TIP webhook
+ *     description: Upserts on URL; an existing webhook's secret and events are overwritten.
+ *     tags: [Threat Intelligence]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [url, secret]
+ *             properties:
+ *               url: { type: string, format: uri, example: 'https://hooks.example.com/tip' }
+ *               secret: { type: string, minLength: 8, example: s3cr3t-hmac-key }
+ *               events:
+ *                 type: array
+ *                 items: { type: string }
+ *                 default: [advisory.created]
+ *                 example: [advisory.created, advisory.resolved]
+ *     responses:
+ *       201:
+ *         description: Webhook registered or updated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 id: { type: string, example: clz9q1x4t0000s6h2webhook1 }
+ *                 url: { type: string, format: uri, example: 'https://hooks.example.com/tip' }
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ZodFlattenedError' }
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Database connection failed' }
+ */
 tipRouter.post(
   '/webhooks',
   asyncHandler(async (req: Request, res: Response) => {
@@ -285,6 +848,28 @@ tipRouter.post(
   }),
 );
 
+/**
+ * @swagger
+ * /api/v1/tip/webhooks/{id}:
+ *   delete:
+ *     summary: Delete a TIP webhook
+ *     tags: [Threat Intelligence]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       204:
+ *         description: Webhook deleted
+ *       500:
+ *         description: Server error or webhook not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Record to delete not found' }
+ */
 tipRouter.delete(
   '/webhooks/:id',
   asyncHandler(async (req: Request, res: Response) => {
@@ -295,6 +880,55 @@ tipRouter.delete(
 
 // ─── Feeds ────────────────────────────────────────────────────────────────────
 
+/**
+ * @swagger
+ * /api/v1/tip/feeds/json:
+ *   get:
+ *     summary: JSON feed of recent non-disputed advisories
+ *     tags: [Threat Intelligence]
+ *     parameters:
+ *       - in: query
+ *         name: limit
+ *         schema: { type: integer, default: 50, maximum: 200 }
+ *         description: Clamped to 200; no 400 is returned for out-of-range values
+ *     responses:
+ *       200:
+ *         description: Advisory feed
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 feed: { type: string, example: Soroban TIP }
+ *                 generated: { type: string, format: date-time, example: '2026-06-19T07:24:26.000Z' }
+ *                 items:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id: { type: string, example: clz9q1x4t0000s6h2advis001 }
+ *                       title: { type: string, example: 'Reentrancy in transfer hook' }
+ *                       severity: { type: string, enum: [critical, high, medium, low, info], example: high }
+ *                       cveId: { type: string, nullable: true, example: 'CVE-2026-1234' }
+ *                       ghsaId: { type: string, nullable: true, example: null }
+ *                       affectedContracts:
+ *                         type: array
+ *                         items: { type: string }
+ *                         example: [CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5]
+ *                       affectedChains:
+ *                         type: array
+ *                         items: { type: string }
+ *                         example: [stellar]
+ *                       publishedAt: { type: string, format: date-time, nullable: true, example: '2026-06-19T07:24:26.000Z' }
+ *                       externalUrl: { type: string, nullable: true, example: null }
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Database connection failed' }
+ */
 tipRouter.get(
   '/feeds/json',
   asyncHandler(async (req: Request, res: Response) => {
@@ -319,6 +953,29 @@ tipRouter.get(
   }),
 );
 
+/**
+ * @swagger
+ * /api/v1/tip/feeds/rss:
+ *   get:
+ *     summary: RSS 2.0 feed of recent non-disputed advisories
+ *     description: Returns the 50 most recent non-disputed advisories as an RSS 2.0 XML document.
+ *     tags: [Threat Intelligence]
+ *     responses:
+ *       200:
+ *         description: RSS 2.0 XML feed
+ *         content:
+ *           application/rss+xml:
+ *             schema:
+ *               type: string
+ *               example: "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\">...</rss>"
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Database connection failed' }
+ */
 tipRouter.get(
   '/feeds/rss',
   asyncHandler(async (_req: Request, res: Response) => {
@@ -361,6 +1018,32 @@ ${entries}
 
 // ─── Analytics ───────────────────────────────────────────────────────────────
 
+/**
+ * @swagger
+ * /api/v1/tip/analytics/severity:
+ *   get:
+ *     summary: Advisory count grouped by severity
+ *     tags: [Threat Intelligence]
+ *     responses:
+ *       200:
+ *         description: Per-severity counts
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   severity: { type: string, enum: [critical, high, medium, low, info], example: high }
+ *                   count: { type: integer, example: 14 }
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Database connection failed' }
+ */
 tipRouter.get(
   '/analytics/severity',
   asyncHandler(async (_req: Request, res: Response) => {
@@ -368,6 +1051,40 @@ tipRouter.get(
   }),
 );
 
+/**
+ * @swagger
+ * /api/v1/tip/analytics/trend:
+ *   get:
+ *     summary: Daily advisory creation trend
+ *     description: Returns a per-day bucket of total, critical, and high advisories over the past N days.
+ *     tags: [Threat Intelligence]
+ *     parameters:
+ *       - in: query
+ *         name: days
+ *         schema: { type: integer, default: 30, maximum: 365 }
+ *         description: Lookback window in days; clamped to 365
+ *     responses:
+ *       200:
+ *         description: Daily trend buckets
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   date: { type: string, example: '2026-06-19' }
+ *                   total: { type: integer, example: 5 }
+ *                   critical: { type: integer, example: 1 }
+ *                   high: { type: integer, example: 2 }
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Database connection failed' }
+ */
 tipRouter.get(
   '/analytics/trend',
   asyncHandler(async (req: Request, res: Response) => {
@@ -376,6 +1093,37 @@ tipRouter.get(
   }),
 );
 
+/**
+ * @swagger
+ * /api/v1/tip/analytics/top-contracts:
+ *   get:
+ *     summary: Contracts most frequently cited in advisories
+ *     tags: [Threat Intelligence]
+ *     parameters:
+ *       - in: query
+ *         name: limit
+ *         schema: { type: integer, default: 10, maximum: 50 }
+ *         description: Clamped to 50
+ *     responses:
+ *       200:
+ *         description: Ranked contract list
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   contract: { type: string, example: CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5 }
+ *                   count: { type: integer, example: 7 }
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Database connection failed' }
+ */
 tipRouter.get(
   '/analytics/top-contracts',
   asyncHandler(async (req: Request, res: Response) => {
@@ -384,6 +1132,32 @@ tipRouter.get(
   }),
 );
 
+/**
+ * @swagger
+ * /api/v1/tip/analytics/status:
+ *   get:
+ *     summary: Advisory count grouped by status
+ *     tags: [Threat Intelligence]
+ *     responses:
+ *       200:
+ *         description: Per-status counts
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   status: { type: string, enum: [open, under_review, resolved, disputed], example: open }
+ *                   count: { type: integer, example: 18 }
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Database connection failed' }
+ */
 tipRouter.get(
   '/analytics/status',
   asyncHandler(async (_req: Request, res: Response) => {
@@ -393,6 +1167,28 @@ tipRouter.get(
 
 // ─── Sources ─────────────────────────────────────────────────────────────────
 
+/**
+ * @swagger
+ * /api/v1/tip/sources:
+ *   get:
+ *     summary: List vulnerability feed sources
+ *     tags: [Threat Intelligence]
+ *     responses:
+ *       200:
+ *         description: All registered sources (NVD, GHSA, COMMUNITY, etc.)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items: { $ref: '#/components/schemas/VulnerabilitySource' }
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf: [{ $ref: '#/components/schemas/Error' }]
+ *               example: { error: 'Database connection failed' }
+ */
 tipRouter.get(
   '/sources',
   asyncHandler(async (_req: Request, res: Response) => {

--- a/src/indexer/swaggerSpec.ts
+++ b/src/indexer/swaggerSpec.ts
@@ -28,6 +28,7 @@ const options: swaggerJsdoc.Options = {
       { name: 'Token Metadata', description: 'Token metadata resolution' },
       { name: 'Protocol', description: 'Protocol version and reconciliation' },
       { name: 'i18n', description: 'Internationalization translation management' },
+      { name: 'Threat Intelligence', description: 'Advisories, review workflow, subscriptions, webhooks, RSS/JSON feeds, analytics, and source management' },
     ],
     components: {
       securitySchemes: {
@@ -955,6 +956,109 @@ const options: swaggerJsdoc.Options = {
             triggerTime: { type: 'string', format: 'date-time', example: '2026-06-19T07:24:26.000Z' },
             delivered: { type: 'boolean', example: false },
             acknowledged: { type: 'boolean', example: false },
+          },
+        },
+        // ── Threat Intelligence Platform (#251) ───────────────────────────────
+        // Full ThreatAdvisory record as stored in DB. mitigations is String? in
+        // the schema even though the Zod input accepts an array.
+        ThreatAdvisory: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', example: 'clz9q1x4t0000s6h2advis001' },
+            title: { type: 'string', example: 'Reentrancy in transfer hook' },
+            description: { type: 'string', nullable: true, example: 'A reentrancy vulnerability allows double-spend via malicious token hook.' },
+            severity: { type: 'string', enum: ['critical', 'high', 'medium', 'low', 'info'], example: 'high' },
+            cvssScore: { type: 'number', nullable: true, example: 8.1 },
+            cveId: { type: 'string', nullable: true, example: 'CVE-2026-1234' },
+            ghsaId: { type: 'string', nullable: true, example: null },
+            affectedContracts: { type: 'array', items: { type: 'string' }, example: ['CALLD5GHXR4QSTKHSWQEK4UVMHM4QHU4KZ5G4SBKWY7C7TXKZ45RJ4M5'] },
+            affectedChains: { type: 'array', items: { type: 'string' }, example: ['stellar'] },
+            mitigations: { type: 'string', nullable: true, description: 'Stored as a serialised value (schema column is String?)', example: null },
+            tags: { type: 'array', items: { type: 'string' }, example: ['reentrancy', 'community'] },
+            sourceId: { type: 'string', nullable: true, example: 'clz9q1x4t0000s6h2vsource1' },
+            status: { type: 'string', enum: ['open', 'under_review', 'resolved', 'disputed'], example: 'open' },
+            publishedAt: { type: 'string', format: 'date-time', nullable: true, example: '2026-06-19T07:24:26.000Z' },
+            externalUrl: { type: 'string', nullable: true, example: null },
+            createdAt: { type: 'string', format: 'date-time', example: '2026-06-19T07:24:26.000Z' },
+            updatedAt: { type: 'string', format: 'date-time', example: '2026-06-19T07:24:27.000Z' },
+          },
+        },
+        // A review decision for a ThreatAdvisory (full ThreatReview record).
+        ThreatReview: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', example: 'clz9q1x4t0000s6h2review001' },
+            advisoryId: { type: 'string', example: 'clz9q1x4t0000s6h2advis001' },
+            role: { type: 'string', nullable: true, enum: ['analyst', 'admin'], example: 'analyst' },
+            decision: { type: 'string', nullable: true, enum: ['approve', 'reject', 'escalate'], example: 'approve' },
+            notes: { type: 'string', nullable: true, example: 'Confirmed exploitable on testnet.' },
+            reviewerKey: { type: 'string', example: 'sk_live_abc123' },
+            createdAt: { type: 'string', format: 'date-time', example: '2026-06-19T07:24:26.000Z' },
+          },
+        },
+        // A community comment on a ThreatAdvisory (full ThreatComment record).
+        ThreatComment: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', example: 'clz9q1x4t0000s6h2comment01' },
+            advisoryId: { type: 'string', example: 'clz9q1x4t0000s6h2advis001' },
+            authorKey: { type: 'string', description: 'X-API-Key header value, or "anonymous" if absent', example: 'anonymous' },
+            body: { type: 'string', example: 'Reproduced on testnet ledger 3168075.' },
+            createdAt: { type: 'string', format: 'date-time', example: '2026-06-19T07:24:26.000Z' },
+          },
+        },
+        // A TIP notification subscription (full TipSubscription record).
+        TipSubscription: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', example: 'clz9q1x4t0000s6h2tipsub01' },
+            channel: { type: 'string', enum: ['email', 'slack', 'discord', 'telegram'], example: 'slack' },
+            target: { type: 'string', description: 'Channel-specific destination (email address, webhook URL, user id, etc.)', example: '#security-alerts' },
+            active: { type: 'boolean', example: true },
+            filters: {
+              type: 'object',
+              nullable: true,
+              description: 'Optional severity/tag filters',
+              properties: {
+                severity: { type: 'array', items: { type: 'string' }, example: ['critical', 'high'] },
+                tags: { type: 'array', items: { type: 'string' }, example: ['reentrancy'] },
+              },
+              example: { severity: ['critical', 'high'] },
+            },
+            createdAt: { type: 'string', format: 'date-time', example: '2026-06-19T07:24:26.000Z' },
+            updatedAt: { type: 'string', format: 'date-time', example: '2026-06-19T07:24:27.000Z' },
+          },
+        },
+        // A registered threat intelligence feed source (full VulnerabilitySource record).
+        VulnerabilitySource: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', example: 'clz9q1x4t0000s6h2vsource1' },
+            name: { type: 'string', description: 'Unique source identifier, e.g. NVD_CVE, GHSA, COMMUNITY', example: 'NVD_CVE' },
+            sourceType: { type: 'string', description: 'Feed type: cve | ghsa | manual | onchain', example: 'cve' },
+            feedUrl: { type: 'string', nullable: true, example: 'https://services.nvd.nist.gov/rest/json/cves/2.0' },
+            lastFetchAt: { type: 'string', format: 'date-time', nullable: true, example: '2026-06-19T07:24:26.000Z' },
+            active: { type: 'boolean', example: true },
+            createdAt: { type: 'string', format: 'date-time', example: '2026-06-19T07:24:26.000Z' },
+            updatedAt: { type: 'string', format: 'date-time', example: '2026-06-19T07:24:27.000Z' },
+          },
+        },
+        // Validation error envelope for routes using .safeParse() + .flatten().
+        // Shape differs from ZodValidationError (which wraps .errors array).
+        ZodFlattenedError: {
+          type: 'object',
+          properties: {
+            error: {
+              type: 'object',
+              properties: {
+                formErrors: { type: 'array', items: { type: 'string' }, example: [] },
+                fieldErrors: {
+                  type: 'object',
+                  additionalProperties: { type: 'array', items: { type: 'string' } },
+                  example: { title: ['String must contain at least 3 character(s)'] },
+                },
+              },
+            },
           },
         },
       },


### PR DESCRIPTION
Adds @swagger docs for tip.ts (22 routes) + 6 components.

Two pre-existing issues found while documenting (not fixed here - flagging):
1. tipRouter is not mounted in router.ts - these routes 404 until `router.use('/tip', tipRouter)` is added (after the data-market line).
2. src/tip/correlator.ts is imported but doesn't exist - /tip/correlate and /tip/advisories/:id/rescore will 500 at runtime until it's created.

Verified via spec generation (lint clean, components resolve). Note: `npm run build` fails on unrelated upstream pricing files (missing Prisma models), not this PR.