### PR TITLE
fix(#421): Mount DEX, MEV, and arbitrage intelligence routers

### DIFF
--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -46,6 +46,12 @@ import { tokenPricesRouter } from './token-prices';
 import { portfolioRouter } from './portfolio';
 import { alertsRouter } from './alerts';
 
+// ── DEX Analytics, MEV & Arbitrage Intelligence ────────────────────────────────
+import { arbitrageRouter } from './arbitrage';
+import { dexAnalyticsRouter } from './dex-analytics';
+import { dexRouter } from './dex';
+import { mevRouter } from './mev';
+
 export const router = Router();
 
 // ── Core Stellar / Soroban ────────────────────────────────────────────────────
@@ -81,3 +87,9 @@ router.use('/data-market', dataMarketRouter);
 // ── NFT Collection Discovery, Rarity Engine, Marketplace Analytics & Portfolio ──
 import { nftRouter } from './nft';
 router.use('/nft', nftRouter);
+
+// ── DEX Analytics, MEV & Arbitrage Intelligence ────────────────────────────────
+router.use('/arbitrage', arbitrageRouter);
+router.use('/dex-analytics', dexAnalyticsRouter);
+router.use('/dex', dexRouter);
+router.use('/mev', mevRouter);

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,10 @@ import { resolve } from 'path';
 import { apiKeyAuth } from './middleware/apiKeyAuth';
 import { auditLogMiddleware } from './middleware/auditLog';
 import { billingRouter } from './services/stripe-billing';
+import { startArbitrageScanner as startArbitrageScannerImpl } from './indexer/arbitrage-scanner';
+import { startPoolPriceMonitor as startPoolPriceMonitorImpl } from './indexer/pool-price-monitor';
+import { startFeeAggregator as startFeeAggregatorImpl } from './indexer/fee-aggregator';
+import { attachArbitrageWebSocket as attachArbitrageWebSocketImpl } from './ws/arbitrageBroadcaster';
 
 let isShuttingDown = false;
 let wssRef: ReturnType<typeof attachWebSocketServer> | null = null;
@@ -49,17 +53,37 @@ function attachPrivacyWebSocket(_server: unknown): void {
 function attachComposabilityWebSocket(_server: unknown): void {
   logger.debug('Composability WebSocket disabled — schema models not yet available');
 }
-function attachArbitrageWebSocket(_server: unknown): void {
-  logger.debug('Arbitrage WebSocket disabled — schema models not yet available');
+function attachArbitrageWebSocket(server: unknown): void {
+  try {
+    attachArbitrageWebSocketImpl(server);
+    logger.debug('Arbitrage WebSocket attached');
+  } catch (err) {
+    logger.warn('Arbitrage WebSocket attachment failed', { error: String(err) });
+  }
 }
 function startPoolPriceMonitor(): void {
-  logger.debug('Pool price monitor disabled — schema models not yet available');
+  try {
+    startPoolPriceMonitorImpl();
+    logger.debug('Pool price monitor started');
+  } catch (err) {
+    logger.warn('Pool price monitor failed to start', { error: String(err) });
+  }
 }
 function startArbitrageScanner(): void {
-  logger.debug('Arbitrage scanner disabled — schema models not yet available');
+  try {
+    startArbitrageScannerImpl();
+    logger.debug('Arbitrage scanner started');
+  } catch (err) {
+    logger.warn('Arbitrage scanner failed to start', { error: String(err) });
+  }
 }
 function startFeeAggregator(): void {
-  logger.debug('Fee aggregator disabled — schema models not yet available');
+  try {
+    startFeeAggregatorImpl();
+    logger.debug('Fee aggregator started');
+  } catch (err) {
+    logger.warn('Fee aggregator failed to start', { error: String(err) });
+  }
 }
 
 const app = express();
@@ -224,21 +248,9 @@ async function main() {
   attachArbitrageWebSocket(httpServer);
 
   if (!process.env.DISABLE_INDEXER) {
-    try {
-      startPoolPriceMonitor();
-    } catch (err) {
-      logger.warn('Pool price monitor failed to start', { error: String(err) });
-    }
-    try {
-      startArbitrageScanner();
-    } catch (err) {
-      logger.warn('Arbitrage scanner failed to start', { error: String(err) });
-    }
-    try {
-      startFeeAggregator();
-    } catch (err) {
-      logger.warn('Fee aggregator failed to start', { error: String(err) });
-    }
+    startPoolPriceMonitor();
+    startArbitrageScanner();
+    startFeeAggregator();
     try {
       startBridgeWorker();
     } catch (err) {


### PR DESCRIPTION
closes #421 

- Mount arbitrage router at /arbitrage
- Mount dex-analytics router at /dex-analytics
- Mount dex router at /dex
- Mount mev router at /mev
- Enable pool price monitor startup function
- Enable arbitrage scanner startup function
- Enable fee aggregator startup function
- Enable arbitrage WebSocket broadcaster

All modules are now fully integrated with the Express API and will start when DISABLE_INDEXER is not set. Resolves #421.

