### PR TITLE
fix: enforce allowedDomains restriction in API key auth middleware

### DIFF
--- a/src/middleware/apiKeyAuth.ts
+++ b/src/middleware/apiKeyAuth.ts
@@ -21,6 +21,7 @@ export interface ApiKeyContext {
   rateLimitOverride?: number;
   allowedIps?: string[];
   allowedEndpoints?: string[];
+  allowedDomains?: string[];
 }
 
 declare global {
@@ -52,6 +53,40 @@ function ipMatchesCidr(ip: string, cidr: string): boolean {
   }
 }
 
+// Extract the effective origin hostname from Origin or Referer headers.
+// Returns null when neither header is present or parseable.
+function extractOriginHost(req: Request): string | null {
+  const origin = req.headers['origin'] as string | undefined;
+  if (origin) {
+    try {
+      return new URL(origin).hostname;
+    } catch {
+      return null;
+    }
+  }
+  const referer = req.headers['referer'] as string | undefined;
+  if (referer) {
+    try {
+      return new URL(referer).hostname;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function domainAllowed(host: string, allowedDomains: string[]): boolean {
+  if (allowedDomains.length === 0) return true;
+  return allowedDomains.some((pattern) => {
+    if (pattern.startsWith('*.')) {
+      // *.example.com matches sub.example.com but NOT bare example.com
+      const suffix = pattern.slice(1); // ".example.com"
+      return host.endsWith(suffix) && host.length > suffix.length;
+    }
+    return host === pattern;
+  });
+}
+
 function endpointAllowed(path: string, allowedEndpoints: string[]): boolean {
   if (allowedEndpoints.length === 0) return true;
   return allowedEndpoints.some((pattern) => {
@@ -68,6 +103,11 @@ const KEY_CACHE_TTL = 60_000;
 /** Exposed for testing only — do not call in production code. */
 export function _keyCacheKeys(): string[] {
   return Array.from(keyCache.keys());
+}
+
+/** Exposed for testing only — do not call in production code. */
+export function _clearKeyCache(): void {
+  keyCache.clear();
 }
 
 async function resolveApiKey(raw: string): Promise<ApiKeyContext | null> {
@@ -106,6 +146,9 @@ async function resolveApiKey(raw: string): Promise<ApiKeyContext | null> {
       allowedEndpoints: Array.isArray(record.allowedEndpoints)
         ? (record.allowedEndpoints as string[])
         : undefined,
+      allowedDomains: Array.isArray(record.allowedDomains)
+        ? (record.allowedDomains as string[])
+        : undefined,
     };
 
     // Update lastUsedAt + usageCount async (non-blocking)
@@ -143,6 +186,16 @@ export async function apiKeyAuth(req: Request, res: Response, next: NextFunction
     if (!ctx.allowedIps.some((cidr) => ipMatchesCidr(clientIp, cidr))) {
       logger.warn('[api-key] IP not in whitelist', { keyId: ctx.id, ip: clientIp });
       res.status(403).json({ error: 'IP address not permitted for this key' });
+      return;
+    }
+  }
+
+  // Domain whitelist check (Origin then Referer)
+  if (ctx.allowedDomains && ctx.allowedDomains.length > 0) {
+    const host = extractOriginHost(req);
+    if (!host || !domainAllowed(host, ctx.allowedDomains)) {
+      logger.warn('[api-key] domain not in whitelist', { keyId: ctx.id, host });
+      res.status(403).json({ error: 'Origin domain not permitted for this key' });
       return;
     }
   }

--- a/tests/api-key-auth.test.ts
+++ b/tests/api-key-auth.test.ts
@@ -13,6 +13,7 @@ import {
   requireApiKey,
   requireKeyTier,
   _keyCacheKeys,
+  _clearKeyCache,
 } from '../src/middleware/apiKeyAuth';
 import { prismaRead } from '../src/db';
 import crypto from 'crypto';
@@ -49,6 +50,7 @@ describe('apiKeyAuth', () => {
     next = vi.fn();
     mockFind.mockResolvedValue(null);
     vi.clearAllMocks();
+    _clearKeyCache();
   });
 
   it('calls next without setting apiKey when no header present', async () => {
@@ -99,6 +101,83 @@ describe('apiKeyAuth', () => {
     const { res, status } = makeRes();
     await apiKeyAuth(req, res, next);
     expect(status).toHaveBeenCalledWith(403);
+  });
+
+  describe('domain whitelist', () => {
+    const DOMAIN_RECORD = { ...VALID_RECORD, allowedDomains: ['example.com'] };
+
+    it('allows request when Origin matches allowedDomains', async () => {
+      mockFind.mockResolvedValue(DOMAIN_RECORD);
+      const req = makeReq({ 'x-api-key': 'valid', origin: 'https://example.com' });
+      const { res } = makeRes();
+      await apiKeyAuth(req, res, next);
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('allows request when Referer hostname matches allowedDomains (fallback)', async () => {
+      mockFind.mockResolvedValue(DOMAIN_RECORD);
+      const req = makeReq({
+        'x-api-key': 'valid',
+        referer: 'https://example.com/some/path?q=1',
+      });
+      const { res } = makeRes();
+      await apiKeyAuth(req, res, next);
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('returns 403 when Origin does not match allowedDomains', async () => {
+      mockFind.mockResolvedValue(DOMAIN_RECORD);
+      const req = makeReq({ 'x-api-key': 'valid', origin: 'https://evil.com' });
+      const { res, status } = makeRes();
+      await apiKeyAuth(req, res, next);
+      expect(status).toHaveBeenCalledWith(403);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when neither Origin nor Referer header is present', async () => {
+      mockFind.mockResolvedValue(DOMAIN_RECORD);
+      const req = makeReq({ 'x-api-key': 'valid' });
+      const { res, status } = makeRes();
+      await apiKeyAuth(req, res, next);
+      expect(status).toHaveBeenCalledWith(403);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('allows request when no domain restriction is configured', async () => {
+      mockFind.mockResolvedValue(VALID_RECORD); // allowedDomains: null
+      const req = makeReq({ 'x-api-key': 'valid', origin: 'https://any-domain.io' });
+      const { res } = makeRes();
+      await apiKeyAuth(req, res, next);
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('wildcard *.example.com matches sub.example.com', async () => {
+      mockFind.mockResolvedValue({ ...VALID_RECORD, allowedDomains: ['*.example.com'] });
+      const req = makeReq({ 'x-api-key': 'valid', origin: 'https://app.example.com' });
+      const { res } = makeRes();
+      await apiKeyAuth(req, res, next);
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('wildcard *.example.com does NOT match bare example.com', async () => {
+      mockFind.mockResolvedValue({ ...VALID_RECORD, allowedDomains: ['*.example.com'] });
+      const req = makeReq({ 'x-api-key': 'valid', origin: 'https://example.com' });
+      const { res, status } = makeRes();
+      await apiKeyAuth(req, res, next);
+      expect(status).toHaveBeenCalledWith(403);
+    });
+
+    it('prefers Origin header over Referer when both are present', async () => {
+      mockFind.mockResolvedValue(DOMAIN_RECORD);
+      const req = makeReq({
+        'x-api-key': 'valid',
+        origin: 'https://example.com',
+        referer: 'https://evil.com/page',
+      });
+      const { res } = makeRes();
+      await apiKeyAuth(req, res, next);
+      expect(next).toHaveBeenCalled();
+    });
   });
 
   it('returns 403 when endpoint not in whitelist', async () => {


### PR DESCRIPTION
## Summary

- `allowedDomains` was selected from the DB but never added to `ApiKeyContext`, so domain restrictions silently had no effect
- Wires `allowedDomains` into the context and enforces it in `apiKeyAuth` via `Origin` header (falling back to `Referer`)
- Supports exact hostname matches and `*.example.com` wildcard patterns (subdomain-only — bare apex is rejected)

## Changes

- `ApiKeyContext` — added `allowedDomains?: string[]` field
- `resolveApiKey` — populates `allowedDomains` from DB record
- `extractOriginHost` — new helper: reads `Origin`, falls back to `Referer`, returns parsed hostname or `null`
- `domainAllowed` — new helper: exact match + `*.` wildcard support
- `apiKeyAuth` — domain enforcement block inserted between IP check and endpoint check; returns `403` when domain is restricted but no matching origin header is present
- `_clearKeyCache` — new test-only export (module-level cache was poisoning cross-test state)

## Test plan

- [x] Origin header matches `allowedDomains` → passes
- [x] Referer hostname used as fallback when Origin absent → passes
- [x] Origin does not match → 403
- [x] Neither Origin nor Referer present, domain restriction set → 403
- [x] No domain restriction configured → passes regardless of Origin
- [x] `*.example.com` matches `app.example.com` → passes
- [x] `*.example.com` rejects bare `example.com` → 403
- [x] Origin takes priority over Referer when both present → passes

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)