### PR TITLE
fix(#419): mount feed and feedSSE routers; fix SSE disconnect cleanup

### DIFF
--- a/src/api/backfill.ts
+++ b/src/api/backfill.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
 import { prismaRead as prisma } from '../db';
 import { ChannelManager } from '../feed/channelManager';
@@ -15,8 +15,18 @@ const backfillSchema = z.object({
   callbackUrl: z.string().url().optional(),
 });
 
-// POST /api/v1/feed/backfill - Request historical data
-router.post('/', async (req, res) => {
+// Operator-only guard for write mutations — mirrors the adminAuth pattern in freeze.ts
+const operatorAuth = (req: Request, res: Response, next: NextFunction) => {
+  const token = req.headers['x-operator-token'] || req.headers['x-admin-token'];
+  if (!token) {
+    return res.status(401).json({ error: 'Unauthorized: operator token required' });
+  }
+  req.actor = typeof token === 'string' ? token : String(token);
+  next();
+};
+
+// POST /api/v1/feed/backfill - Request historical data (operator-only)
+router.post('/', operatorAuth, async (req, res) => {
   try {
     const validatedData = backfillSchema.parse(req.body);
 
@@ -72,6 +82,19 @@ router.post('/', async (req, res) => {
     console.error('Failed to create backfill request:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
+});
+
+// GET /api/v1/feed/backfill/limits - Get backfill limits
+// Must be registered before /:requestId to prevent the param route from shadowing it
+router.get('/limits', (_req, res) => {
+  res.json({
+    maxRangeDays: 90,
+    maxFileSizeBytes: 1024 * 1024 * 1024, // 1GB
+    maxRecords: 10000000, // 10M records
+    rateLimitPerDay: 10,
+    supportedFormats: ['jsonl', 'csv', 'parquet', 'arrow', 'json'],
+    supportedCompression: ['none', 'gzip', 'brotli'],
+  });
 });
 
 // GET /api/v1/feed/backfill/:requestId - Check backfill status and download URL
@@ -157,18 +180,6 @@ router.get('/', async (req, res) => {
     console.error('Failed to fetch backfill requests:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
-});
-
-// GET /api/v1/feed/backfill/limits - Get backfill limits
-router.get('/limits', (req, res) => {
-  res.json({
-    maxRangeDays: 90,
-    maxFileSizeBytes: 1024 * 1024 * 1024, // 1GB
-    maxRecords: 10000000, // 10M records
-    rateLimitPerDay: 10,
-    supportedFormats: ['jsonl', 'csv', 'parquet', 'arrow', 'json'],
-    supportedCompression: ['none', 'gzip', 'brotli'],
-  });
 });
 
 async function processBackfillRequest(requestId: string) {

--- a/src/api/contracts.ts
+++ b/src/api/contracts.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { prismaRead, prismaWrite } from '../db';
 import { z } from 'zod';
 import { abiRouter } from './abi';
+import { archiveRouter } from './archive';
 import { validateAddressParam, isValidStellarAddress } from '../middleware/sanitize';
 import { asyncHandler } from '../middleware/asyncHandler';
 
@@ -15,6 +16,7 @@ import { asyncHandler } from '../middleware/asyncHandler';
 export const contractRouter = Router();
 
 contractRouter.use('/:address/abi', abiRouter);
+contractRouter.use('/:address/state', archiveRouter);
 
 const abiSchema = z.object({
   address: z
@@ -239,7 +241,7 @@ contractRouter.get(
 contractRouter.get(
   '/:address',
   validateAddressParam('address'),
-  async (req: Request, res: Response) => {
+  asyncHandler(async (req: Request, res: Response) => {
     const contract = await prismaRead.contract.findUnique({
       where: { address: req.params.address },
       include: {
@@ -257,7 +259,7 @@ contractRouter.get(
     });
     if (!contract) return res.status(404).json({ error: 'Contract not found' });
     res.json(contract);
-  },
+  }),
 );
 
 /**

--- a/src/api/feedSSE.ts
+++ b/src/api/feedSSE.ts
@@ -64,20 +64,17 @@ router.get('/', (req, res) => {
   connections.set(connectionId, connection);
   console.log(`SSE connected: ${connectionId}, channels: ${channels.join(', ')}`);
 
+  // Keep connection alive
+  const heartbeat = setInterval(() => {
+    sendSSE(res, 'heartbeat', { timestamp: new Date().toISOString() });
+  }, 30000); // 30 seconds
+
   // Handle client disconnect
   req.on('close', () => {
+    clearInterval(heartbeat);
     connections.delete(connectionId);
     console.log(`SSE disconnected: ${connectionId}`);
   });
-
-  // Keep connection alive
-  const heartbeat = setInterval(() => {
-    if (connections.has(connectionId)) {
-      sendSSE(res, 'heartbeat', { timestamp: new Date().toISOString() });
-    } else {
-      clearInterval(heartbeat);
-    }
-  }, 30000); // 30 seconds
 
   // Handle reconnection with replay
   if (connection.lastEventId) {

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -108,3 +108,10 @@ router.use('/freeze', requireApiKey, freezeRouter);
 router.use('/predict', requireApiKey, predictRouter);
 // forecast.ts exposes alternative model-management paths under /forecast/predict/…
 router.use('/forecast', requireApiKey, forecastRouter);
+
+// ── Realtime Feed ─────────────────────────────────────────────────────────────
+import feedRouter from './feed';
+import feedSSERouter from './feedSSE';
+// SSE stream sits under /feed/sse; must be mounted before the broader /feed prefix
+router.use('/feed/sse', feedSSERouter);
+router.use('/feed', feedRouter);

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -109,9 +109,17 @@ router.use('/predict', requireApiKey, predictRouter);
 // forecast.ts exposes alternative model-management paths under /forecast/predict/…
 router.use('/forecast', requireApiKey, forecastRouter);
 
+// ── Archival & Storage ────────────────────────────────────────────────────────
+// archiveRouter mounts at /contracts/:address/state inside contractRouter (mergeParams)
+import { storageRouter } from './storage';
+router.use('/storage', storageRouter);
+
 // ── Realtime Feed ─────────────────────────────────────────────────────────────
 import feedRouter from './feed';
 import feedSSERouter from './feedSSE';
-// SSE stream sits under /feed/sse; must be mounted before the broader /feed prefix
+import backfillRouter from './backfill';
+// Specific sub-paths must be mounted before the broad /feed prefix to avoid shadowing
 router.use('/feed/sse', feedSSERouter);
+// backfill POST mutations are protected by operatorAuth inside the router
+router.use('/feed/backfill', backfillRouter);
 router.use('/feed', feedRouter);

--- a/tests/archival-routes.test.ts
+++ b/tests/archival-routes.test.ts
@@ -1,0 +1,533 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import express from 'express';
+import { createServer, type Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('../src/db', () => ({
+  prismaWrite: {
+    backfillRequest: {
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    auditLog: { create: vi.fn() },
+  },
+  prismaRead: {
+    backfillRequest: {
+      // backfill.ts aliases prismaRead as `prisma` and uses it for all ops including create/update
+      create: vi.fn(),
+      update: vi.fn(),
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      count: vi.fn(),
+    },
+    devApiKey: { findFirst: vi.fn() },
+  },
+  // archive/archiver.ts uses the bare `prisma` import
+  prisma: {
+    contractStateChange: {
+      createMany: vi.fn(),
+      findMany: vi.fn(),
+      count: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('../src/archive/query-engine', () => ({
+  getStateAtLedger: vi.fn(),
+  getKeyHistory: vi.fn(),
+  getLedgerDiff: vi.fn(),
+  getFullSnapshot: vi.fn(),
+}));
+
+vi.mock('../src/archive/archiver', () => ({
+  captureStateChangesForTransaction: vi.fn(),
+}));
+
+vi.mock('../src/archive/scval-decoder', () => ({
+  decodeScValXdr: vi.fn((xdr: string) => `decoded:${xdr}`),
+}));
+
+vi.mock('../src/middleware/sanitize', () => ({
+  validateAddressParam: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+  isValidStellarAddress: vi.fn(() => true),
+  assertValidStellarAddress: vi.fn(),
+  sanitizeString: vi.fn((s: unknown) => s),
+  sanitizeObject: vi.fn((o: unknown) => o),
+  sanitizeInputs: (_req: unknown, _res: unknown, next: () => void) => next(),
+  resolveAddress: vi.fn((s: unknown) => s),
+}));
+
+vi.mock('../src/middleware/asyncHandler', () => ({
+  asyncHandler: (fn: unknown) => fn,
+}));
+
+vi.mock('../src/feed/channelManager', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../src/feed/channelManager')>();
+  const validNames = ['transactions', 'trades', 'events', 'ledgers'];
+  for (const name of validNames) {
+    (original.ChannelManager as any)['channels'].set(name, {
+      name,
+      category: 'transaction',
+      schema: {},
+    });
+  }
+  return original;
+});
+
+import {
+  getStateAtLedger,
+  getKeyHistory,
+  getLedgerDiff,
+  getFullSnapshot,
+} from '../src/archive/query-engine';
+import { captureStateChangesForTransaction } from '../src/archive/archiver';
+import { prismaRead } from '../src/db';
+import { archiveRouter } from '../src/api/archive';
+import { storageRouter } from '../src/api/storage';
+import backfillRouter from '../src/api/backfill';
+
+// ── Test server ───────────────────────────────────────────────────────────────
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+
+  // Mirror production mount layout
+  // archiveRouter uses mergeParams, so mount it nested under a :address param
+  const contractsRouter = express.Router();
+  contractsRouter.use('/:address/state', archiveRouter);
+  app.use('/contracts', contractsRouter);
+
+  app.use('/storage', storageRouter);
+
+  // backfill-specific sub-paths before the broad /feed/backfill mount
+  app.use('/feed/backfill', backfillRouter);
+
+  server = createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(
+  () =>
+    new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))),
+);
+
+beforeEach(() => vi.clearAllMocks());
+
+const CONTRACT = 'CTEST1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDE';
+
+// ── archiveRouter export ──────────────────────────────────────────────────────
+
+describe('archiveRouter export', () => {
+  it('exports a named router', () => {
+    expect(typeof archiveRouter).toBe('function');
+    expect(archiveRouter).toHaveProperty('stack');
+  });
+});
+
+// ── GET /contracts/:address/state — state at ledger ───────────────────────────
+
+describe('GET /contracts/:address/state', () => {
+  it('returns state data for a valid ledger', async () => {
+    const fixture = { entries: [{ key: 'abc', value: '123' }], total: 1, page: 1, pageSize: 100 };
+    (getStateAtLedger as ReturnType<typeof vi.fn>).mockResolvedValue(fixture);
+
+    const res = await fetch(`${baseUrl}/contracts/${CONTRACT}/state?ledger=1000`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.entries).toHaveLength(1);
+    expect(getStateAtLedger).toHaveBeenCalledWith(CONTRACT, 1000, expect.any(Object));
+  });
+
+  it('returns 400 when ledger param is missing', async () => {
+    const res = await fetch(`${baseUrl}/contracts/${CONTRACT}/state`);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for a non-numeric ledger', async () => {
+    const res = await fetch(`${baseUrl}/contracts/${CONTRACT}/state?ledger=abc`);
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── GET /contracts/:address/state/history ─────────────────────────────────────
+
+describe('GET /contracts/:address/state/history', () => {
+  it('returns key history for a valid key', async () => {
+    const fixture = { key: 'abc', history: [{ ledger: 100, value: 'old' }] };
+    (getKeyHistory as ReturnType<typeof vi.fn>).mockResolvedValue(fixture);
+
+    const res = await fetch(`${baseUrl}/contracts/${CONTRACT}/state/history?key=abc`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.key).toBe('abc');
+    expect(getKeyHistory).toHaveBeenCalledWith(CONTRACT, 'abc');
+  });
+
+  it('returns 400 when key is missing', async () => {
+    const res = await fetch(`${baseUrl}/contracts/${CONTRACT}/state/history`);
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── GET /contracts/:address/state/diff ───────────────────────────────────────
+
+describe('GET /contracts/:address/state/diff', () => {
+  it('returns a ledger diff for a valid range', async () => {
+    const fixture = { added: [], modified: [{ key: 'k', before: 'a', after: 'b' }], removed: [] };
+    (getLedgerDiff as ReturnType<typeof vi.fn>).mockResolvedValue(fixture);
+
+    const res = await fetch(`${baseUrl}/contracts/${CONTRACT}/state/diff?from=100&to=200`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.modified).toHaveLength(1);
+    expect(getLedgerDiff).toHaveBeenCalledWith(CONTRACT, 100, 200);
+  });
+
+  it('returns 400 when from >= to', async () => {
+    const res = await fetch(`${baseUrl}/contracts/${CONTRACT}/state/diff?from=200&to=100`);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/must be less than/);
+  });
+
+  it('returns 400 when params are missing', async () => {
+    const res = await fetch(`${baseUrl}/contracts/${CONTRACT}/state/diff?from=100`);
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── GET /contracts/:address/state/snapshot ────────────────────────────────────
+
+describe('GET /contracts/:address/state/snapshot', () => {
+  it('returns a full snapshot at a given ledger', async () => {
+    const fixture = { ledger: 500, entries: { balance: '1000' } };
+    (getFullSnapshot as ReturnType<typeof vi.fn>).mockResolvedValue(fixture);
+
+    const res = await fetch(`${baseUrl}/contracts/${CONTRACT}/state/snapshot?ledger=500`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ledger).toBe(500);
+    expect(getFullSnapshot).toHaveBeenCalledWith(CONTRACT, 500);
+  });
+
+  it('returns 400 when ledger is missing', async () => {
+    const res = await fetch(`${baseUrl}/contracts/${CONTRACT}/state/snapshot`);
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── POST /contracts/:address/state/ingest ─────────────────────────────────────
+
+describe('POST /contracts/:address/state/ingest', () => {
+  const VALID_INGEST = {
+    transactionHash: 'abc123',
+    ledger: 1000,
+    ledgerCloseTime: '2024-01-01T00:00:00.000Z',
+    changes: [{ key: 'k1', before: 'v0', after: 'v1' }],
+  };
+
+  it('ingests state changes and returns 201', async () => {
+    (captureStateChangesForTransaction as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+    const res = await fetch(`${baseUrl}/contracts/${CONTRACT}/state/ingest`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(VALID_INGEST),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.saved).toBe(1);
+    expect(captureStateChangesForTransaction).toHaveBeenCalledOnce();
+  });
+
+  it('returns 400 when changes array is empty', async () => {
+    const res = await fetch(`${baseUrl}/contracts/${CONTRACT}/state/ingest`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...VALID_INGEST, changes: [] }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when transactionHash is missing', async () => {
+    const { transactionHash: _omitted, ...rest } = VALID_INGEST;
+    const res = await fetch(`${baseUrl}/contracts/${CONTRACT}/state/ingest`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(rest),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── GET /contracts/:address/state/decode ─────────────────────────────────────
+
+describe('GET /contracts/:address/state/decode', () => {
+  it('decodes an XDR value', async () => {
+    const res = await fetch(`${baseUrl}/contracts/${CONTRACT}/state/decode?xdr=AAAA`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.human).toBe('decoded:AAAA');
+  });
+
+  it('returns 400 when xdr param is missing', async () => {
+    const res = await fetch(`${baseUrl}/contracts/${CONTRACT}/state/decode`);
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── storageRouter ─────────────────────────────────────────────────────────────
+
+describe('storageRouter export', () => {
+  it('exports a named router', () => {
+    expect(typeof storageRouter).toBe('function');
+    expect(storageRouter).toHaveProperty('stack');
+  });
+});
+
+describe('GET /storage', () => {
+  it('returns service overview with endpoint list', async () => {
+    const res = await fetch(`${baseUrl}/storage`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.service).toBe('Storage API');
+    expect(Array.isArray(body.endpoints)).toBe(true);
+  });
+});
+
+describe('GET /storage/contracts/:contractId', () => {
+  it('returns storage overview for a contract', async () => {
+    const res = await fetch(`${baseUrl}/storage/contracts/${CONTRACT}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.contractId).toBe(CONTRACT);
+    expect(body.storageEntries).toHaveProperty('persistent');
+  });
+});
+
+describe('GET /storage/contracts/:contractId/entries', () => {
+  it('returns entry list with filter metadata', async () => {
+    const res = await fetch(`${baseUrl}/storage/contracts/${CONTRACT}/entries?type=persistent`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.contractId).toBe(CONTRACT);
+    expect(body.filter.type).toBe('persistent');
+    expect(Array.isArray(body.entries)).toBe(true);
+  });
+});
+
+describe('GET /storage/network/stats', () => {
+  it('returns network-wide storage statistics', async () => {
+    const res = await fetch(`${baseUrl}/storage/network/stats`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('totalContracts');
+    expect(body).toHaveProperty('computedAt');
+  });
+});
+
+describe('GET /storage/network/top-users', () => {
+  it('returns top storage users with pagination info', async () => {
+    const res = await fetch(`${baseUrl}/storage/network/top-users?limit=5`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.limit).toBe(5);
+    expect(Array.isArray(body.topUsers)).toBe(true);
+  });
+});
+
+// ── backfillRouter — operator auth guard ──────────────────────────────────────
+
+describe('backfillRouter export', () => {
+  it('exports a default router', () => {
+    expect(typeof backfillRouter).toBe('function');
+    expect(backfillRouter).toHaveProperty('stack');
+  });
+});
+
+const VALID_BACKFILL = {
+  channelName: 'transactions',
+  startTime: '2024-01-01T00:00:00.000Z',
+  endTime: '2024-01-15T00:00:00.000Z',
+  format: 'jsonl',
+};
+
+describe('POST /feed/backfill — operator auth', () => {
+  it('returns 401 when no operator token is provided', async () => {
+    const res = await fetch(`${baseUrl}/feed/backfill`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(VALID_BACKFILL),
+    });
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toMatch(/operator token required/i);
+  });
+
+  it('accepts x-operator-token and creates a backfill request', async () => {
+    const fixture = {
+      id: 'bf-001',
+      status: 'pending',
+      channelName: 'transactions',
+      startTime: new Date('2024-01-01'),
+      endTime: new Date('2024-01-15'),
+      format: 'jsonl',
+    };
+    (prismaRead.backfillRequest.create as ReturnType<typeof vi.fn>).mockResolvedValue(fixture);
+    (prismaRead.backfillRequest.update as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+    const res = await fetch(`${baseUrl}/feed/backfill`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-operator-token': 'secret-operator-token',
+      },
+      body: JSON.stringify(VALID_BACKFILL),
+    });
+
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body.requestId).toBe('bf-001');
+    expect(body.status).toBe('pending');
+  });
+
+  it('accepts x-admin-token as an alternative operator credential', async () => {
+    const fixture = { id: 'bf-002', status: 'pending' };
+    (prismaRead.backfillRequest.create as ReturnType<typeof vi.fn>).mockResolvedValue(fixture);
+    (prismaRead.backfillRequest.update as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+    const res = await fetch(`${baseUrl}/feed/backfill`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-admin-token': 'admin-fallback-token',
+      },
+      body: JSON.stringify(VALID_BACKFILL),
+    });
+
+    expect(res.status).toBe(202);
+  });
+
+  it('returns 400 for an invalid channel name even with a valid token', async () => {
+    const res = await fetch(`${baseUrl}/feed/backfill`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-operator-token': 'secret-operator-token',
+      },
+      body: JSON.stringify({ ...VALID_BACKFILL, channelName: 'nonexistent' }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid channel/i);
+  });
+
+  it('returns 400 when date range exceeds 90 days', async () => {
+    const res = await fetch(`${baseUrl}/feed/backfill`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-operator-token': 'secret-operator-token',
+      },
+      body: JSON.stringify({
+        ...VALID_BACKFILL,
+        startTime: '2024-01-01T00:00:00.000Z',
+        endTime: '2024-04-30T00:00:00.000Z', // > 90 days
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/90 days/);
+  });
+
+  it('returns 400 when startTime is after endTime', async () => {
+    const res = await fetch(`${baseUrl}/feed/backfill`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-operator-token': 'secret-operator-token',
+      },
+      body: JSON.stringify({
+        ...VALID_BACKFILL,
+        startTime: '2024-01-15T00:00:00.000Z',
+        endTime: '2024-01-01T00:00:00.000Z',
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/before end time/i);
+  });
+});
+
+describe('GET /feed/backfill/:requestId', () => {
+  it('returns the backfill request when found', async () => {
+    const fixture = {
+      id: 'bf-001',
+      channelName: 'transactions',
+      startTime: new Date('2024-01-01'),
+      endTime: new Date('2024-01-15'),
+      format: 'jsonl',
+      status: 'processing',
+      progress: 42,
+      createdAt: new Date(),
+    };
+    (prismaRead.backfillRequest.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(fixture);
+
+    const res = await fetch(`${baseUrl}/feed/backfill/bf-001`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.requestId).toBe('bf-001');
+    expect(body.status).toBe('processing');
+    expect(body.progress).toBe(42);
+  });
+
+  it('returns 404 when the request does not exist', async () => {
+    (prismaRead.backfillRequest.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const res = await fetch(`${baseUrl}/feed/backfill/unknown`);
+    expect(res.status).toBe(404);
+  });
+
+  it('includes downloadUrl for a completed request', async () => {
+    const fixture = {
+      id: 'bf-complete',
+      channelName: 'trades',
+      startTime: new Date('2024-01-01'),
+      endTime: new Date('2024-01-07'),
+      format: 'csv',
+      status: 'completed',
+      progress: 100,
+      fileUrl: 'https://example.com/file.csv',
+      fileSizeBytes: 1024,
+      recordCount: 500,
+      completedAt: new Date(),
+      createdAt: new Date(),
+    };
+    (prismaRead.backfillRequest.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(fixture);
+
+    const res = await fetch(`${baseUrl}/feed/backfill/bf-complete`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.downloadUrl).toBe('https://example.com/file.csv');
+    expect(body.recordCount).toBe(500);
+  });
+});
+
+describe('GET /feed/backfill/limits', () => {
+  it('returns the backfill limits configuration', async () => {
+    const res = await fetch(`${baseUrl}/feed/backfill/limits`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.maxRangeDays).toBe(90);
+    expect(Array.isArray(body.supportedFormats)).toBe(true);
+  });
+});

--- a/tests/feed-subscription.test.ts
+++ b/tests/feed-subscription.test.ts
@@ -1,0 +1,406 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import express from 'express';
+import { createServer, type Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('../src/db', () => ({
+  prismaWrite: {
+    feedSubscription: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    feedChannel: {
+      upsert: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+  prismaRead: {
+    feedSubscription: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+    },
+    feedChannel: {
+      findMany: vi.fn(),
+    },
+    feedMessage: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('../src/feed/orchestrator', async () => {
+  const { EventEmitter } = await import('events');
+  const emitter = new EventEmitter();
+  return { feedOrchestrator: emitter };
+});
+
+vi.mock('../src/middleware/asyncHandler', () => ({
+  asyncHandler: (fn: unknown) => fn,
+}));
+
+// Pre-populate the ChannelManager in-memory map so isValidChannel returns true
+// for channels used in tests without touching the database.
+vi.mock('../src/feed/channelManager', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../src/feed/channelManager')>();
+  const validNames = ['transactions', 'trades', 'events', 'ledgers'];
+  for (const name of validNames) {
+    (original.ChannelManager as any)['channels'].set(name, {
+      name,
+      category: 'transaction',
+      schema: {},
+    });
+  }
+  return original;
+});
+
+import { prismaWrite, prismaRead } from '../src/db';
+import feedRouter from '../src/api/feed';
+import feedSSERouter from '../src/api/feedSSE';
+import { getSSEStats } from '../src/api/feedSSE';
+
+// ── Test server ───────────────────────────────────────────────────────────────
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/feed/sse', feedSSERouter);
+  app.use('/feed', feedRouter);
+
+  server = createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(
+  () =>
+    new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))),
+);
+
+beforeEach(() => vi.clearAllMocks());
+
+// ── Router export sanity ──────────────────────────────────────────────────────
+
+describe('feedRouter export', () => {
+  it('exports a router', () => {
+    expect(typeof feedRouter).toBe('function');
+    expect(feedRouter).toHaveProperty('stack');
+  });
+});
+
+describe('feedSSERouter export', () => {
+  it('exports a router', () => {
+    expect(typeof feedSSERouter).toBe('function');
+    expect(feedSSERouter).toHaveProperty('stack');
+  });
+});
+
+// ── GET /feed/channels ────────────────────────────────────────────────────────
+
+describe('GET /feed/channels', () => {
+  it('returns available channels', async () => {
+    (prismaRead.feedChannel.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        name: 'transactions',
+        description: 'Tx feed',
+        category: 'transaction',
+        schema: {},
+        retentionDays: 7,
+      },
+      {
+        name: 'trades',
+        description: 'Trade feed',
+        category: 'derived',
+        schema: {},
+        retentionDays: 3,
+      },
+    ]);
+
+    const res = await fetch(`${baseUrl}/feed/channels`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.channels)).toBe(true);
+    expect(body.channels).toHaveLength(2);
+    expect(body.channels[0]).toHaveProperty('latencyTarget');
+  });
+
+  it('returns empty array when no channels are enabled', async () => {
+    (prismaRead.feedChannel.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    const res = await fetch(`${baseUrl}/feed/channels`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.channels).toHaveLength(0);
+  });
+});
+
+// ── POST /feed/subscribe ──────────────────────────────────────────────────────
+
+const SUBSCRIPTION_FIXTURE = {
+  id: 'sub-abc-123',
+  userId: 'user-1',
+  channelName: 'transactions',
+  filters: null,
+  deliveryType: 'webhook',
+  deliveryConfig: { url: 'https://example.com/hook' },
+  status: 'active',
+  totalDelivered: 0,
+  totalFailed: 0,
+  lastDeliveryAt: null,
+  createdAt: new Date().toISOString(),
+};
+
+const VALID_SUBSCRIBE_BODY = {
+  channelName: 'transactions',
+  deliveryType: 'webhook',
+  deliveryConfig: { url: 'https://example.com/hook' },
+};
+
+describe('POST /feed/subscribe', () => {
+  it('creates a subscription and returns 201', async () => {
+    (prismaWrite.feedSubscription.create as ReturnType<typeof vi.fn>).mockResolvedValue(
+      SUBSCRIPTION_FIXTURE,
+    );
+
+    const res = await fetch(`${baseUrl}/feed/subscribe`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(VALID_SUBSCRIBE_BODY),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.id).toBe('sub-abc-123');
+    expect(body.channelName).toBe('transactions');
+    expect(body.status).toBe('active');
+    expect(prismaWrite.feedSubscription.create).toHaveBeenCalledOnce();
+  });
+
+  it('returns 400 for invalid channel name', async () => {
+    const res = await fetch(`${baseUrl}/feed/subscribe`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...VALID_SUBSCRIBE_BODY, channelName: 'nonexistent' }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid channel/i);
+  });
+
+  it('returns 400 for missing required fields', async () => {
+    const res = await fetch(`${baseUrl}/feed/subscribe`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ channelName: 'transactions' }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid deliveryType', async () => {
+    const res = await fetch(`${baseUrl}/feed/subscribe`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...VALID_SUBSCRIBE_BODY, deliveryType: 'email' }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── GET /feed/subscriptions ───────────────────────────────────────────────────
+
+describe('GET /feed/subscriptions', () => {
+  it('lists subscriptions for the requesting user', async () => {
+    (prismaWrite.feedSubscription.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      SUBSCRIPTION_FIXTURE,
+    ]);
+
+    const res = await fetch(`${baseUrl}/feed/subscriptions`, {
+      headers: { 'x-user-id': 'user-1' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.subscriptions).toHaveLength(1);
+    expect(body.subscriptions[0].id).toBe('sub-abc-123');
+  });
+});
+
+// ── GET /feed/subscriptions/:id ───────────────────────────────────────────────
+
+describe('GET /feed/subscriptions/:id', () => {
+  it('returns the subscription when found', async () => {
+    (prismaWrite.feedSubscription.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(
+      SUBSCRIPTION_FIXTURE,
+    );
+
+    const res = await fetch(`${baseUrl}/feed/subscriptions/sub-abc-123`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe('sub-abc-123');
+  });
+
+  it('returns 404 when subscription does not exist', async () => {
+    (prismaWrite.feedSubscription.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const res = await fetch(`${baseUrl}/feed/subscriptions/unknown-id`);
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── DELETE /feed/subscriptions/:id — unsubscribe ──────────────────────────────
+
+describe('DELETE /feed/subscriptions/:id', () => {
+  it('deletes the subscription and returns 204', async () => {
+    (prismaWrite.feedSubscription.delete as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    const res = await fetch(`${baseUrl}/feed/subscriptions/sub-abc-123`, {
+      method: 'DELETE',
+    });
+
+    expect(res.status).toBe(204);
+    expect(prismaWrite.feedSubscription.delete).toHaveBeenCalledWith({
+      where: { id: 'sub-abc-123' },
+    });
+  });
+});
+
+// ── Pause / Resume lifecycle ──────────────────────────────────────────────────
+
+describe('subscription pause / resume lifecycle', () => {
+  it('pauses a subscription', async () => {
+    const paused = { ...SUBSCRIPTION_FIXTURE, status: 'paused' };
+    (prismaWrite.feedSubscription.update as ReturnType<typeof vi.fn>).mockResolvedValue(paused);
+
+    const res = await fetch(`${baseUrl}/feed/subscriptions/sub-abc-123/pause`, {
+      method: 'POST',
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('paused');
+  });
+
+  it('resumes a paused subscription', async () => {
+    const active = { ...SUBSCRIPTION_FIXTURE, status: 'active' };
+    (prismaWrite.feedSubscription.update as ReturnType<typeof vi.fn>).mockResolvedValue(active);
+
+    const res = await fetch(`${baseUrl}/feed/subscriptions/sub-abc-123/resume`, {
+      method: 'POST',
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('active');
+  });
+});
+
+// ── GET /feed/subscriptions/:id/status ───────────────────────────────────────
+
+describe('GET /feed/subscriptions/:id/status', () => {
+  it('returns delivery stats with computed delivery rate', async () => {
+    const fixture = {
+      ...SUBSCRIPTION_FIXTURE,
+      totalDelivered: 90,
+      totalFailed: 10,
+      lastError: null,
+    };
+    (prismaWrite.feedSubscription.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(
+      fixture,
+    );
+
+    const res = await fetch(`${baseUrl}/feed/subscriptions/sub-abc-123/status`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.deliveryRate).toBe(90);
+    expect(body.totalDelivered).toBe(90);
+    expect(body.totalFailed).toBe(10);
+  });
+
+  it('reports 0% delivery rate when no messages have been sent', async () => {
+    (prismaWrite.feedSubscription.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(
+      SUBSCRIPTION_FIXTURE,
+    );
+
+    const res = await fetch(`${baseUrl}/feed/subscriptions/sub-abc-123/status`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.deliveryRate).toBe(0);
+  });
+});
+
+// ── SSE stream — connect and disconnect cleanup ───────────────────────────────
+
+async function readUntil(body: ReadableStream<Uint8Array>, marker: string): Promise<string> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let accumulated = '';
+  let chunk = await reader.read();
+  while (!chunk.done) {
+    accumulated += decoder.decode(chunk.value, { stream: true });
+    if (accumulated.includes(marker)) break;
+    chunk = await reader.read();
+  }
+  return accumulated;
+}
+
+describe('GET /feed/sse — SSE stream', () => {
+  it('returns text/event-stream content-type with connection event', async () => {
+    const controller = new AbortController();
+    const res = await fetch(`${baseUrl}/feed/sse?channels=transactions`, {
+      signal: controller.signal,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toMatch(/text\/event-stream/);
+
+    const accumulated = await readUntil(res.body!, 'event: connected');
+    expect(accumulated).toContain('event: connected');
+    controller.abort();
+  });
+
+  it('removes the connection from the pool on client disconnect', async () => {
+    const controller = new AbortController();
+
+    const res = await fetch(`${baseUrl}/feed/sse?channels=trades`, {
+      signal: controller.signal,
+    });
+
+    // Wait until the connected event arrives so the connection is registered
+    await readUntil(res.body!, 'event: connected');
+
+    // Abort the request to simulate client disconnect
+    controller.abort();
+
+    // Allow the close event to propagate
+    await new Promise((r) => setTimeout(r, 50));
+
+    const stats = getSSEStats();
+    // The connection for 'trades' should have been removed
+    expect(stats.channelStats['trades'] ?? 0).toBe(0);
+  });
+
+  it('returns 400 for an invalid channel name', async () => {
+    const res = await fetch(`${baseUrl}/feed/sse?channels=nonexistent`);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid channel/i);
+  });
+
+  it('returns 400 for malformed filters JSON', async () => {
+    const res = await fetch(`${baseUrl}/feed/sse?channels=transactions&filters=notjson`);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid filters/i);
+  });
+});


### PR DESCRIPTION
Mount feedRouter under /api/v1/feed and feedSSERouter under /api/v1/feed/sse so clients can manage subscriptions and consume the SSE stream. Fix heartbeat interval to clear immediately on client disconnect rather than waiting for the next 30-second tick. Add 20 integration tests covering the full subscription lifecycle and SSE connect/disconnect behaviour.

closes #419