### PR TITLE
fix: validate required URLs at startup and make /readyz check real deps

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -54,6 +54,15 @@ export async function cacheConnect(): Promise<void> {
   await getRedisClient();
 }
 
+/**
+ * Returns true when the cache layer is operational:
+ * - always true when using the in-process memory store (no Redis configured)
+ * - true only after a successful Redis connection when a Redis URL is configured
+ */
+export function isCacheReady(): boolean {
+  return !USE_REDIS || redisAvailable;
+}
+
 export async function cacheClose(): Promise<void> {
   if (redisClient) {
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,8 @@ import { attachWebSocketServer, shutdownWebSocketServer } from './ws/eventBroadc
 import { attachPrivacyWebSocket as attachPrivacyWebSocketReal } from './ws/privacyBroadcaster';
 import yogaHandler from './graphql';
 import { warmTokenMetadataCache } from './indexer/token-metadata';
-import { cacheConnect, cacheClose } from './cache';
+import { cacheConnect, cacheClose, isCacheReady } from './cache';
+import { markReady, markNotReady, getReadinessState, isFullyReady } from './readiness';
 import { errorHandler } from './middleware/errorHandler';
 import { logger } from './logger';
 import { feedOrchestrator } from './feed/orchestrator';
@@ -160,9 +161,13 @@ app.get('/health', (_req, res) => {
 
 app.get('/readyz', (_req, res) => {
   if (isShuttingDown) {
-    return res.status(503).json({ status: 'not_ready' });
+    return res.status(503).json({ status: 'not_ready', reason: 'shutting_down' });
   }
-  res.json({ status: 'ready' });
+  const dependencies = getReadinessState();
+  if (!isFullyReady()) {
+    return res.status(503).json({ status: 'not_ready', dependencies });
+  }
+  res.json({ status: 'ready', dependencies });
 });
 
 app.use(errorHandler);
@@ -254,18 +259,28 @@ async function main() {
   registerShutdownHandlers();
 
   await initRateLimitStore();
+
   await cacheConnect();
+  if (isCacheReady()) markReady('cache');
+
   await prisma.$connect();
   dbConnectionStatus.set(1);
+  markReady('db');
+
   await initializeColdStorage();
+  markReady('coldStorage');
 
   if (!process.env.DISABLE_INDEXER) {
-    startIndexerService().catch((err) =>
-      logger.error('Indexer service failed', { error: String(err) }),
-    );
+    markReady('indexer');
+    startIndexerService().catch((err) => {
+      logger.error('Indexer service failed', { error: String(err) });
+      markNotReady('indexer');
+    });
     warmTokenMetadataCache().catch((err) =>
       logger.warn('Token-metadata cache warm-up failed', { error: String(err) }),
     );
+  } else {
+    markReady('indexer');
   }
 
   const httpServer: Server = createServer(app);

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -80,7 +80,73 @@ const PROFILES: Record<NetworkName, NetworkProfile> = {
   },
 };
 
-/** Return the profile for `name`, throwing if unknown. */
+// ─── Profile validation ───────────────────────────────────────────────────────
+
+function isHttpUrl(s: string): boolean {
+  return s.startsWith('https://') || s.startsWith('http://');
+}
+
+function isWsUrl(s: string): boolean {
+  return s.startsWith('wss://') || s.startsWith('ws://');
+}
+
+function isDbUrl(s: string): boolean {
+  return s.startsWith('postgresql://') || s.startsWith('postgres://');
+}
+
+/**
+ * Validates that a profile's critical URLs are present and well-formed.
+ * Throws with an actionable message on the first violation found.
+ */
+export function validateProfile(profile: NetworkProfile): void {
+  const { name, databaseUrl, rpcUrl, rpcWsUrl, horizonUrl } = profile;
+
+  // ── Required fields ──────────────────────────────────────────────────────
+  if (!databaseUrl) {
+    throw new Error(
+      `[${name}] databaseUrl is required. Set ${name.toUpperCase()}_DATABASE_URL.`,
+    );
+  }
+  if (!rpcUrl) {
+    throw new Error(`[${name}] rpcUrl is required. Set ${name.toUpperCase()}_RPC_URL.`);
+  }
+  if (!rpcWsUrl) {
+    throw new Error(`[${name}] rpcWsUrl is required. Set ${name.toUpperCase()}_RPC_WS_URL.`);
+  }
+
+  // ── URL protocol validation ───────────────────────────────────────────────
+  if (!isDbUrl(databaseUrl)) {
+    throw new Error(
+      `[${name}] databaseUrl must begin with postgresql:// or postgres://, got: "${databaseUrl.slice(0, 30)}"`,
+    );
+  }
+  if (!isHttpUrl(rpcUrl)) {
+    throw new Error(
+      `[${name}] rpcUrl must begin with https:// or http://, got: "${rpcUrl.slice(0, 30)}"`,
+    );
+  }
+  if (!isWsUrl(rpcWsUrl)) {
+    throw new Error(
+      `[${name}] rpcWsUrl must begin with wss:// or ws://, got: "${rpcWsUrl.slice(0, 30)}"`,
+    );
+  }
+  if (horizonUrl && !isHttpUrl(horizonUrl)) {
+    throw new Error(
+      `[${name}] horizonUrl must begin with https:// or http://, got: "${horizonUrl.slice(0, 30)}"`,
+    );
+  }
+
+  // ── Network profile consistency ───────────────────────────────────────────
+  if (name === 'mainnet') {
+    if (rpcUrl.includes('testnet') || horizonUrl.includes('testnet')) {
+      throw new Error(
+        `[mainnet] rpcUrl or horizonUrl appears to point to testnet infrastructure.`,
+      );
+    }
+  }
+}
+
+/** Return the profile for `name`, throwing if unknown or misconfigured. */
 export function getProfile(name: string): NetworkProfile {
   const profile = PROFILES[name as NetworkName];
   if (!profile) {
@@ -88,6 +154,7 @@ export function getProfile(name: string): NetworkProfile {
       `Unknown STELLAR_NETWORK "${name}". Valid values: ${Object.keys(PROFILES).join(', ')}`,
     );
   }
+  validateProfile(profile);
   return profile;
 }
 

--- a/src/readiness.ts
+++ b/src/readiness.ts
@@ -1,0 +1,24 @@
+export type DependencyName = 'db' | 'cache' | 'indexer' | 'coldStorage';
+
+const _state: Record<DependencyName, boolean> = {
+  db: false,
+  cache: false,
+  indexer: false,
+  coldStorage: false,
+};
+
+export function markReady(dep: DependencyName): void {
+  _state[dep] = true;
+}
+
+export function markNotReady(dep: DependencyName): void {
+  _state[dep] = false;
+}
+
+export function getReadinessState(): Record<DependencyName, boolean> {
+  return { ..._state };
+}
+
+export function isFullyReady(): boolean {
+  return Object.values(_state).every(Boolean);
+}

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -150,6 +150,7 @@ describe('config — network profile wiring', () => {
     vi.stubEnv('STELLAR_NETWORK', 'mainnet');
     vi.stubEnv('MAINNET_DATABASE_URL', 'postgresql://localhost/mainnet');
     vi.stubEnv('MAINNET_RPC_URL', 'https://mainnet.stellar.org/rpc');
+    vi.stubEnv('MAINNET_RPC_WS_URL', 'wss://mainnet.stellar.org/rpc');
     const cfg = await loadConfig();
     expect(cfg.stellarNetwork).toBe('mainnet');
     expect(cfg.networkPassphrase).toContain('Public Global Stellar Network');

--- a/tests/profiles.test.ts
+++ b/tests/profiles.test.ts
@@ -21,6 +21,9 @@ describe('profiles — getProfile', () => {
   });
 
   it('returns mainnet profile', async () => {
+    vi.stubEnv('MAINNET_RPC_URL', 'https://mainnet.rpc.example.com');
+    vi.stubEnv('MAINNET_RPC_WS_URL', 'wss://mainnet.rpc.example.com');
+    vi.stubEnv('MAINNET_DATABASE_URL', 'postgresql://mainnet-db/soroban');
     const { getProfile } = await loadProfiles();
     const p = getProfile('mainnet');
     expect(p.name).toBe('mainnet');
@@ -114,6 +117,8 @@ describe('profiles — env var overrides', () => {
 
   it('mainnet rpcUrl set via env', async () => {
     vi.stubEnv('MAINNET_RPC_URL', 'https://mainnet.validationcloud.io/rpc');
+    vi.stubEnv('MAINNET_RPC_WS_URL', 'wss://mainnet.validationcloud.io/rpc');
+    vi.stubEnv('MAINNET_DATABASE_URL', 'postgresql://mainnet-db/soroban');
     const { getProfile } = await loadProfiles();
     const p = getProfile('mainnet');
     expect(p.rpcUrl).toBe('https://mainnet.validationcloud.io/rpc');

--- a/tests/readyz.test.ts
+++ b/tests/readyz.test.ts
@@ -1,0 +1,178 @@
+/**
+ * tests/readyz.test.ts
+ *
+ * Verifies the /readyz endpoint tracks real dependency state and returns
+ * 503 with per-dependency details when any dependency is not yet ready.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import type { DependencyName } from '../src/readiness';
+
+// Each test gets a fresh module instance so state never leaks between tests.
+async function freshReadiness() {
+  vi.resetModules();
+  return import('../src/readiness');
+}
+
+type ReadinessMod = Awaited<ReturnType<typeof freshReadiness>>;
+
+function buildReadyzApp(mod: ReadinessMod, shutting = false) {
+  const { getReadinessState, isFullyReady } = mod;
+  const app = express();
+  app.get('/readyz', (_req, res) => {
+    if (shutting) {
+      return res.status(503).json({ status: 'not_ready', reason: 'shutting_down' });
+    }
+    const dependencies = getReadinessState();
+    if (!isFullyReady()) {
+      return res.status(503).json({ status: 'not_ready', dependencies });
+    }
+    res.json({ status: 'ready', dependencies });
+  });
+  return app;
+}
+
+// ── Initial state ─────────────────────────────────────────────────────────────
+
+describe('/readyz — initial state', () => {
+  it('returns 503 when no dependencies have been marked ready', async () => {
+    const mod = await freshReadiness();
+    const res = await request(buildReadyzApp(mod)).get('/readyz');
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe('not_ready');
+  });
+
+  it('includes per-dependency breakdown in the 503 body', async () => {
+    const mod = await freshReadiness();
+    const res = await request(buildReadyzApp(mod)).get('/readyz');
+    const { dependencies } = res.body as { dependencies: Record<DependencyName, boolean> };
+    expect(dependencies).toBeDefined();
+    expect(dependencies.db).toBe(false);
+    expect(dependencies.cache).toBe(false);
+    expect(dependencies.indexer).toBe(false);
+    expect(dependencies.coldStorage).toBe(false);
+  });
+});
+
+// ── Partial readiness ─────────────────────────────────────────────────────────
+
+describe('/readyz — partial readiness', () => {
+  it('returns 503 when only some dependencies are ready', async () => {
+    const mod = await freshReadiness();
+    mod.markReady('db');
+    mod.markReady('cache');
+    // indexer and coldStorage still false
+    const res = await request(buildReadyzApp(mod)).get('/readyz');
+    expect(res.status).toBe(503);
+    expect(res.body.dependencies.db).toBe(true);
+    expect(res.body.dependencies.cache).toBe(true);
+    expect(res.body.dependencies.indexer).toBe(false);
+    expect(res.body.dependencies.coldStorage).toBe(false);
+  });
+});
+
+// ── Full readiness ────────────────────────────────────────────────────────────
+
+describe('/readyz — fully ready', () => {
+  it('returns 200 once all dependencies are marked ready', async () => {
+    const mod = await freshReadiness();
+    mod.markReady('db');
+    mod.markReady('cache');
+    mod.markReady('indexer');
+    mod.markReady('coldStorage');
+    const res = await request(buildReadyzApp(mod)).get('/readyz');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ready');
+  });
+
+  it('includes all dependencies as true in the 200 body', async () => {
+    const mod = await freshReadiness();
+    mod.markReady('db');
+    mod.markReady('cache');
+    mod.markReady('indexer');
+    mod.markReady('coldStorage');
+    const res = await request(buildReadyzApp(mod)).get('/readyz');
+    const { dependencies } = res.body as { dependencies: Record<DependencyName, boolean> };
+    expect(dependencies.db).toBe(true);
+    expect(dependencies.cache).toBe(true);
+    expect(dependencies.indexer).toBe(true);
+    expect(dependencies.coldStorage).toBe(true);
+  });
+});
+
+// ── Shutdown override ─────────────────────────────────────────────────────────
+
+describe('/readyz — shutdown', () => {
+  it('returns 503 with shutting_down reason even when all deps are ready', async () => {
+    const mod = await freshReadiness();
+    mod.markReady('db');
+    mod.markReady('cache');
+    mod.markReady('indexer');
+    mod.markReady('coldStorage');
+    const res = await request(buildReadyzApp(mod, /* shutting= */ true)).get('/readyz');
+    expect(res.status).toBe(503);
+    expect(res.body.reason).toBe('shutting_down');
+  });
+});
+
+// ── Readiness transitions ─────────────────────────────────────────────────────
+
+describe('/readyz — readiness transitions', () => {
+  it('transitions from not_ready to ready as deps come up', async () => {
+    const mod = await freshReadiness();
+    const app = buildReadyzApp(mod);
+
+    let res = await request(app).get('/readyz');
+    expect(res.status).toBe(503);
+
+    mod.markReady('db');
+    mod.markReady('cache');
+    mod.markReady('indexer');
+    mod.markReady('coldStorage');
+
+    res = await request(app).get('/readyz');
+    expect(res.status).toBe(200);
+  });
+
+  it('transitions back to not_ready when the indexer fails post-startup', async () => {
+    const mod = await freshReadiness();
+    mod.markReady('db');
+    mod.markReady('cache');
+    mod.markReady('indexer');
+    mod.markReady('coldStorage');
+
+    const app = buildReadyzApp(mod);
+
+    let res = await request(app).get('/readyz');
+    expect(res.status).toBe(200);
+
+    mod.markNotReady('indexer');
+
+    res = await request(app).get('/readyz');
+    expect(res.status).toBe(503);
+    expect(res.body.dependencies.indexer).toBe(false);
+    // Other deps remain up
+    expect(res.body.dependencies.db).toBe(true);
+    expect(res.body.dependencies.cache).toBe(true);
+    expect(res.body.dependencies.coldStorage).toBe(true);
+  });
+
+  it('recovers to ready after a dep is restored', async () => {
+    const mod = await freshReadiness();
+    mod.markReady('db');
+    mod.markReady('cache');
+    mod.markReady('indexer');
+    mod.markReady('coldStorage');
+
+    const app = buildReadyzApp(mod);
+
+    mod.markNotReady('cache');
+    let res = await request(app).get('/readyz');
+    expect(res.status).toBe(503);
+
+    mod.markReady('cache');
+    res = await request(app).get('/readyz');
+    expect(res.status).toBe(200);
+  });
+});

--- a/tests/startup-validation.test.ts
+++ b/tests/startup-validation.test.ts
@@ -1,0 +1,180 @@
+/**
+ * tests/startup-validation.test.ts
+ *
+ * Verifies that getProfile() rejects incomplete or misconfigured profiles
+ * before the process starts connecting to external services.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+async function loadProfiles() {
+  vi.resetModules();
+  return import('../src/profiles');
+}
+
+// ── Required URL fields ───────────────────────────────────────────────────────
+
+describe('startup validation — mainnet requires explicit URLs', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('throws when MAINNET_DATABASE_URL is not set', async () => {
+    vi.stubEnv('MAINNET_RPC_URL', 'https://mainnet.example.com/rpc');
+    vi.stubEnv('MAINNET_RPC_WS_URL', 'wss://mainnet.example.com/rpc');
+    const { getProfile } = await loadProfiles();
+    expect(() => getProfile('mainnet')).toThrow(/databaseUrl is required/);
+  });
+
+  it('throws when MAINNET_RPC_URL is not set', async () => {
+    vi.stubEnv('MAINNET_DATABASE_URL', 'postgresql://mainnet-db/soroban');
+    vi.stubEnv('MAINNET_RPC_WS_URL', 'wss://mainnet.example.com/rpc');
+    const { getProfile } = await loadProfiles();
+    expect(() => getProfile('mainnet')).toThrow(/rpcUrl is required/);
+  });
+
+  it('throws when MAINNET_RPC_WS_URL is not set', async () => {
+    vi.stubEnv('MAINNET_DATABASE_URL', 'postgresql://mainnet-db/soroban');
+    vi.stubEnv('MAINNET_RPC_URL', 'https://mainnet.example.com/rpc');
+    const { getProfile } = await loadProfiles();
+    expect(() => getProfile('mainnet')).toThrow(/rpcWsUrl is required/);
+  });
+
+  it('accepts mainnet when all required URLs are provided', async () => {
+    vi.stubEnv('MAINNET_DATABASE_URL', 'postgresql://mainnet-db/soroban');
+    vi.stubEnv('MAINNET_RPC_URL', 'https://mainnet.example.com/rpc');
+    vi.stubEnv('MAINNET_RPC_WS_URL', 'wss://mainnet.example.com/rpc');
+    const { getProfile } = await loadProfiles();
+    expect(() => getProfile('mainnet')).not.toThrow();
+  });
+});
+
+describe('startup validation — testnet requires a database URL', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('throws when neither TESTNET_DATABASE_URL nor DATABASE_URL is set', async () => {
+    vi.stubEnv('TESTNET_DATABASE_URL', '');
+    vi.stubEnv('DATABASE_URL', '');
+    const { getProfile } = await loadProfiles();
+    expect(() => getProfile('testnet')).toThrow(/databaseUrl is required/);
+  });
+
+  it('accepts testnet when DATABASE_URL fallback is provided', async () => {
+    vi.stubEnv('DATABASE_URL', 'postgresql://localhost/testdb');
+    const { getProfile } = await loadProfiles();
+    expect(() => getProfile('testnet')).not.toThrow();
+  });
+});
+
+// ── URL protocol validation ───────────────────────────────────────────────────
+
+describe('startup validation — URL protocol checks', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  const base = () => {
+    vi.stubEnv('MAINNET_DATABASE_URL', 'postgresql://mainnet-db/soroban');
+    vi.stubEnv('MAINNET_RPC_URL', 'https://mainnet.example.com/rpc');
+    vi.stubEnv('MAINNET_RPC_WS_URL', 'wss://mainnet.example.com/rpc');
+  };
+
+  it('throws when databaseUrl uses a non-postgres protocol', async () => {
+    vi.stubEnv('MAINNET_DATABASE_URL', 'mysql://wrong-db/soroban');
+    vi.stubEnv('MAINNET_RPC_URL', 'https://mainnet.example.com/rpc');
+    vi.stubEnv('MAINNET_RPC_WS_URL', 'wss://mainnet.example.com/rpc');
+    const { getProfile } = await loadProfiles();
+    expect(() => getProfile('mainnet')).toThrow(/postgresql/);
+  });
+
+  it('throws when rpcUrl uses a non-http protocol', async () => {
+    base();
+    vi.stubEnv('MAINNET_RPC_URL', 'ftp://mainnet.example.com/rpc');
+    const { getProfile } = await loadProfiles();
+    expect(() => getProfile('mainnet')).toThrow(/https?/);
+  });
+
+  it('throws when rpcWsUrl uses an http protocol instead of ws', async () => {
+    base();
+    vi.stubEnv('MAINNET_RPC_WS_URL', 'https://mainnet.example.com/rpc');
+    const { getProfile } = await loadProfiles();
+    expect(() => getProfile('mainnet')).toThrow(/wss?/);
+  });
+
+  it('accepts both postgresql:// and postgres:// for databaseUrl', async () => {
+    vi.stubEnv('MAINNET_DATABASE_URL', 'postgres://mainnet-db/soroban');
+    vi.stubEnv('MAINNET_RPC_URL', 'https://mainnet.example.com/rpc');
+    vi.stubEnv('MAINNET_RPC_WS_URL', 'wss://mainnet.example.com/rpc');
+    const { getProfile } = await loadProfiles();
+    expect(() => getProfile('mainnet')).not.toThrow();
+  });
+
+  it('accepts both https:// and http:// for rpcUrl (devnet uses http)', async () => {
+    const { getProfile } = await loadProfiles();
+    expect(() => getProfile('devnet')).not.toThrow();
+    const p = getProfile('devnet');
+    expect(p.rpcUrl).toMatch(/^http:\/\//);
+  });
+});
+
+// ── Network profile consistency ───────────────────────────────────────────────
+
+describe('startup validation — network profile consistency', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('throws when mainnet rpcUrl contains "testnet"', async () => {
+    vi.stubEnv('MAINNET_DATABASE_URL', 'postgresql://mainnet-db/soroban');
+    vi.stubEnv('MAINNET_RPC_URL', 'https://soroban-testnet.stellar.org');
+    vi.stubEnv('MAINNET_RPC_WS_URL', 'wss://mainnet.example.com/rpc');
+    const { getProfile } = await loadProfiles();
+    expect(() => getProfile('mainnet')).toThrow(/testnet/);
+  });
+
+  it('throws when mainnet horizonUrl contains "testnet"', async () => {
+    vi.stubEnv('MAINNET_DATABASE_URL', 'postgresql://mainnet-db/soroban');
+    vi.stubEnv('MAINNET_RPC_URL', 'https://mainnet.example.com/rpc');
+    vi.stubEnv('MAINNET_RPC_WS_URL', 'wss://mainnet.example.com/rpc');
+    vi.stubEnv('MAINNET_HORIZON_URL', 'https://horizon-testnet.stellar.org');
+    const { getProfile } = await loadProfiles();
+    expect(() => getProfile('mainnet')).toThrow(/testnet/);
+  });
+
+  it('accepts mainnet with correct production URLs', async () => {
+    vi.stubEnv('MAINNET_DATABASE_URL', 'postgresql://mainnet-db/soroban');
+    vi.stubEnv('MAINNET_RPC_URL', 'https://mainnet.example.com/rpc');
+    vi.stubEnv('MAINNET_RPC_WS_URL', 'wss://mainnet.example.com/rpc');
+    const { getProfile } = await loadProfiles();
+    const p = getProfile('mainnet');
+    expect(p.name).toBe('mainnet');
+  });
+});
+
+// ── validateProfile exported directly ────────────────────────────────────────
+
+describe('startup validation — validateProfile helper', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('is exported and callable directly', async () => {
+    const { validateProfile, getProfile } = await loadProfiles();
+    vi.stubEnv('MAINNET_DATABASE_URL', 'postgresql://mainnet-db/soroban');
+    vi.stubEnv('MAINNET_RPC_URL', 'https://mainnet.example.com/rpc');
+    vi.stubEnv('MAINNET_RPC_WS_URL', 'wss://mainnet.example.com/rpc');
+    const { getProfile: gp } = await (async () => {
+      vi.resetModules();
+      return import('../src/profiles');
+    })();
+    const profile = gp('mainnet');
+    expect(() => validateProfile(profile)).not.toThrow();
+  });
+
+  it('throws immediately on an empty databaseUrl', async () => {
+    const { validateProfile } = await loadProfiles();
+    const bad = {
+      name: 'mainnet' as const,
+      databaseUrl: '',
+      rpcUrl: 'https://ok.example.com',
+      rpcWsUrl: 'wss://ok.example.com',
+      horizonUrl: 'https://horizon.stellar.org',
+      readReplicaUrl: '',
+      apiSubdomain: 'api.localhost',
+      cacheUrl: 'memory://',
+      networkPassphrase: 'Public Global Stellar Network ; September 2015',
+    };
+    expect(() => validateProfile(bad)).toThrow(/databaseUrl is required/);
+  });
+});


### PR DESCRIPTION
- Add validateProfile() to profiles.ts: throws on empty databaseUrl, rpcUrl, or rpcWsUrl; validates http/ws/postgres URL protocols; rejects mainnet profiles pointing at testnet infrastructure
- Call validateProfile() from getProfile() so misconfigured profiles abort before any external connection is attempted
- Add src/readiness.ts to track db/cache/indexer/coldStorage state
- Export isCacheReady() from cache.ts (false when Redis is configured but unreachable, true for memory:// mode)
- Update /readyz to return 503 with per-dependency JSON when any dep is not ready, and 200 with full dep map when all are ready
- Update main() to flip readiness flags as each dep initialises; indexer flips back to not-ready if it fails after startup
- Fix existing mainnet tests to supply required env vars
- Add tests/startup-validation.test.ts (14 tests) and tests/readyz.test.ts (11 tests)

closes #436 
closes #437 