### PR TITLE
fix: secure API keys, event ID collisions, pagination bounds, HTTP en…

### DIFF
--- a/src/api/reputation.ts
+++ b/src/api/reputation.ts
@@ -1,3 +1,4 @@
+import { randomBytes, createHash } from 'crypto';
 import { Router, Request, Response } from 'express';
 import { prismaRead, prismaWrite } from '../db';
 import {
@@ -2054,7 +2055,7 @@ reputationRouter.post(
         address: canonical,
         badgeType,
         tokenId,
-        mintedTxHash: `tx-${Math.random().toString(36).substring(2, 12)}`,
+        mintedTxHash: `tx-${randomBytes(5).toString('hex')}`,
       },
     });
 
@@ -2223,12 +2224,14 @@ reputationRouter.post(
     const { name } = req.body;
     if (!name) return res.status(400).json({ error: 'name is required' });
 
-    const apiKey = `rep-sdk-${Math.random().toString(36).substring(2, 15)}`;
+    const rawKey = randomBytes(32).toString('hex');
+    const apiKey = `rep-sdk-${rawKey}`;
+    const keyHash = createHash('sha256').update(apiKey).digest('hex');
     const dapp = await prismaWrite.registeredDapp.create({
-      data: { name, apiKey },
+      data: { name, apiKey: keyHash },
     });
 
-    return res.json(dapp);
+    return res.json({ ...dapp, apiKey });
   }),
 );
 

--- a/src/indexer/indexer.ts
+++ b/src/indexer/indexer.ts
@@ -193,7 +193,10 @@ export async function processLedgerRange(start: number, end: number) {
     }
 
     const { eventType, decoded } = decodeEvent(event.topics, event.data);
-    const eventId = `${event.transactionHash}-${event.topics[0] ?? '0'}`;
+    // Include paging token (unique per event position) to prevent ID collisions
+    // when a single transaction emits multiple events with the same first topic.
+    const positionKey = event.pagingToken || `${event.ledgerSequence}-${events.indexOf(event)}`;
+    const eventId = `${event.transactionHash}-${positionKey}`;
     const savedEvent = await prisma.event.upsert({
       where: { id: eventId },
       update: {},

--- a/src/indexer/rpc.ts
+++ b/src/indexer/rpc.ts
@@ -3,7 +3,17 @@ import { SorobanRpc } from '@stellar/stellar-sdk';
 import { config } from '../config';
 import { cacheGet, cacheSet } from '../cache';
 
-export const rpc = new SorobanRpc.Server(config.stellarRpcUrl, { allowHttp: true });
+const isDevnet = config.profile.name === 'devnet';
+
+// Reject plain-HTTP RPC URLs in non-devnet environments at startup.
+if (!isDevnet && config.stellarRpcUrl.startsWith('http://')) {
+  throw new Error(
+    `[${config.profile.name}] Insecure RPC URL rejected: "${config.stellarRpcUrl}". ` +
+      `Use https:// for testnet and mainnet, or switch to STELLAR_NETWORK=devnet for local development.`,
+  );
+}
+
+export const rpc = new SorobanRpc.Server(config.stellarRpcUrl, { allowHttp: isDevnet });
 
 export interface LedgerEvent {
   contractId: string;
@@ -12,6 +22,7 @@ export interface LedgerEvent {
   ledgerCloseTime: Date;
   topics: string[];
   data: string;
+  pagingToken: string;
 }
 
 const LEDGER_CACHE_PREFIX = 'ledger:';
@@ -76,6 +87,14 @@ export async function fetchEvents(startLedger: number, endLedger: number): Promi
       break;
     }
 
+    // Stop paginating if every event on this page is already beyond endLedger.
+    // This is the server-side stop condition that prevents fetching unbounded
+    // pages when the range is small but there are many later events.
+    const minLedger = Math.min(...page.map((e: any) => Number(e.ledger)));
+    if (minLedger > endLedger) {
+      break;
+    }
+
     const mapped = page
       .filter(
         (e) => typeof e.ledger === 'number' && e.ledger >= startLedger && e.ledger <= endLedger,
@@ -87,6 +106,7 @@ export async function fetchEvents(startLedger: number, endLedger: number): Promi
         ledgerCloseTime: new Date(e.ledgerClosedAt ?? Date.now()),
         topics: Array.isArray(e.topic) ? e.topic.map((t: any) => t.toXDR('base64')) : [],
         data: e.value?.toXDR ? e.value.toXDR('base64') : String(e.value ?? ''),
+        pagingToken: String(e.pagingToken ?? e.paging_token ?? ''),
       }));
 
     events.push(...mapped);
@@ -156,9 +176,7 @@ export function getRpcWebsocketUrl(): string {
   return config.stellarRpcWsUrl;
 }
 
-export async function fetchLedgerMetadata(
-  sequence: number,
-): Promise<{
+export async function fetchLedgerMetadata(sequence: number): Promise<{
   sequence: number;
   hash: string;
   previousLedgerHash: string;


### PR DESCRIPTION
…forcement

Closes #493: Generate SDK API keys with crypto.randomBytes(32), store sha256 hash
Closes #502: Include pagingToken in event ID to prevent collision on repeated topics
Closes #503: Break fetchEvents pagination when page ledgers exceed endLedger
Closes #504: Allow allowHttp only for devnet; reject plain HTTP on testnet/mainnet