### PR TITLE
Add event type filtering to websocket broadcaster

### DIFF
--- a/src/ws/eventBroadcaster.ts
+++ b/src/ws/eventBroadcaster.ts
@@ -1,10 +1,11 @@
 import { WebSocketServer, WebSocket } from 'ws';
 import { IncomingMessage, Server } from 'http';
 
-// Each client can subscribe to a specific contract address or '*' for all events
+// Each client can subscribe to a specific contract address or event type, or leave them unset for all events
 interface Client {
   ws: WebSocket;
-  contractFilter: string | null; // null = all events
+  contractFilter: string | null; // null = all contracts
+  eventTypeFilter: string | null; // null = all event types
 }
 
 const clients = new Set<Client>();
@@ -13,11 +14,12 @@ export function attachWebSocketServer(httpServer: Server): WebSocketServer {
   const wss = new WebSocketServer({ server: httpServer, path: '/ws/events' });
 
   wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
-    // Optional: ?contract=CXXX... to filter by contract
+    // Optional query params: ?contract=CXXX... to filter by contract and ?eventType=token_transfer to filter by event type
     const url = new URL(req.url ?? '', 'http://localhost');
     const contractFilter = url.searchParams.get('contract');
+    const eventTypeFilter = url.searchParams.get('eventType');
 
-    const client: Client = { ws, contractFilter };
+    const client: Client = { ws, contractFilter, eventTypeFilter };
     clients.add(client);
 
     ws.on('close', () => clients.delete(client));
@@ -41,6 +43,7 @@ export function broadcastEvent(event: {
   for (const client of clients) {
     if (client.ws.readyState !== WebSocket.OPEN) continue;
     if (client.contractFilter && client.contractFilter !== event.contractAddress) continue;
+    if (client.eventTypeFilter && client.eventTypeFilter !== event.eventType) continue;
     client.ws.send(payload);
   }
 }

--- a/tests/event-broadcaster.test.ts
+++ b/tests/event-broadcaster.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+import { WebSocket } from 'ws';
+import {
+  attachWebSocketServer,
+  broadcastEvent,
+  shutdownWebSocketServer,
+} from '../src/ws/eventBroadcaster';
+
+const servers: Server[] = [];
+
+afterEach(() => {
+  while (servers.length > 0) {
+    const server = servers.pop();
+    shutdownWebSocketServer();
+    server?.close();
+  }
+});
+
+describe('event broadcaster', () => {
+  it('filters events by contract and event type for matching clients', async () => {
+    const server = createServer();
+    servers.push(server);
+    attachWebSocketServer(server);
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address() as AddressInfo;
+
+    const messages: string[] = [];
+    const client = new WebSocket(
+      `ws://127.0.0.1:${port}/ws/events?contract=C123&eventType=token_transfer`,
+    );
+
+    await new Promise<void>((resolve, reject) => {
+      client.once('open', () => resolve());
+      client.once('error', reject);
+    });
+
+    client.on('message', (data) => messages.push(String(data)));
+
+    broadcastEvent({
+      id: 'evt-1',
+      contractAddress: 'C123',
+      eventType: 'token_transfer',
+      decoded: { amount: 10 },
+      ledger: 100,
+      ledgerCloseTime: new Date('2024-01-01T00:00:00.000Z'),
+      transactionHash: 'tx-1',
+    });
+
+    broadcastEvent({
+      id: 'evt-2',
+      contractAddress: 'C456',
+      eventType: 'token_transfer',
+      decoded: { amount: 20 },
+      ledger: 101,
+      ledgerCloseTime: new Date('2024-01-01T00:00:00.000Z'),
+      transactionHash: 'tx-2',
+    });
+
+    broadcastEvent({
+      id: 'evt-3',
+      contractAddress: 'C123',
+      eventType: 'swap',
+      decoded: { amount: 30 },
+      ledger: 102,
+      ledgerCloseTime: new Date('2024-01-01T00:00:00.000Z'),
+      transactionHash: 'tx-3',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain('"id":"evt-1"');
+
+    client.close();
+  });
+});


### PR DESCRIPTION
## Summary
- support event-type filtering for WebSocket clients via `?eventType=...`
- preserve contract-based filtering while allowing more precise subscriptions
- add a regression test for contract + event-type matching

## Testing
- `npx vitest run tests/event-broadcaster.test.ts`
closes #294 