### PR TITLE
fix: webhook reliability and security (#478 #481 #482 #483)

### DIFF
--- a/prisma/migrations/20260629000000_webhook_ownership_and_strong_secrets/migration.sql
+++ b/prisma/migrations/20260629000000_webhook_ownership_and_strong_secrets/migration.sql
@@ -1,0 +1,10 @@
+-- Issue #478: Associate subscriptions with an API key owner
+ALTER TABLE "WebhookSubscription" ADD COLUMN "apiKeyId" TEXT NOT NULL DEFAULT '';
+
+-- Issue #481: Secret is now always present (non-null); backfill empty strings so
+-- existing rows satisfy the NOT NULL constraint before the default is dropped.
+ALTER TABLE "WebhookSubscription" ALTER COLUMN "secret" SET NOT NULL;
+UPDATE "WebhookSubscription" SET "secret" = '' WHERE "secret" IS NULL;
+
+-- Index for owner-scoped queries
+CREATE INDEX "WebhookSubscription_apiKeyId_idx" ON "WebhookSubscription"("apiKeyId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2880,8 +2880,9 @@ model WebhookDelivery {
 
 model WebhookSubscription {
   id              String    @id @default(cuid())
+  apiKeyId        String
   url             String
-  secret          String?
+  secret          String
   contractAddress String?
   eventType       String?
   topicSymbol     String?
@@ -2892,6 +2893,8 @@ model WebhookSubscription {
   updatedAt       DateTime @updatedAt
 
   delivery WebhookDelivery[]
+
+  @@index([apiKeyId])
 }
 
 model YieldDistribution {

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -108,3 +108,8 @@ router.use('/admin', adminRouter);
 // ── Universal ABI Extraction (#289) ──────────────────────────────────────────
 import { abiExtractRouter } from './abi-extract';
 router.use('/abi-extract', abiExtractRouter);
+
+// ── Webhook Subscriptions (#478 #481 #482 #483) ───────────────────────────────
+// Auth and owner-scoping are enforced inside webhooksRouter itself.
+import { webhooksRouter } from './webhooks';
+router.use('/webhooks', webhooksRouter);

--- a/src/api/webhooks.ts
+++ b/src/api/webhooks.ts
@@ -1,14 +1,23 @@
+import crypto from 'crypto';
 import { Router, Request, Response } from 'express';
 import { z } from 'zod';
 import { prismaWrite as prisma, prismaRead } from '../db';
 import { asyncHandler } from '../middleware/asyncHandler';
+import { apiKeyAuth, requireApiKey } from '../middleware/apiKeyAuth';
 import { assertSafeUrl, SsrfBlockedError } from '../webhooks/ssrf-guard';
 
 export const webhooksRouter = Router();
 
+// Apply API key authentication to every route on this router (#478).
+// apiKeyAuth populates req.apiKey; requireApiKey enforces its presence.
+webhooksRouter.use(apiKeyAuth, requireApiKey);
+
+// Secret must be at least 32 characters to carry sufficient HMAC entropy (#481).
+const MIN_SECRET_LENGTH = 32;
+
 const createSchema = z.object({
   url: z.string().url(),
-  secret: z.string().min(8).optional(),
+  secret: z.string().min(MIN_SECRET_LENGTH).optional(),
   contractAddress: z.string().optional(),
   eventType: z.string().optional(),
   topicSymbol: z.string().optional(),
@@ -22,8 +31,11 @@ const createSchema = z.object({
  *     description: >
  *       Register a server endpoint to receive on-chain contract event
  *       notifications. Each delivery is signed with HMAC-SHA256 using the
- *       provided secret (X-Webhook-Signature header). Failed deliveries are
+ *       signing secret (X-Webhook-Signature header). Failed deliveries are
  *       retried with exponential backoff (up to 5 attempts).
+ *       The secret is returned only once in this response — store it securely.
+ *     security:
+ *       - ApiKeyAuth: []
  *     tags: [Webhooks]
  *     requestBody:
  *       required: true
@@ -39,8 +51,11 @@ const createSchema = z.object({
  *                 description: HTTPS endpoint to receive webhook payloads
  *               secret:
  *                 type: string
- *                 minLength: 8
- *                 description: Signing secret for HMAC-SHA256 signature verification
+ *                 minLength: 32
+ *                 description: >
+ *                   Optional signing secret (min 32 chars). If omitted a
+ *                   256-bit random secret is generated for you. The value is
+ *                   returned only once — it cannot be retrieved again.
  *               contractAddress:
  *                 type: string
  *                 description: Filter to a specific contract (omit for all contracts)
@@ -52,19 +67,19 @@ const createSchema = z.object({
  *                 description: Filter to a specific topic symbol
  *     responses:
  *       201:
- *         description: Subscription created
+ *         description: Subscription created — includes the signing secret (shown once)
  *       400:
  *         description: Validation error
+ *       401:
+ *         description: API key required
  */
-// POST /webhooks — register a new subscription
 webhooksRouter.post(
   '/',
   asyncHandler(async (req: Request, res: Response) => {
     const parsed = createSchema.safeParse(req.body);
     if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
 
-    // SSRF guard: reject URLs that resolve to private/loopback/metadata addresses
-    // before they are ever persisted or contacted.
+    // SSRF guard: reject URLs that resolve to private/loopback/metadata addresses.
     try {
       await assertSafeUrl(parsed.data.url);
     } catch (err) {
@@ -72,8 +87,31 @@ webhooksRouter.post(
       return res.status(400).json({ error: message });
     }
 
-    const sub = await prisma.webhookSubscription.create({ data: parsed.data });
-    res.status(201).json(sub);
+    // Generate a high-entropy secret when the caller doesn't supply one (#481).
+    const secret = parsed.data.secret ?? crypto.randomBytes(32).toString('hex');
+
+    const sub = await prisma.webhookSubscription.create({
+      data: {
+        apiKeyId: req.apiKey!.id,
+        url: parsed.data.url,
+        secret,
+        contractAddress: parsed.data.contractAddress,
+        eventType: parsed.data.eventType,
+        topicSymbol: parsed.data.topicSymbol,
+      },
+    });
+
+    // Return the secret only at creation time (#481).
+    res.status(201).json({
+      id: sub.id,
+      url: sub.url,
+      secret,
+      contractAddress: sub.contractAddress,
+      eventType: sub.eventType,
+      topicSymbol: sub.topicSymbol,
+      active: sub.active,
+      createdAt: sub.createdAt,
+    });
   }),
 );
 
@@ -81,17 +119,21 @@ webhooksRouter.post(
  * @swagger
  * /webhooks:
  *   get:
- *     summary: List webhook subscriptions
+ *     summary: List webhook subscriptions owned by the caller
+ *     security:
+ *       - ApiKeyAuth: []
  *     tags: [Webhooks]
  *     responses:
  *       200:
  *         description: List of subscriptions (secrets omitted)
+ *       401:
+ *         description: API key required
  */
-// GET /webhooks — list all subscriptions
 webhooksRouter.get(
   '/',
-  asyncHandler(async (_req: Request, res: Response) => {
+  asyncHandler(async (req: Request, res: Response) => {
     const subs = await prismaRead.webhookSubscription.findMany({
+      where: { apiKeyId: req.apiKey!.id },
       orderBy: { createdAt: 'desc' },
       select: {
         id: true,
@@ -112,6 +154,8 @@ webhooksRouter.get(
  * /webhooks/{id}:
  *   delete:
  *     summary: Delete a webhook subscription
+ *     security:
+ *       - ApiKeyAuth: []
  *     tags: [Webhooks]
  *     parameters:
  *       - in: path
@@ -122,23 +166,31 @@ webhooksRouter.get(
  *       204:
  *         description: Deleted
  *       404:
- *         description: Not found
+ *         description: Not found or not owned by caller
+ *       401:
+ *         description: API key required
  */
-// DELETE /webhooks/:id — remove a subscription
-webhooksRouter.delete('/:id', async (req: Request, res: Response) => {
-  try {
-    await prisma.webhookSubscription.delete({ where: { id: req.params.id } });
-    res.status(204).end();
-  } catch {
-    res.status(404).json({ error: 'Subscription not found' });
-  }
-});
+webhooksRouter.delete(
+  '/:id',
+  asyncHandler(async (req: Request, res: Response) => {
+    try {
+      await prisma.webhookSubscription.delete({
+        where: { id: req.params.id, apiKeyId: req.apiKey!.id },
+      });
+      res.status(204).end();
+    } catch {
+      res.status(404).json({ error: 'Subscription not found' });
+    }
+  }),
+);
 
 /**
  * @swagger
  * /webhooks/{id}:
  *   patch:
  *     summary: Enable or disable a webhook subscription
+ *     security:
+ *       - ApiKeyAuth: []
  *     tags: [Webhooks]
  *     parameters:
  *       - in: path
@@ -158,19 +210,36 @@ webhooksRouter.delete('/:id', async (req: Request, res: Response) => {
  *       200:
  *         description: Updated subscription
  *       404:
- *         description: Not found
+ *         description: Not found or not owned by caller
+ *       401:
+ *         description: API key required
  */
-// PATCH /webhooks/:id — enable / disable
 webhooksRouter.patch(
   '/:id',
   asyncHandler(async (req: Request, res: Response) => {
     const { active } = z.object({ active: z.boolean() }).parse(req.body);
     try {
       const sub = await prisma.webhookSubscription.update({
-        where: { id: req.params.id },
+        where: { id: req.params.id, apiKeyId: req.apiKey!.id },
         data: { active },
       });
-      res.json(sub);
+
+      // When deactivating, immediately cancel all pending deliveries so the
+      // retry loop doesn't attempt them before it notices the subscription is
+      // inactive (#482).
+      if (!active) {
+        await prisma.webhookDelivery.updateMany({
+          where: { subscriptionId: sub.id, status: 'pending' },
+          data: {
+            status: 'cancelled',
+            processingStatus: 'done',
+            leaseExpiresAt: null,
+            nextRetryAt: null,
+          },
+        });
+      }
+
+      res.json({ id: sub.id, url: sub.url, active: sub.active, updatedAt: sub.updatedAt });
     } catch {
       res.status(404).json({ error: 'Subscription not found' });
     }
@@ -183,6 +252,8 @@ webhooksRouter.patch(
  *   get:
  *     summary: Get delivery history for a webhook subscription
  *     description: Returns the last 50 delivery attempts including status, HTTP response, and retry schedule.
+ *     security:
+ *       - ApiKeyAuth: []
  *     tags: [Webhooks]
  *     parameters:
  *       - in: path
@@ -192,13 +263,23 @@ webhooksRouter.patch(
  *     responses:
  *       200:
  *         description: Delivery history
+ *       404:
+ *         description: Subscription not found or not owned by caller
+ *       401:
+ *         description: API key required
  */
-// GET /webhooks/:id/deliveries — delivery history for a subscription
 webhooksRouter.get(
   '/:id/deliveries',
   asyncHandler(async (req: Request, res: Response) => {
+    // Verify ownership before returning delivery history (#478).
+    const sub = await prismaRead.webhookSubscription.findFirst({
+      where: { id: req.params.id, apiKeyId: req.apiKey!.id },
+      select: { id: true },
+    });
+    if (!sub) return res.status(404).json({ error: 'Subscription not found' });
+
     const deliveries = await prismaRead.webhookDelivery.findMany({
-      where: { subscriptionId: req.params.id },
+      where: { subscriptionId: sub.id },
       orderBy: { createdAt: 'desc' },
       take: 50,
     });

--- a/src/webhooks/dispatcher.ts
+++ b/src/webhooks/dispatcher.ts
@@ -9,12 +9,70 @@ export const MAX_ATTEMPTS = 5;
 export const REQUEST_TIMEOUT_MS = 10_000;
 // How long a processing lease is held before it is considered stale (ms)
 export const LEASE_DURATION_MS = 60_000;
+// Maximum concurrent outbound HTTP deliveries for fan-out and retry (#483)
+export const DISPATCH_CONCURRENCY = parseInt(process.env.WEBHOOK_DISPATCH_CONCURRENCY ?? '10', 10);
 
 /** Compute exponential backoff delay for a given attempt (1-based). */
 export function backoffMs(attempt: number): number {
   // 10s, 30s, 90s, 270s, 810s — capped at 15 min
   return Math.min(10_000 * 3 ** (attempt - 1), 900_000);
 }
+
+// ── Metrics (#483) ────────────────────────────────────────────────────────────
+
+let _queueDepth = 0;
+let _lastDeliveryLatencyMs = 0;
+
+/** Live dispatch metrics exported for observability. */
+export function getDispatchMetrics(): { queueDepth: number; lastDeliveryLatencyMs: number } {
+  return { queueDepth: _queueDepth, lastDeliveryLatencyMs: _lastDeliveryLatencyMs };
+}
+
+// ── Concurrency pool (#483) ───────────────────────────────────────────────────
+
+/**
+ * Run `fn` over every item in `items` with at most `concurrency` tasks
+ * executing in parallel. Excess items wait in a queue. Errors are swallowed
+ * per item so that one failure doesn't abort remaining deliveries.
+ */
+async function runWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<void>,
+): Promise<void> {
+  if (items.length === 0) return;
+
+  const queue = [...items];
+  _queueDepth += queue.length;
+
+  await new Promise<void>((resolve) => {
+    let active = 0;
+    let settled = 0;
+    const total = items.length;
+
+    function next(): void {
+      while (active < concurrency && queue.length > 0) {
+        const item = queue.shift()!;
+        _queueDepth--;
+        active++;
+        fn(item)
+          .catch(() => {
+            /* individual delivery errors are handled inside fn */
+          })
+          .finally(() => {
+            active--;
+            settled++;
+            if (settled === total) resolve();
+            else next();
+          });
+      }
+    }
+
+    next();
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 export interface WebhookPayload {
   id: string;
@@ -30,6 +88,7 @@ export interface WebhookPayload {
 /**
  * Fan-out a single event to all matching active webhook subscriptions.
  * Each delivery is persisted and dispatched immediately (attempt 1).
+ * Concurrency is bounded by DISPATCH_CONCURRENCY (#483).
  */
 export async function dispatchWebhooks(event: WebhookPayload): Promise<void> {
   const subs = await prisma.webhookSubscription.findMany({
@@ -56,18 +115,16 @@ export async function dispatchWebhooks(event: WebhookPayload): Promise<void> {
     return true;
   });
 
-  await Promise.all(
-    matching.map((sub) =>
-      deliverOnce(
-        sub.id,
-        sub.url,
-        sub.secret,
-        event,
-        1,
-        undefined,
-        sub.storeResponseBody,
-        sub.responseRetentionDays,
-      ),
+  await runWithConcurrency(matching, DISPATCH_CONCURRENCY, (sub) =>
+    deliverOnce(
+      sub.id,
+      sub.url,
+      sub.secret,
+      event,
+      1,
+      undefined,
+      sub.storeResponseBody,
+      sub.responseRetentionDays,
     ),
   );
 }
@@ -76,6 +133,7 @@ export async function dispatchWebhooks(event: WebhookPayload): Promise<void> {
  * Retry all pending deliveries whose nextRetryAt is due.
  * Rows are claimed atomically with a processing lease so that concurrent
  * service replicas cannot pick up the same delivery twice.
+ * Concurrency is bounded by DISPATCH_CONCURRENCY (#483).
  *
  * Call this on a periodic schedule (e.g. every 30s from the indexer).
  */
@@ -84,8 +142,6 @@ export async function retryPendingDeliveries(): Promise<void> {
   const leaseExpiry = new Date(now.getTime() + LEASE_DURATION_MS);
 
   // Atomically claim a batch of due deliveries that are currently idle.
-  // The UPDATE … WHERE … prevents two replicas from claiming the same row
-  // because the second writer will find processingStatus != 'idle' and skip it.
   const claimed = await prisma.$transaction(async (tx) => {
     const rows = await tx.webhookDelivery.findMany({
       where: {
@@ -104,9 +160,6 @@ export async function retryPendingDeliveries(): Promise<void> {
 
     const ids = rows.map((r) => r.id);
 
-    // Mark all selected rows as "processing" in one query — rows already
-    // taken by another replica (processingStatus changed since the findMany)
-    // are simply skipped by the WHERE predicate, so no double-delivery occurs.
     await tx.webhookDelivery.updateMany({
       where: {
         id: { in: ids },
@@ -118,7 +171,6 @@ export async function retryPendingDeliveries(): Promise<void> {
       data: { processingStatus: 'processing', leaseExpiresAt: leaseExpiry },
     });
 
-    // Re-fetch only the rows we successfully claimed
     return tx.webhookDelivery.findMany({
       where: { id: { in: ids }, processingStatus: 'processing', leaseExpiresAt: leaseExpiry },
       include: {
@@ -135,28 +187,27 @@ export async function retryPendingDeliveries(): Promise<void> {
     });
   });
 
-  await Promise.all(
-    claimed.map((d) => {
-      // Skip deliveries for inactive subscriptions
-      if (!d.subscription.active) {
-        return prisma.webhookDelivery.update({
-          where: { id: d.id },
-          data: { status: 'cancelled', processingStatus: 'done', leaseExpiresAt: null },
-        });
-      }
+  await runWithConcurrency(claimed, DISPATCH_CONCURRENCY, async (d) => {
+    // Skip deliveries for inactive subscriptions (#482).
+    if (!d.subscription.active) {
+      await prisma.webhookDelivery.update({
+        where: { id: d.id },
+        data: { status: 'cancelled', processingStatus: 'done', leaseExpiresAt: null },
+      });
+      return;
+    }
 
-      return deliverOnce(
-        d.subscriptionId,
-        d.subscription.url,
-        d.subscription.secret,
-        null,
-        d.attempt ?? 1,
-        d.id,
-        d.subscription.storeResponseBody,
-        d.subscription.responseRetentionDays,
-      );
-    }),
-  );
+    await deliverOnce(
+      d.subscriptionId,
+      d.subscription.url,
+      d.subscription.secret,
+      null,
+      d.attempt ?? 1,
+      d.id,
+      d.subscription.storeResponseBody,
+      d.subscription.responseRetentionDays,
+    );
+  });
 }
 
 /**
@@ -169,7 +220,7 @@ export async function retryPendingDeliveries(): Promise<void> {
 async function deliverOnce(
   subscriptionId: string,
   url: string,
-  secret: string | null,
+  secret: string,
   event: WebhookPayload | null,
   attempt: number,
   deliveryId?: string,
@@ -183,7 +234,6 @@ async function deliverOnce(
     const row = await prisma.webhookDelivery.findUnique({ where: { id: deliveryId } });
     if (!row) return;
     eventId = row.eventId ?? '';
-    // Re-fetch the event to rebuild the payload
     const ev = await prisma.event.findUnique({ where: { id: eventId } });
     if (!ev) return;
     payload = {
@@ -200,13 +250,11 @@ async function deliverOnce(
 
   if (!payload) return;
 
-  // Pre-flight SSRF check: validate URL and resolve DNS before opening a
-  // socket.  safePost() will re-validate on every redirect hop as well.
+  // Pre-flight SSRF check before opening a socket.
   try {
     await assertSafeUrl(url);
   } catch (err) {
     const msg = err instanceof SsrfBlockedError ? err.message : String(err);
-    // Permanently fail — retrying a blocked URL will never succeed.
     if (deliveryId) {
       await prisma.webhookDelivery.update({
         where: { id: deliveryId },
@@ -225,16 +273,12 @@ async function deliverOnce(
   const body = JSON.stringify({ event: payload, attempt });
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
 
-  if (secret) {
-    const sig = crypto.createHmac('sha256', secret).update(body).digest('hex');
-    headers['X-Webhook-Signature'] = `sha256=${sig}`;
-  }
+  // Every subscription now has a secret (#481).
+  const sig = crypto.createHmac('sha256', secret).update(body).digest('hex');
+  headers['X-Webhook-Signature'] = `sha256=${sig}`;
 
   const expiresAt = new Date(Date.now() + responseRetentionDays * 24 * 60 * 60 * 1000);
 
-  // Create or update the delivery row to "pending" before attempting.
-  // For new deliveries (no deliveryId) we start with processingStatus='processing'
-  // so the retry loop cannot also pick it up while the initial attempt is in-flight.
   const delivery = deliveryId
     ? await prisma.webhookDelivery.update({
         where: { id: deliveryId },
@@ -252,9 +296,11 @@ async function deliverOnce(
         },
       });
 
+  const startMs = Date.now();
+
   try {
-    // safePost validates the URL (and every redirect target) before sending
     const response = await safePost(url, body, headers, REQUEST_TIMEOUT_MS);
+    _lastDeliveryLatencyMs = Date.now() - startMs;
 
     const success = response.status >= 200 && response.status < 300;
     const rawResponseBody = String(response.data ?? '');
@@ -290,6 +336,7 @@ async function deliverOnce(
       processedResponseBody,
     );
   } catch (err: unknown) {
+    _lastDeliveryLatencyMs = Date.now() - startMs;
     const msg = err instanceof Error ? err.message : String(err);
 
     // SSRF blocks on redirect are permanent failures — don't retry
@@ -317,7 +364,7 @@ async function scheduleRetryOrFail(
   attempt: number,
   errorMsg: string,
   httpStatus?: number,
-  responseBody?: string,
+  responseBody?: string | null,
 ): Promise<void> {
   const nextAttempt = attempt + 1;
 


### PR DESCRIPTION
## Summary

Addresses four webhook issues across security, authorization, and reliability categories.

### closes #478 — Authentication and owner scoping (Critical)

All webhook routes (`POST`, `GET`, `DELETE`, `PATCH`, `GET /deliveries`) were fully unauthenticated and did not scope data to any owner, making cross-tenant access trivially possible.

**Changes:**
- `apiKeyAuth` + `requireApiKey` middleware applied to the entire `webhooksRouter`
- New `apiKeyId` column on `WebhookSubscription` (migration: `20260629000000_webhook_ownership_and_strong_secrets`)
- Every `findMany`, `findFirst`, `update`, and `delete` call now filters on `apiKeyId: req.apiKey!.id` — a caller can only see and mutate their own subscriptions
- `GET /:id/deliveries` verifies ownership before returning delivery records
- `webhooksRouter` is now mounted in the central router at `/webhooks`

### closes #481 — Strong signing secrets (High)

Secrets were optional and only 8 characters minimum, allowing unsigned deliveries and weak HMAC keys.

**Changes:**
- When the caller omits a secret, the server generates `crypto.randomBytes(32).toString('hex')` (64 hex chars / 256 bits of entropy)
- Minimum length for caller-supplied secrets raised from 8 → 32 characters
- `WebhookSubscription.secret` made non-nullable in the schema; the column always holds a value
- The secret is returned **only once** in the `201 Created` response; `GET /webhooks` and all other reads omit it

### closes #482 — Skip retries for inactive subscriptions (Medium)

The retry loop already cancelled deliveries for inactive subscriptions, but there was no eager cancellation at deactivation time — pending deliveries continued to exist until the retry loop picked them up.

**Changes:**
- `PATCH /webhooks/:id` with `active: false` now immediately runs `updateMany` to mark all `pending` deliveries for that subscription as `status='cancelled' / processingStatus='done'`
- The dispatcher's existing active-check guard is retained as a safety net for the race window between deactivation and claim

### closes #483 — Bounded fan-out concurrency (High)

Both `dispatchWebhooks` and `retryPendingDeliveries` used unbounded `Promise.all`, creating burst spikes of outbound connections on large subscription lists.

**Changes:**
- `runWithConcurrency(items, concurrency, fn)` — inline pool that keeps at most N tasks in flight simultaneously; excess items wait in a local queue
- Default concurrency: **10**, overridable via `WEBHOOK_DISPATCH_CONCURRENCY` env var
- Exported `getDispatchMetrics()` returns live `{ queueDepth, lastDeliveryLatencyMs }` for wiring into observability dashboards
- Both fan-out paths (`dispatchWebhooks`, `retryPendingDeliveries`) now use the pool

## Migration

```sql
-- 20260629000000_webhook_ownership_and_strong_secrets
ALTER TABLE "WebhookSubscription" ADD COLUMN "apiKeyId" TEXT NOT NULL DEFAULT '';
ALTER TABLE "WebhookSubscription" ALTER COLUMN "secret" SET NOT NULL;
UPDATE "WebhookSubscription" SET "secret" = '' WHERE "secret" IS NULL;
CREATE INDEX "WebhookSubscription_apiKeyId_idx" ON "WebhookSubscription"("apiKeyId");
```

Existing rows get an empty `apiKeyId`; they will not match any authenticated API key and will not appear in any scoped query.

## Test plan

- [ ] `POST /webhooks` without `X-Api-Key` → 401
- [ ] `POST /webhooks` with valid key → 201 with `secret` field (64-char hex)
- [ ] `GET /webhooks` with key A → does not return subscriptions created by key B
- [ ] `DELETE /webhooks/:id` with wrong API key → 404 (not 403, to avoid enumeration)
- [ ] `PATCH /webhooks/:id` with `active: false` → pending deliveries immediately cancelled in DB
- [ ] `dispatchWebhooks` with 50 subscriptions → at most 10 concurrent outbound requests
- [ ] `getDispatchMetrics().queueDepth` > 0 while dispatching
- [ ] Supplied secret shorter than 32 chars → 400 validation error
- [ ] Secret omitted → auto-generated, returned once, absent from subsequent GET