### PR TITLE
Fix/repair script docker security

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,11 @@
+# ─── Docker Compose database credentials ─────────────────────────────────────
+# REQUIRED when using docker-compose. Use a strong, unique password.
+# Never commit real credentials; rotate immediately if leaked.
+# Exception process: document any known-vulnerable dependency below with an
+# expiry date, e.g.: # EXCEPTION: lodash@4.17.20 CVE-2021-23337 expires 2025-12-31
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=changeme_before_deploying
+
 # ─── Server ───────────────────────────────────────────────────────────────────
 NODE_ENV=development
 PORT=3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update -qq && apt-get install -y -qq openssl ca-certificates > /dev/
 WORKDIR /app
 COPY package*.json ./
 COPY prisma/schema.prisma ./prisma/schema.prisma
-RUN npm ci && npm audit || true
+RUN npm ci && npm audit --audit-level=high
 COPY . .
 RUN npx prisma generate
 RUN npm run build
@@ -15,7 +15,7 @@ RUN apt-get update -qq && apt-get install -y -qq curl ca-certificates gnupg lsb-
     trivy --version && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app /app
-RUN trivy filesystem --exit-code 1 --severity CRITICAL --no-progress /app 2>&1 || echo "Trivy scan complete (some vulnerabilities found)"
+RUN trivy filesystem --exit-code 1 --severity CRITICAL --no-progress --format json --output /trivy-report.json /app
 
 FROM node:20-slim
 RUN addgroup --gid 1001 appgroup && \
@@ -27,7 +27,7 @@ RUN apt-get update -qq && apt-get install -y -qq openssl wget ca-certificates > 
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm ci --omit=dev --ignore-scripts && npm audit --omit=dev || true
+RUN npm ci --omit=dev --ignore-scripts && npm audit --omit=dev --audit-level=high
 
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ x-security: &security
 
 # ─── Per-network DB defaults ──────────────────────────────────────────────────
 x-db-healthcheck: &db-healthcheck
-  test: ['CMD-SHELL', 'pg_isready -U postgres']
+  test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-postgres}']
   interval: 5s
   timeout: 5s
   retries: 5
@@ -95,11 +95,9 @@ services:
     image: postgres:16-alpine
     restart: unless-stopped
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
       POSTGRES_DB: soroban_testnet
-    ports:
-      - '5432:5432'
     volumes:
       - pgdata-testnet:/var/lib/postgresql/data
     healthcheck: *db-healthcheck
@@ -114,8 +112,8 @@ services:
       - '3000:3000'
     environment:
       STELLAR_NETWORK: testnet
-      TESTNET_DATABASE_URL: postgresql://postgres:password@db-testnet:5432/soroban_testnet
-      DATABASE_URL: postgresql://postgres:password@db-testnet:5432/soroban_testnet
+      TESTNET_DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@db-testnet:5432/soroban_testnet
+      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@db-testnet:5432/soroban_testnet
       TESTNET_RPC_URL: https://soroban-testnet.stellar.org
       TESTNET_HORIZON_URL: https://horizon-testnet.stellar.org
       TESTNET_PASSPHRASE: "Test SDF Network ; September 2015"
@@ -141,8 +139,8 @@ services:
     restart: unless-stopped
     environment:
       STELLAR_NETWORK: testnet
-      TESTNET_DATABASE_URL: postgresql://postgres:password@db-testnet:5432/soroban_testnet
-      DATABASE_URL: postgresql://postgres:password@db-testnet:5432/soroban_testnet
+      TESTNET_DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@db-testnet:5432/soroban_testnet
+      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@db-testnet:5432/soroban_testnet
       TESTNET_RPC_URL: https://soroban-testnet.stellar.org
       TESTNET_HORIZON_URL: https://horizon-testnet.stellar.org
       TESTNET_PASSPHRASE: "Test SDF Network ; September 2015"
@@ -165,11 +163,9 @@ services:
     image: postgres:16-alpine
     restart: unless-stopped
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
       POSTGRES_DB: soroban_mainnet
-    ports:
-      - '5433:5432'
     volumes:
       - pgdata-mainnet:/var/lib/postgresql/data
     healthcheck: *db-healthcheck
@@ -185,8 +181,8 @@ services:
       - '3001:3001'
     environment:
       STELLAR_NETWORK: mainnet
-      MAINNET_DATABASE_URL: postgresql://postgres:password@db-mainnet:5432/soroban_mainnet
-      DATABASE_URL: postgresql://postgres:password@db-mainnet:5432/soroban_mainnet
+      MAINNET_DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@db-mainnet:5432/soroban_mainnet
+      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@db-mainnet:5432/soroban_mainnet
       MAINNET_RPC_URL: ${MAINNET_RPC_URL:-}
       MAINNET_HORIZON_URL: https://horizon.stellar.org
       MAINNET_PASSPHRASE: "Public Global Stellar Network ; September 2015"
@@ -213,8 +209,8 @@ services:
     restart: unless-stopped
     environment:
       STELLAR_NETWORK: mainnet
-      MAINNET_DATABASE_URL: postgresql://postgres:password@db-mainnet:5432/soroban_mainnet
-      DATABASE_URL: postgresql://postgres:password@db-mainnet:5432/soroban_mainnet
+      MAINNET_DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@db-mainnet:5432/soroban_mainnet
+      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@db-mainnet:5432/soroban_mainnet
       MAINNET_RPC_URL: ${MAINNET_RPC_URL:-}
       MAINNET_HORIZON_URL: https://horizon.stellar.org
       MAINNET_PASSPHRASE: "Public Global Stellar Network ; September 2015"
@@ -238,11 +234,9 @@ services:
     image: postgres:16-alpine
     restart: unless-stopped
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
       POSTGRES_DB: soroban_devnet
-    ports:
-      - '5434:5432'
     volumes:
       - pgdata-devnet:/var/lib/postgresql/data
     healthcheck: *db-healthcheck
@@ -258,8 +252,8 @@ services:
       - '3002:3002'
     environment:
       STELLAR_NETWORK: devnet
-      DEVNET_DATABASE_URL: postgresql://postgres:password@db-devnet:5432/soroban_devnet
-      DATABASE_URL: postgresql://postgres:password@db-devnet:5432/soroban_devnet
+      DEVNET_DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@db-devnet:5432/soroban_devnet
+      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@db-devnet:5432/soroban_devnet
       DEVNET_RPC_URL: http://stellar-quickstart:8000/soroban/rpc
       DEVNET_HORIZON_URL: http://stellar-quickstart:8000
       DEVNET_PASSPHRASE: "Standalone Network ; February 2017"
@@ -286,8 +280,8 @@ services:
     restart: unless-stopped
     environment:
       STELLAR_NETWORK: devnet
-      DEVNET_DATABASE_URL: postgresql://postgres:password@db-devnet:5432/soroban_devnet
-      DATABASE_URL: postgresql://postgres:password@db-devnet:5432/soroban_devnet
+      DEVNET_DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@db-devnet:5432/soroban_devnet
+      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@db-devnet:5432/soroban_devnet
       DEVNET_RPC_URL: http://stellar-quickstart:8000/soroban/rpc
       DEVNET_HORIZON_URL: http://stellar-quickstart:8000
       DEVNET_PASSPHRASE: "Standalone Network ; February 2017"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "index:testnet": "STELLAR_NETWORK=testnet ts-node src/indexer/run.ts",
     "index:mainnet": "STELLAR_NETWORK=mainnet ts-node src/indexer/run.ts",
     "index:devnet": "STELLAR_NETWORK=devnet ts-node src/indexer/run.ts",
-    "repair": "echo 'Not implemented yet'",
+    "repair": "ts-node src/indexer/repair-run.ts",
     "archive": "ts-node src/archival/run.ts",
     "seed": "ts-node prisma/seed.ts",
     "test": "vitest run",

--- a/src/indexer/repair-run.ts
+++ b/src/indexer/repair-run.ts
@@ -1,0 +1,68 @@
+/**
+ * CLI entry point for the indexer repair tool.
+ *
+ * Usage:
+ *   npm run repair                         # one-shot sweep over full indexed range
+ *   npm run repair -- --dry-run            # scan for gaps without writing anything
+ *   npm run repair -- --from 1000 --to 2000  # sweep a specific ledger range
+ *   npm run repair -- --loop              # continuous background repair loop
+ *
+ * Safe production usage:
+ *   - Always run --dry-run first to inspect gaps before committing writes.
+ *   - Use --from/--to to scope repairs to a known-bad range.
+ *   - --loop is intended for long-running sidecar processes, not one-off ops.
+ *   - The repair process never touches IndexerState, so the live indexer cursor
+ *     is unaffected regardless of which mode is used.
+ */
+
+import { runRepairSweep, startRepairLoop } from './repair';
+
+const args = process.argv.slice(2);
+
+const dryRun = args.includes('--dry-run');
+const loop = args.includes('--loop');
+
+const fromIdx = args.indexOf('--from');
+const toIdx = args.indexOf('--to');
+
+const fromSeq = fromIdx !== -1 ? parseInt(args[fromIdx + 1], 10) : undefined;
+const toSeq = toIdx !== -1 ? parseInt(args[toIdx + 1], 10) : undefined;
+
+if (fromSeq !== undefined && isNaN(fromSeq)) {
+  console.error('[repair] --from requires a numeric ledger sequence');
+  process.exit(1);
+}
+
+if (toSeq !== undefined && isNaN(toSeq)) {
+  console.error('[repair] --to requires a numeric ledger sequence');
+  process.exit(1);
+}
+
+if (fromSeq !== undefined && toSeq !== undefined && fromSeq > toSeq) {
+  console.error('[repair] --from must be less than or equal to --to');
+  process.exit(1);
+}
+
+if (loop && (fromSeq !== undefined || toSeq !== undefined)) {
+  console.error('[repair] --loop cannot be combined with --from/--to');
+  process.exit(1);
+}
+
+if (dryRun) {
+  console.log('[repair] DRY-RUN mode — no data will be written to the database');
+}
+
+async function main() {
+  if (loop) {
+    await startRepairLoop();
+  } else {
+    const result = await runRepairSweep({ dryRun, fromSeq, toSeq });
+    console.log(`[repair] Done. Hard gaps: ${result.hardGaps}, soft gaps: ${result.softGaps}`);
+    process.exit(0);
+  }
+}
+
+main().catch((err) => {
+  console.error('[repair] Fatal error:', err);
+  process.exit(1);
+});

--- a/src/indexer/repair.ts
+++ b/src/indexer/repair.ts
@@ -125,41 +125,58 @@ async function backfill(sequences: number[]): Promise<void> {
  *
  * Returns counts of sequences repaired.
  */
-export async function runRepairSweep(): Promise<{ hardGaps: number; softGaps: number }> {
-  // Bounds: use the min/max sequence actually present in the Ledger table
-  const bounds = await prisma.ledger.aggregate({
-    _min: { sequence: true },
-    _max: { sequence: true },
-  });
+export interface RepairSweepOptions {
+  dryRun?: boolean;
+  fromSeq?: number;
+  toSeq?: number;
+}
 
-  const minSeq = bounds._min.sequence;
-  const maxSeq = bounds._max.sequence;
+export async function runRepairSweep(
+  opts?: RepairSweepOptions,
+): Promise<{ hardGaps: number; softGaps: number }> {
+  const dryRun = opts?.dryRun ?? false;
+
+  let minSeq: number | null = opts?.fromSeq ?? null;
+  let maxSeq: number | null = opts?.toSeq ?? null;
+
+  if (minSeq === null || maxSeq === null) {
+    const bounds = await prisma.ledger.aggregate({
+      _min: { sequence: true },
+      _max: { sequence: true },
+    });
+    if (minSeq === null) minSeq = bounds._min.sequence;
+    if (maxSeq === null) maxSeq = bounds._max.sequence;
+  }
 
   if (minSeq === null || maxSeq === null) {
     console.log('[repair] No ledgers indexed yet — nothing to sweep.');
     return { hardGaps: 0, softGaps: 0 };
   }
 
-  // Cap the sweep window to avoid scanning an unbounded range on first run
-  const sweepMax = Math.min(maxSeq, minSeq + MAX_EMPTY_BATCH * 10);
+  // Cap the sweep window unless an explicit upper bound was supplied
+  const sweepMax =
+    opts?.toSeq !== undefined ? maxSeq : Math.min(maxSeq, minSeq + MAX_EMPTY_BATCH * 10);
 
-  console.log(`[repair] Sweeping ledgers ${minSeq}–${sweepMax}`);
+  console.log(`[repair] Sweeping ledgers ${minSeq}–${sweepMax}${dryRun ? ' (dry-run)' : ''}`);
 
   // 1. Hard gaps
   const missing = await findMissingSequences(minSeq, sweepMax, REPAIR_CHUNK);
   if (missing.length > 0) {
     console.log(`[repair] Found ${missing.length} missing sequence(s)`);
-    await backfill(missing);
+    if (!dryRun) await backfill(missing);
   }
 
   // 2. Soft gaps
   const empty = await findEmptyLedgers(REPAIR_CHUNK);
   if (empty.length > 0) {
     console.log(`[repair] Found ${empty.length} empty ledger(s)`);
-    await backfill(empty);
+    if (!dryRun) await backfill(empty);
   }
 
-  console.log(`[repair] Sweep complete — hard: ${missing.length}, soft: ${empty.length}`);
+  console.log(
+    `[repair] Sweep complete — hard: ${missing.length}, soft: ${empty.length}` +
+      (dryRun ? ' (no changes written — dry-run)' : ''),
+  );
   return { hardGaps: missing.length, softGaps: empty.length };
 }
 


### PR DESCRIPTION
closes #443 
closes #444 
closes #445 
closes #446


---
Issue 1 — npm run repair Not Implemented (package.json, src/indexer/repair.ts, src/indexer/repair-run.ts)

- Created src/indexer/repair-run.ts: A CLI entry point that parses --dry-run, --from <N>, --to <N>, and --loop flags, validates them, and delegates to runRepairSweep() or startRepairLoop() from the existing repair.ts.
- Modified src/indexer/repair.ts: Added a RepairSweepOptions interface and updated runRepairSweep() to accept { dryRun?, fromSeq?, toSeq? }. Dry-run mode scans for gaps and logs counts without writing anything. Range options (fromSeq/toSeq) bound the sweep to a specific ledger window.
- Updated package.json: Changed "repair": "echo 'Not implemented yet'" → "repair": "ts-node src/indexer/repair-run.ts".
- Safe production usage documented in repair-run.ts: always --dry-run first, scope with --from/--to, --loop for sidecars.

---
Issue 2 — npm audit || true Allows Vulnerable Builds (Dockerfile)

- Removed || true from both audit lines (builder and runtime stages).
- Added --audit-level=high threshold — builds now fail when high or critical vulnerabilities are found.
- Exception process with expiry dates documented in .env.example.

---
Issue 3 — Trivy Scan Exit Code Suppressed (Dockerfile)

- Removed || echo "Trivy scan complete (some vulnerabilities found)" which was converting non-zero Trivy exits into success.
- Added --format json --output /trivy-report.json so the scan report is stored as a build artifact in the security-scan stage.
- Trivy's --exit-code 1 now correctly fails the build stage on CRITICAL findings.

---
Issue 4 — Hardcoded DB Credentials and Exposed Ports (docker-compose.yml, .env.example)

- Removed all hardcoded password values from POSTGRES_PASSWORD in all three DB services (testnet, mainnet, devnet). Replaced with ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required} — Docker Compose will refuse to start if the variable is unset.
- POSTGRES_USER uses ${POSTGRES_USER:-postgres} (defaults to postgres but overridable).
- All DATABASE_URL / *_DATABASE_URL env vars in API and indexer services updated to use the same variables.
- Removed ports: mappings from all three DB services (5432:5432, 5433:5432, 5434:5432) — database ports are no longer published to the host; inter-service communication still works via the internal Docker network.
- Updated .env.example: Added a POSTGRES_USER/POSTGRES_PASSWORD section at the top with a safe placeholder value and instructions for the exception process.
