### PR TITLE
Fix/redis security cache lru ttl

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,12 +75,27 @@ services:
   redis:
     image: redis:7-alpine
     restart: unless-stopped
-    ports:
-      - '6379:6379'
+    # No host-port mapping — Redis is reachable only on the internal Compose network.
+    # Set REDIS_PASSWORD in the host environment to enable requirepass authentication.
+    command: >-
+      sh -c 'if [ -n "$$REDIS_PASSWORD" ]; then
+        exec redis-server --requirepass "$$REDIS_PASSWORD";
+      else
+        exec redis-server;
+      fi'
+    environment:
+      REDIS_PASSWORD: '${REDIS_PASSWORD:-}'
     volumes:
       - redis-data:/data
     healthcheck:
-      test: ['CMD', 'redis-cli', 'ping']
+      test:
+        - CMD-SHELL
+        - >-
+          if [ -n "$$REDIS_PASSWORD" ]; then
+            redis-cli -a "$$REDIS_PASSWORD" ping;
+          else
+            redis-cli ping;
+          fi
       interval: 5s
       timeout: 5s
       retries: 5

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -4,17 +4,52 @@ import type { RedisClientType } from 'redis';
 const CACHE_URL = config.cacheUrl ?? 'memory://';
 const USE_REDIS = CACHE_URL !== '' && !CACHE_URL.startsWith('memory://');
 
+// Maximum number of entries kept in the process-local store before LRU eviction kicks in.
+const MAX_CACHE_SIZE = Math.max(1, parseInt(process.env.CACHE_MAX_SIZE ?? '1000'));
+
 interface MemoryEntry {
   payload: string;
   expiresAt: number | null;
 }
 
+// Map insertion order is used as LRU order: oldest entry is first.
 const memoryStore = new Map<string, MemoryEntry>();
 let redisClient: RedisClientType | null = null;
 let redisAvailable = false;
+let _evictionCount = 0;
+
+/** Returns current cache size and cumulative eviction count for metrics. */
+export function cacheStats(): { size: number; evictions: number } {
+  return { size: memoryStore.size, evictions: _evictionCount };
+}
 
 function localNow(): number {
   return Date.now();
+}
+
+/** Insert or update an entry, evicting the LRU entry when the cache is full. */
+function lruSet(key: string, entry: MemoryEntry): void {
+  if (memoryStore.has(key)) {
+    // Re-insert at tail to mark as most-recently used.
+    memoryStore.delete(key);
+  } else if (memoryStore.size >= MAX_CACHE_SIZE) {
+    const oldestKey = memoryStore.keys().next().value;
+    if (oldestKey !== undefined) {
+      memoryStore.delete(oldestKey);
+      _evictionCount++;
+    }
+  }
+  memoryStore.set(key, entry);
+}
+
+/** Read an entry and move it to the tail (most-recently used). */
+function lruGet(key: string): MemoryEntry | undefined {
+  const entry = memoryStore.get(key);
+  if (entry !== undefined) {
+    memoryStore.delete(key);
+    memoryStore.set(key, entry);
+  }
+  return entry;
 }
 
 async function getRedisClient(): Promise<RedisClientType | null> {
@@ -77,12 +112,13 @@ export async function cacheClose(): Promise<void> {
 
 export function cacheClear(): void {
   memoryStore.clear();
+  _evictionCount = 0;
 }
 
 export async function cacheGet<T>(key: string): Promise<T | null> {
   const normalizedKey = key;
 
-  const local = memoryStore.get(normalizedKey);
+  const local = lruGet(normalizedKey);
   if (local) {
     if (isExpired(local)) {
       memoryStore.delete(normalizedKey);
@@ -101,8 +137,13 @@ export async function cacheGet<T>(key: string): Promise<T | null> {
   try {
     const payload = await client.get(normalizedKey);
     if (!payload) return null;
+    // Mirror the remaining Redis TTL into the local store so the entry expires at
+    // the same time as the Redis key, preventing stale data from living forever.
+    // pTTL returns: >0 = ms remaining, -1 = no expiry, -2 = key missing.
+    const pttl = await client.pTTL(normalizedKey);
+    const expiresAt = pttl > 0 ? localNow() + pttl : null;
     const value = JSON.parse(payload) as T;
-    memoryStore.set(normalizedKey, { payload, expiresAt: null });
+    lruSet(normalizedKey, { payload, expiresAt });
     return value;
   } catch (err) {
     console.warn(`[cache] Failed to read key ${normalizedKey} from Redis:`, err);
@@ -117,7 +158,7 @@ export async function cacheSet<T>(
 ): Promise<void> {
   const normalizedKey = key;
   const payload = JSON.stringify(value);
-  memoryStore.set(normalizedKey, {
+  lruSet(normalizedKey, {
     payload,
     expiresAt: buildExpiry(ttlSeconds),
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,9 @@ let isShuttingDown = false;
 let wssRef: ReturnType<typeof attachWebSocketServer> | null = null;
 
 const SHUTDOWN_TIMEOUT_MS = parseInt(process.env.SHUTDOWN_TIMEOUT_MS ?? '30000');
-const STATE_DUMP_PATH = process.env.STATE_DUMP_PATH ?? './data/state';
+// Default to /tmp/state so the path is writable in read-only container filesystems.
+// /tmp is already mounted as a tmpfs in the Compose security profile.
+const STATE_DUMP_PATH = process.env.STATE_DUMP_PATH ?? '/tmp/state';
 
 // Feature flags — set env var to 'true' to enable each optional service.
 const ENABLE_PRIVACY_WS = process.env.ENABLE_PRIVACY_WS === 'true';
@@ -255,8 +257,24 @@ function registerShutdownHandlers(): void {
   });
 }
 
+async function validateStateDumpPath(): Promise<void> {
+  try {
+    await mkdir(STATE_DUMP_PATH, { recursive: true });
+    const testFile = resolve(STATE_DUMP_PATH, '.write-test');
+    await writeFile(testFile, '');
+    const { unlink } = await import('fs/promises');
+    await unlink(testFile).catch(() => {});
+  } catch (err) {
+    logger.warn('State dump path is not writable; shutdown state will not be persisted', {
+      path: STATE_DUMP_PATH,
+      error: String(err),
+    });
+  }
+}
+
 async function main() {
   registerShutdownHandlers();
+  await validateStateDumpPath();
 
   await initRateLimitStore();
 

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -230,3 +230,153 @@ describe('cache — throughput sanity', () => {
     expect(results.filter((r) => r === null).length).toBe(0);
   });
 });
+
+// ── Phase 5: LRU eviction — memory-bound tests ────────────────────────────────
+
+describe('cache — LRU eviction', () => {
+  beforeEach(() => {
+    vi.stubEnv('CACHE_MAX_SIZE', '3');
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('evicts the oldest entry when the cache is full', async () => {
+    const { cacheSet, cacheGet, cacheStats } = await freshCache();
+
+    await cacheSet('a', 1);
+    await cacheSet('b', 2);
+    await cacheSet('c', 3);
+    // Cache is now full (size === 3); adding 'd' should evict 'a'
+    await cacheSet('d', 4);
+
+    expect(await cacheGet('a')).toBeNull();
+    expect(await cacheGet('b')).toBe(2);
+    expect(await cacheGet('c')).toBe(3);
+    expect(await cacheGet('d')).toBe(4);
+    expect(cacheStats().evictions).toBeGreaterThanOrEqual(1);
+  });
+
+  it('accessing a key promotes it and protects it from eviction', async () => {
+    const { cacheSet, cacheGet } = await freshCache();
+
+    await cacheSet('a', 1);
+    await cacheSet('b', 2);
+    await cacheSet('c', 3);
+
+    // Access 'a' to make it most-recently-used
+    await cacheGet('a');
+
+    // Adding 'd' should evict 'b' (now the oldest), not 'a'
+    await cacheSet('d', 4);
+
+    expect(await cacheGet('a')).toBe(1);
+    expect(await cacheGet('b')).toBeNull();
+  });
+
+  it('cache size never exceeds the configured maximum', async () => {
+    const { cacheSet, cacheStats } = await freshCache();
+
+    for (let i = 0; i < 20; i++) {
+      await cacheSet(`k${i}`, i);
+    }
+
+    expect(cacheStats().size).toBeLessThanOrEqual(3);
+    expect(cacheStats().evictions).toBeGreaterThanOrEqual(17);
+  });
+
+  it('cacheClear resets the eviction counter', async () => {
+    const { cacheSet, cacheClear, cacheStats } = await freshCache();
+
+    await cacheSet('x', 1);
+    await cacheSet('y', 2);
+    await cacheSet('z', 3);
+    await cacheSet('w', 4); // triggers eviction
+
+    expect(cacheStats().evictions).toBeGreaterThanOrEqual(1);
+    cacheClear();
+    expect(cacheStats().evictions).toBe(0);
+  });
+});
+
+// ── Phase 6: Stale-cache regression — Redis TTL mirrored locally ───────────────
+
+describe('cache — Redis TTL mirrored to local store', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unmock('redis');
+    vi.unstubAllEnvs();
+  });
+
+  it('local entry expires when the mirrored Redis TTL elapses', async () => {
+    vi.resetModules();
+
+    const pttlMs = 5_000; // 5 s remaining on the Redis key
+
+    vi.mock('redis', () => ({
+      createClient: () => ({
+        on: vi.fn(),
+        connect: vi.fn().mockResolvedValue(undefined),
+        get: vi.fn().mockResolvedValue(JSON.stringify('stale-value')),
+        // pTTL returns remaining milliseconds
+        pTTL: vi.fn().mockResolvedValue(pttlMs),
+        set: vi.fn().mockResolvedValue('OK'),
+        del: vi.fn().mockResolvedValue(1),
+        quit: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn(),
+      }),
+    }));
+
+    vi.stubEnv('CACHE_URL', 'redis://localhost:6379');
+
+    const mod = await import('../src/cache');
+    mod.cacheClear();
+
+    // Prime the local store via a Redis get
+    const first = await mod.cacheGet('redis-key');
+    expect(first).toBe('stale-value');
+
+    // Advance time past the mirrored TTL — local entry should now be expired
+    vi.advanceTimersByTime(pttlMs + 1);
+
+    // The redis mock get is called again (local miss) but returns null this time
+    const { createClient } = await import('redis');
+    const mockClient = (createClient as ReturnType<typeof vi.fn>)();
+    mockClient.get.mockResolvedValue(null);
+
+    const second = await mod.cacheGet('redis-key');
+    expect(second).toBeNull();
+  });
+
+  it('local entry has no expiry when Redis key has no TTL (pTTL === -1)', async () => {
+    vi.resetModules();
+
+    vi.mock('redis', () => ({
+      createClient: () => ({
+        on: vi.fn(),
+        connect: vi.fn().mockResolvedValue(undefined),
+        get: vi.fn().mockResolvedValue(JSON.stringify('persistent')),
+        pTTL: vi.fn().mockResolvedValue(-1), // no expiry set in Redis
+        set: vi.fn().mockResolvedValue('OK'),
+        del: vi.fn().mockResolvedValue(1),
+        quit: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn(),
+      }),
+    }));
+
+    vi.stubEnv('CACHE_URL', 'redis://localhost:6379');
+
+    const mod = await import('../src/cache');
+    mod.cacheClear();
+
+    await mod.cacheGet('persist-key');
+
+    // Even after a very long time the local entry should still be valid
+    vi.advanceTimersByTime(999_999_000);
+
+    // get is mocked; advance won't re-fetch from Redis for a still-valid local hit
+    const val = await mod.cacheGet('persist-key');
+    expect(val).toBe('persistent');
+  });
+});


### PR DESCRIPTION
closes #463 
closes #464 
closes #465 
closes #466 

Summary

Issue 1 — Redis exposed on host port (security)
Removed the 6379:6379 host-port mapping from the redis service in docker-compose.yml. Redis is now reachable only on the internal Compose network. Added optional requirepass authentication: set REDIS_PASSWORD in the host environment to enable it. Health check updated to pass the password to redis-cli -a when set.

Issue 2 — Shutdown state write on read-only filesystem (reliability)
Changed STATE_DUMP_PATH default from ./data/state to /tmp/state in src/index.ts. The Compose security profile already mounts /tmp as a writable tmpfs, so no volume change is needed. Added validateStateDumpPath() called at startup that tests write access and logs a warning (non-fatal) if the path is unwritable.

Issue 3 — Unbounded in-memory cache (reliability)
Replaced the bare Map with an LRU-evicting store in src/cache.ts. Max size is configurable via CACHE_MAX_SIZE (default 1000). Added cacheStats() exporting current size and cumulative eviction count for metrics. cacheClear() now resets the eviction counter.

Issue 4 — Stale Redis data persisted forever in local cache (correctness)
cacheGet now calls client.pTTL(key) after the Redis GET to read the remaining TTL in milliseconds. The local memory entry is stored with the matching expiresAt, so it expires at the same time as the Redis key and can never outlive it.

Test plan

- [x] CACHE_MAX_SIZE=3 — fill cache with 4 keys, verify oldest is evicted (LRU eviction suite)
- [x] Verify cacheStats().evictions increments correctly and resets on cacheClear()
- [x] pTTL = 5000ms mock — advance timer past TTL, verify local entry returns null (stale-cache regression suite)
- [x] pTTL = -1 mock — advance timer far, verify persistent entry still returns value
- [x] Start Compose stack, confirm Redis is not reachable from host on port 6379
- [x] Set REDIS_PASSWORD=secret, confirm redis-cli -a secret ping works from another container and unauthenticated access is rejected

---
FILES CHANGED:
- docker-compose.yml
- src/index.ts
- src/cache.ts
- tests/cache.test.ts