### PR TITLE
Fix/graphql dataloader pagination validation tokens

### DIFF
--- a/src/graphql/loaders.ts
+++ b/src/graphql/loaders.ts
@@ -1,64 +1,64 @@
 import DataLoader from 'dataloader';
 import { prismaRead as prisma } from '../db';
 
-const batchTransactionsByHash = new DataLoader<string, any>(async (hashes) => {
-  const txs = await prisma.transaction.findMany({
-    where: { hash: { in: [...hashes] } },
-  });
-  const map = new Map(txs.map((t) => [t.hash, t]));
-  return hashes.map((h) => map.get(h) ?? null);
-});
-
-const batchEventsById = new DataLoader<string, any>(async (ids) => {
-  const events = await prisma.event.findMany({
-    where: { id: { in: [...ids] } },
-  });
-  const map = new Map(events.map((e) => [e.id, e]));
-  return ids.map((id) => map.get(id) ?? null);
-});
-
-const batchContractsByAddress = new DataLoader<string, any>(async (addresses) => {
-  const contracts = await prisma.contract.findMany({
-    where: { address: { in: [...addresses] } },
-  });
-  const map = new Map(contracts.map((c) => [c.address, c]));
-  return addresses.map((a) => map.get(a) ?? null);
-});
-
-const batchTransactionsByLedger = new DataLoader<number, any[]>(async (sequences) => {
-  const txs = await prisma.transaction.findMany({
-    where: { ledgerSequence: { in: [...sequences] } },
-    orderBy: [{ ledgerSequence: 'desc' }, { id: 'desc' }],
-  });
-  const map = new Map<number, any[]>();
-  for (const seq of sequences) map.set(seq, []);
-  for (const tx of txs) map.get(tx.ledgerSequence)!.push(tx);
-  return sequences.map((s) => map.get(s) ?? []);
-});
-
-const batchEventsByLedger = new DataLoader<number, any[]>(async (sequences) => {
-  const events = await prisma.event.findMany({
-    where: { ledgerSequence: { in: [...sequences] } },
-    orderBy: { ledgerSequence: 'desc' },
-  });
-  const map = new Map<number, any[]>();
-  for (const seq of sequences) map.set(seq, []);
-  for (const ev of events) map.get(ev.ledgerSequence)!.push(ev);
-  return sequences.map((s) => map.get(s) ?? []);
-});
-
-const batchEventsByTxHash = new DataLoader<string, any[]>(async (hashes) => {
-  const events = await prisma.event.findMany({
-    where: { transactionHash: { in: [...hashes] } },
-    orderBy: { ledgerSequence: 'desc' },
-  });
-  const map = new Map<string, any[]>();
-  for (const h of hashes) map.set(h, []);
-  for (const ev of events) map.get(ev.transactionHash)!.push(ev);
-  return hashes.map((h) => map.get(h) ?? []);
-});
-
 export function createLoaders() {
+  const batchTransactionsByHash = new DataLoader<string, any>(async (hashes) => {
+    const txs = await prisma.transaction.findMany({
+      where: { hash: { in: [...hashes] } },
+    });
+    const map = new Map(txs.map((t) => [t.hash, t]));
+    return hashes.map((h) => map.get(h) ?? null);
+  });
+
+  const batchEventsById = new DataLoader<string, any>(async (ids) => {
+    const events = await prisma.event.findMany({
+      where: { id: { in: [...ids] } },
+    });
+    const map = new Map(events.map((e) => [e.id, e]));
+    return ids.map((id) => map.get(id) ?? null);
+  });
+
+  const batchContractsByAddress = new DataLoader<string, any>(async (addresses) => {
+    const contracts = await prisma.contract.findMany({
+      where: { address: { in: [...addresses] } },
+    });
+    const map = new Map(contracts.map((c) => [c.address, c]));
+    return addresses.map((a) => map.get(a) ?? null);
+  });
+
+  const batchTransactionsByLedger = new DataLoader<number, any[]>(async (sequences) => {
+    const txs = await prisma.transaction.findMany({
+      where: { ledgerSequence: { in: [...sequences] } },
+      orderBy: [{ ledgerSequence: 'desc' }, { id: 'desc' }],
+    });
+    const map = new Map<number, any[]>();
+    for (const seq of sequences) map.set(seq, []);
+    for (const tx of txs) map.get(tx.ledgerSequence)!.push(tx);
+    return sequences.map((s) => map.get(s) ?? []);
+  });
+
+  const batchEventsByLedger = new DataLoader<number, any[]>(async (sequences) => {
+    const events = await prisma.event.findMany({
+      where: { ledgerSequence: { in: [...sequences] } },
+      orderBy: { ledgerSequence: 'desc' },
+    });
+    const map = new Map<number, any[]>();
+    for (const seq of sequences) map.set(seq, []);
+    for (const ev of events) map.get(ev.ledgerSequence)!.push(ev);
+    return sequences.map((s) => map.get(s) ?? []);
+  });
+
+  const batchEventsByTxHash = new DataLoader<string, any[]>(async (hashes) => {
+    const events = await prisma.event.findMany({
+      where: { transactionHash: { in: [...hashes] } },
+      orderBy: { ledgerSequence: 'desc' },
+    });
+    const map = new Map<string, any[]>();
+    for (const h of hashes) map.set(h, []);
+    for (const ev of events) map.get(ev.transactionHash)!.push(ev);
+    return hashes.map((h) => map.get(h) ?? []);
+  });
+
   return {
     transactionByHash: batchTransactionsByHash,
     eventById: batchEventsById,

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -1,6 +1,8 @@
 import type { GraphQLContext } from './context';
 
 const MAX_LIMIT = 100;
+const DEFAULT_PAGE_LIMIT = 20;
+const DEFAULT_LIST_LIMIT = 50;
 
 interface PageArgs {
   cursor?: string | null;
@@ -33,7 +35,7 @@ async function paginateTransactions(
   args: PageArgs,
   orderBy: Record<string, string>[] = [{ ledgerSequence: 'desc' }, { id: 'desc' }],
 ) {
-  const limit = clampLimit(args.limit, 20);
+  const limit = clampLimit(args.limit, DEFAULT_PAGE_LIMIT);
 
   let finalWhere: Record<string, unknown> = where;
   if (args.cursor) {
@@ -68,7 +70,7 @@ async function paginateTransactions(
 }
 
 async function paginateEvents(ctx: GraphQLContext, where: Record<string, unknown>, args: PageArgs) {
-  const limit = clampLimit(args.limit, 20);
+  const limit = clampLimit(args.limit, DEFAULT_PAGE_LIMIT);
 
   let finalWhere: Record<string, unknown> = where;
   if (args.cursor) {
@@ -201,7 +203,7 @@ export const resolvers = {
       return ctx.loaders.contractByAddress.load(parent.address);
     },
     async transfers(parent: any, args: { limit?: number }, ctx: GraphQLContext) {
-      const limit = clampLimit(args.limit, 50);
+      const limit = clampLimit(args.limit, DEFAULT_LIST_LIMIT);
       return ctx.prisma.event.findMany({
         where: { contractAddress: parent.address, eventType: 'transfer' },
         orderBy: { ledgerSequence: 'desc' },
@@ -246,7 +248,7 @@ export const resolvers = {
       );
     },
     async contracts(parent: { address: string }, args: { limit?: number }, ctx: GraphQLContext) {
-      const limit = clampLimit(args.limit, 50);
+      const limit = clampLimit(args.limit, DEFAULT_LIST_LIMIT);
       return ctx.prisma.contract.findMany({
         where: { transactions: { some: { sourceAccount: parent.address } } },
         take: limit,
@@ -306,7 +308,7 @@ export const resolvers = {
       return ctx.loaders.contractByAddress.load(args.address);
     },
     async contracts(_parent: unknown, args: { limit?: number }, ctx: GraphQLContext) {
-      const limit = clampLimit(args.limit, 50);
+      const limit = clampLimit(args.limit, DEFAULT_LIST_LIMIT);
       return ctx.prisma.contract.findMany({
         take: limit,
         orderBy: { createdAt: 'desc' },
@@ -330,7 +332,7 @@ export const resolvers = {
       args: { cursor?: string; limit?: number },
       ctx: GraphQLContext,
     ) {
-      const limit = clampLimit(args.limit, 20);
+      const limit = clampLimit(args.limit, DEFAULT_PAGE_LIMIT);
 
       const contracts = await ctx.prisma.contract.findMany({
         where: { isToken: true },

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -12,12 +12,12 @@ function clampLimit(value: number | undefined | null, defaultVal: number): numbe
 }
 
 function encodeCursor(ledgerSequence: number, id: string): string {
-  return Buffer.from(JSON.stringify({ l: ledgerSequence, i: id })).toString('base64');
+  return Buffer.from(JSON.stringify({ l: ledgerSequence, i: id })).toString('base64url');
 }
 
 function decodeCursor(cursor: string): { ledgerSequence: number; id: string } | undefined {
   try {
-    const parsed = JSON.parse(Buffer.from(cursor, 'base64').toString('utf8'));
+    const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'));
     if (typeof parsed.l === 'number' && typeof parsed.i === 'string') {
       return { ledgerSequence: parsed.l, id: parsed.i };
     }

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -1,13 +1,30 @@
 import type { GraphQLContext } from './context';
 
+const MAX_LIMIT = 100;
+
 interface PageArgs {
   cursor?: string | null;
   limit?: number;
 }
 
-function toInt(v: unknown): number | undefined {
-  const n = typeof v === 'string' ? parseInt(v, 10) : (v as number);
-  return Number.isFinite(n) ? n : undefined;
+function clampLimit(value: number | undefined | null, defaultVal: number): number {
+  return Math.max(1, Math.min(value ?? defaultVal, MAX_LIMIT));
+}
+
+function encodeCursor(ledgerSequence: number, id: string): string {
+  return Buffer.from(JSON.stringify({ l: ledgerSequence, i: id })).toString('base64');
+}
+
+function decodeCursor(cursor: string): { ledgerSequence: number; id: string } | undefined {
+  try {
+    const parsed = JSON.parse(Buffer.from(cursor, 'base64').toString('utf8'));
+    if (typeof parsed.l === 'number' && typeof parsed.i === 'string') {
+      return { ledgerSequence: parsed.l, id: parsed.i };
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 async function paginateTransactions(
@@ -16,41 +33,73 @@ async function paginateTransactions(
   args: PageArgs,
   orderBy: Record<string, string>[] = [{ ledgerSequence: 'desc' }, { id: 'desc' }],
 ) {
-  const limit = Math.min(args.limit ?? 20, 100);
+  const limit = clampLimit(args.limit, 20);
+
+  let finalWhere: Record<string, unknown> = where;
   if (args.cursor) {
-    const cursorVal = toInt(args.cursor);
-    if (cursorVal !== undefined) {
-      where.ledgerSequence = { ...((where.ledgerSequence as object) || {}), lt: cursorVal };
+    const decoded = decodeCursor(args.cursor);
+    if (decoded) {
+      finalWhere = {
+        AND: [
+          where,
+          {
+            OR: [
+              { ledgerSequence: { lt: decoded.ledgerSequence } },
+              { ledgerSequence: decoded.ledgerSequence, id: { lt: decoded.id } },
+            ],
+          },
+        ],
+      };
     }
   }
+
   const rows = await ctx.prisma.transaction.findMany({
-    where: where as any,
+    where: finalWhere as any,
     orderBy,
     take: limit + 1,
   });
   const hasNext = rows.length > limit;
   const data = hasNext ? rows.slice(0, limit) : rows;
-  const nextCursor = hasNext && data.length > 0 ? data[data.length - 1].ledgerSequence : null;
-  return { data, hasNext, nextCursor: nextCursor != null ? String(nextCursor) : null };
+  const nextCursor =
+    hasNext && data.length > 0
+      ? encodeCursor(data[data.length - 1].ledgerSequence, data[data.length - 1].id)
+      : null;
+  return { data, hasNext, nextCursor };
 }
 
 async function paginateEvents(ctx: GraphQLContext, where: Record<string, unknown>, args: PageArgs) {
-  const limit = Math.min(args.limit ?? 20, 100);
+  const limit = clampLimit(args.limit, 20);
+
+  let finalWhere: Record<string, unknown> = where;
   if (args.cursor) {
-    const cursorVal = toInt(args.cursor);
-    if (cursorVal !== undefined) {
-      where.ledgerSequence = { ...((where.ledgerSequence as object) || {}), lt: cursorVal };
+    const decoded = decodeCursor(args.cursor);
+    if (decoded) {
+      finalWhere = {
+        AND: [
+          where,
+          {
+            OR: [
+              { ledgerSequence: { lt: decoded.ledgerSequence } },
+              { ledgerSequence: decoded.ledgerSequence, id: { lt: decoded.id } },
+            ],
+          },
+        ],
+      };
     }
   }
+
   const rows = await ctx.prisma.event.findMany({
-    where: where as any,
-    orderBy: { ledgerSequence: 'desc' },
+    where: finalWhere as any,
+    orderBy: [{ ledgerSequence: 'desc' }, { id: 'desc' }],
     take: limit + 1,
   });
   const hasNext = rows.length > limit;
   const data = hasNext ? rows.slice(0, limit) : rows;
-  const nextCursor = hasNext && data.length > 0 ? data[data.length - 1].ledgerSequence : null;
-  return { data, hasNext, nextCursor: nextCursor != null ? String(nextCursor) : null };
+  const nextCursor =
+    hasNext && data.length > 0
+      ? encodeCursor(data[data.length - 1].ledgerSequence, data[data.length - 1].id)
+      : null;
+  return { data, hasNext, nextCursor };
 }
 
 export const resolvers = {
@@ -152,7 +201,7 @@ export const resolvers = {
       return ctx.loaders.contractByAddress.load(parent.address);
     },
     async transfers(parent: any, args: { limit?: number }, ctx: GraphQLContext) {
-      const limit = Math.min(args.limit ?? 50, 100);
+      const limit = clampLimit(args.limit, 50);
       return ctx.prisma.event.findMany({
         where: { contractAddress: parent.address, eventType: 'transfer' },
         orderBy: { ledgerSequence: 'desc' },
@@ -197,7 +246,7 @@ export const resolvers = {
       );
     },
     async contracts(parent: { address: string }, args: { limit?: number }, ctx: GraphQLContext) {
-      const limit = Math.min(args.limit ?? 50, 100);
+      const limit = clampLimit(args.limit, 50);
       return ctx.prisma.contract.findMany({
         where: { transactions: { some: { sourceAccount: parent.address } } },
         take: limit,
@@ -257,7 +306,7 @@ export const resolvers = {
       return ctx.loaders.contractByAddress.load(args.address);
     },
     async contracts(_parent: unknown, args: { limit?: number }, ctx: GraphQLContext) {
-      const limit = Math.min(args.limit ?? 50, 100);
+      const limit = clampLimit(args.limit, 50);
       return ctx.prisma.contract.findMany({
         take: limit,
         orderBy: { createdAt: 'desc' },
@@ -276,18 +325,35 @@ export const resolvers = {
         __contract: contract,
       };
     },
-    async tokens(_parent: unknown, _args: unknown, ctx: GraphQLContext) {
+    async tokens(
+      _parent: unknown,
+      args: { cursor?: string; limit?: number },
+      ctx: GraphQLContext,
+    ) {
+      const limit = clampLimit(args.limit, 20);
+
       const contracts = await ctx.prisma.contract.findMany({
         where: { isToken: true },
-        orderBy: { tokenSymbol: 'asc' },
+        orderBy: [{ tokenSymbol: 'asc' }, { address: 'asc' }],
+        take: limit + 1,
+        ...(args.cursor ? { cursor: { address: args.cursor }, skip: 1 } : {}),
       });
-      return contracts.map((c) => ({
-        address: c.address,
-        name: c.tokenName,
-        symbol: c.tokenSymbol,
-        decimals: c.tokenDecimals,
-        __contract: c,
-      }));
+
+      const hasNext = contracts.length > limit;
+      const data = hasNext ? contracts.slice(0, limit) : contracts;
+      const nextCursor = hasNext && data.length > 0 ? data[data.length - 1].address : null;
+
+      return {
+        data: data.map((c) => ({
+          address: c.address,
+          name: c.tokenName,
+          symbol: c.tokenSymbol,
+          decimals: c.tokenDecimals,
+          __contract: c,
+        })),
+        hasNext,
+        nextCursor,
+      };
     },
     wallet(_parent: unknown, args: { address: string }, _ctx: GraphQLContext) {
       return { address: args.address };

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -108,6 +108,12 @@ export const typeDefs = `#graphql
     transfers(limit: Int = 50): [Event!]
   }
 
+  type TokenPage implements Page {
+    data: [Token!]!
+    hasNext: Boolean!
+    nextCursor: Cursor
+  }
+
   # ── Wallet ─────────────────────────────────────────────────────────
   type Wallet @key(fields: "address") {
     address: ID!
@@ -168,7 +174,7 @@ export const typeDefs = `#graphql
     token(address: ID!): Token
 
     """List all known tokens"""
-    tokens: [Token!]!
+    tokens(cursor: Cursor, limit: Int = 20): TokenPage!
 
     """Fetch a wallet by Stellar address"""
     wallet(address: ID!): Wallet


### PR DESCRIPTION

closes #471
closes #472
closes #473
closes #474

---
FILES CHANGED:
- src/graphql/loaders.ts
- src/graphql/resolvers.ts
- src/graphql/schema.ts

---
Description of changes:

Issue 1 — DataLoader module-scope shared cache (loaders.ts):
All six DataLoader instances were constructed at module scope, making them shared singletons across all requests. Moved all instantiations inside createLoaders() so each request gets a fresh loader with an empty cache — caches are now discarded after each request.

Issue 2 — Pagination cursor encodes only ledger number (resolvers.ts):
The old cursor was ledgerSequence alone, so when paginating through multiple transactions in the same ledger, the first page's last item would produce a cursor that skips all remaining rows in that ledger. Fixed by encoding both ledgerSequence and id into a base64url JSON cursor. The composite predicate (ledgerSequence < cursorLedger) OR (ledgerSequence = cursorLedger AND id < cursorId) is applied to correctly resume mid-ledger. Both paginateTransactions and paginateEvents are fixed; events now also order by [ledgerSequence DESC, id DESC] for a stable sort.

Issue 3 — No lower bound on limits (resolvers.ts):
Replaced every bare Math.min(...) with a shared clampLimit() helper that applies Math.max(1, Math.min(value ?? default, 100)), enforcing a minimum of 1 on all paginated and list queries so zero or negative values never reach Prisma.

Issue 4 — tokens resolver loads all rows (resolvers.ts, schema.ts):
The tokens query had no limit or cursor, scanning every token contract on every call. Added cursor and limit args (max 100, default 20), a new TokenPage return type in the schema, and Prisma cursor-based pagination keyed on the unique address field with orderBy: [tokenSymbol asc, address asc].