### PR TITLE
fix: clearly mark predictive models as simulated/educational, rename Mock classes to Simulation

### DIFF
--- a/src/predictive/ensemble.ts
+++ b/src/predictive/ensemble.ts
@@ -1,5 +1,16 @@
 import { IForecastingModel, ForecastResult } from './models';
 
+/**
+ * SIMULATED ENSEMBLE FORECASTER
+ *
+ * This ensemble performs a simple equal-weighted average of sub-model
+ * predictions. The confidence-interval adjustment (multiply by
+ * confidenceLevel / 0.95) is a heuristic approximation, NOT a real
+ * Bayesian optimization or Gaussian-process fusion.
+ *
+ * Suitable for demo / educational use only.
+ */
+
 export class EnsembleForecaster {
   private models: IForecastingModel[];
 

--- a/src/predictive/factory.ts
+++ b/src/predictive/factory.ts
@@ -1,7 +1,7 @@
 import { config } from '../config';
 import { EnsembleForecaster } from './ensemble';
 import { generateDeterministicSeries } from './random';
-import { ArimaMock, XgboostMock, LstmMock } from './models';
+import { ArimaSimulation, XgboostSimulation, LstmSimulation } from './models';
 import { LinearTrendModel, SeasonalMeanModel } from './production-models';
 
 export type ForecastMode = 'demo' | 'production';
@@ -20,7 +20,7 @@ export function createForecaster(options: ForecasterOptions = {}): EnsembleForec
   const models =
     mode === 'production'
       ? [new LinearTrendModel(), new SeasonalMeanModel()]
-      : [new ArimaMock(seed), new XgboostMock(seed), new LstmMock(seed)];
+      : [new ArimaSimulation(seed), new XgboostSimulation(seed), new LstmSimulation(seed)];
 
   const forecaster = new EnsembleForecaster(models);
   forecaster.trainAll(generateDeterministicSeries(30, seed));

--- a/src/predictive/fraud-models.ts
+++ b/src/predictive/fraud-models.ts
@@ -10,8 +10,28 @@ export interface InferenceResult {
 }
 
 /**
- * 1. Time-series Anomaly Detector (LSTM-based Autoencoder mock)
- * Trained on normal transaction patterns, flags outliers.
+ * =========================================================================
+ * SIMULATED / EDUCATIONAL FRAUD-DETECTION MODELS
+ *
+ * The classes below (LstmAnomalyDetector, GnnClusterDetector,
+ * XgboostWashTradingClassifier, ExploitPredictor) are RULE-BASED
+ * HEURISTICS — NOT real neural networks, graph neural networks,
+ * gradient-boosted trees, or LLMs.
+ *
+ * - No PyTorch / TensorFlow / ONNX runtime is loaded.
+ * - No XGBoost / LightGBM binaries are invoked.
+ * - SHAP values are hard-coded weights, not Shapley values.
+ * - "LIME explanations" are pre-formed template strings.
+ *
+ * These classes exist for demo / educational / integration-test
+ * purposes. They are NOT suitable for production fraud detection.
+ * =========================================================================
+ */
+
+/**
+ * 1. Time-series Anomaly Detector — rule-based simulation.
+ * Not an actual LSTM autoencoder. Uses a simple threshold on gas-price
+ * deviation and inter-transaction timing.
  */
 export class LstmAnomalyDetector {
   private normalThreshold = 0.65;
@@ -72,8 +92,8 @@ export class LstmAnomalyDetector {
 }
 
 /**
- * 2. Graph Neural Network (GNN - GraphSAGE / GAT mock)
- * Detects wash trading rings, Sybil clusters, and money laundering.
+ * 2. Graph Neural Network simulation — rule-based, not a real GNN.
+ * Uses centrality + PageRank heuristics rather than message-passing on a graph.
  */
 export class GnnClusterDetector {
   async predict(features: TransactionFeatures): Promise<InferenceResult> {
@@ -111,8 +131,9 @@ export class GnnClusterDetector {
 }
 
 /**
- * 3. Wash Trading Classifier (XGBoost/LightGBM mock)
- * Uses self-trading ratios, volume clustering, price deviations.
+ * 3. Wash Trading Classifier — rule-based simulation.
+ * Not real XGBoost / LightGBM. Uses simple thresholds on volume clustering
+ * and liquidity change to produce a heuristic risk score.
  */
 export class XgboostWashTradingClassifier {
   async predict(features: TransactionFeatures): Promise<InferenceResult> {
@@ -151,8 +172,9 @@ export class XgboostWashTradingClassifier {
 }
 
 /**
- * 4. Smart Contract Exploit Predictor (LLM-embedding mock)
- * Predicts reentrancy, flash loan attacks, oracle manipulation.
+ * 4. Smart Contract Exploit Predictor — rule-based simulation.
+ * Not an actual LLM/embedding model. Uses call-depth and storage-access
+ * heuristics to flag reentrancy, flash-loan, and oracle-manipulation patterns.
  */
 export class ExploitPredictor {
   async predict(features: TransactionFeatures): Promise<InferenceResult> {

--- a/src/predictive/models.ts
+++ b/src/predictive/models.ts
@@ -1,6 +1,20 @@
 import type { RandomSource } from './random';
 import { createSeededRandom, mathRandomSource } from './random';
 
+/**
+ * SIMULATED / EDUCATIONAL FORECASTING MODELS
+ *
+ * The classes in this file (ArimaSimulation, XgboostSimulation, LstmSimulation)
+ * are NOT real ARIMA, XGBoost, or LSTM implementations. They use simplified
+ * math + seeded PRNG to produce plausible-looking forecasts for demo/educational
+ * purposes only. They are NOT suitable for production financial decisions.
+ *
+ * For production use, set FORECAST_MODE=production in your environment, which
+ * activates the real mathematical models in production-models.ts (linear trend &
+ * seasonal mean). Those models are still simple statistics — not ML — but they
+ * are deterministic, auditable, and appropriate for a block-explorer context.
+ */
+
 export interface ForecastResult {
   timestamp: Date;
   predictedValue: number;
@@ -36,9 +50,13 @@ function rngForPrediction(seed: number | undefined, recentData: number[]): Rando
   return createSeededRandom(hash);
 }
 
-export class ArimaMock implements IForecastingModel {
-  name = 'ARIMA-auto';
-  type = 'arima';
+/**
+ * ARIMA simulation — not a real ARIMA model.
+ * Uses a simple trend + noise heuristic instead of actual differencing / ACF / PACF.
+ */
+export class ArimaSimulation implements IForecastingModel {
+  name = 'ARIMA-Simulation';
+  type = 'arima-simulation';
   version = '1.0.0';
 
   private lastValue = 0;
@@ -82,9 +100,14 @@ export class ArimaMock implements IForecastingModel {
   }
 }
 
-export class XgboostMock implements IForecastingModel {
-  name = 'XGBoost-Regressor';
-  type = 'xgboost';
+/**
+ * XGBoost simulation — not a real gradient-boosted tree model.
+ * Returns a sinusoidal baseline + noise shaped to resemble an ensemble forecast.
+ * SHAP values are synthetic percentages, not computed from actual feature attributions.
+ */
+export class XgboostSimulation implements IForecastingModel {
+  name = 'XGBoost-Simulation';
+  type = 'xgboost-simulation';
   version = '1.2.0';
 
   private baseValue = 0;
@@ -128,9 +151,14 @@ export class XgboostMock implements IForecastingModel {
   }
 }
 
-export class LstmMock implements IForecastingModel {
-  name = 'LSTM-Attention';
-  type = 'lstm';
+/**
+ * LSTM simulation — not a real recurrent neural network.
+ * Uses mean-reverting random walk instead of actual gated memory cells.
+ * The "attention" and "momentum" terms are narrative only.
+ */
+export class LstmSimulation implements IForecastingModel {
+  name = 'LSTM-Simulation';
+  type = 'lstm-simulation';
   version = '2.0.0';
 
   private baseValue = 0;

--- a/tests/predictive/__snapshots__/deterministic-forecast.test.ts.snap
+++ b/tests/predictive/__snapshots__/deterministic-forecast.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`demo forecast models (seeded) > ArimaMock produces identical output for the same seed and input 1`] = `
+exports[`demo forecast models (seeded) > ArimaSimulation produces identical output for the same seed and input 1`] = `
 [
   {
     "lowerBound": 927.059883,
@@ -35,7 +35,7 @@ exports[`demo forecast models (seeded) > ArimaMock produces identical output for
 ]
 `;
 
-exports[`demo forecast models (seeded) > XgboostMock produces identical SHAP values for the same seed 1`] = `
+exports[`demo forecast models (seeded) > XgboostSimulation produces identical SHAP values for the same seed 1`] = `
 [
   {
     "predictedValue": 1039.209518,

--- a/tests/predictive/deterministic-forecast.test.ts
+++ b/tests/predictive/deterministic-forecast.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { ArimaMock, XgboostMock } from '../../src/predictive/models';
+import { ArimaSimulation, XgboostSimulation } from '../../src/predictive/models';
 import { EnsembleForecaster } from '../../src/predictive/ensemble';
 import { createForecaster } from '../../src/predictive/factory';
 import { LinearTrendModel, SeasonalMeanModel } from '../../src/predictive/production-models';
@@ -26,9 +26,9 @@ describe('demo forecast models (seeded)', () => {
     vi.useRealTimers();
   });
 
-  it('ArimaMock produces identical output for the same seed and input', () => {
-    const a = new ArimaMock(42);
-    const b = new ArimaMock(42);
+  it('ArimaSimulation produces identical output for the same seed and input', () => {
+    const a = new ArimaSimulation(42);
+    const b = new ArimaSimulation(42);
     a.train(SAMPLE_DATA);
     b.train(SAMPLE_DATA);
 
@@ -39,8 +39,8 @@ describe('demo forecast models (seeded)', () => {
     expect(runA).toEqual(normalizeForecast(a.predict(5, SAMPLE_DATA, undefined, FIXED_NOW)));
   });
 
-  it('XgboostMock produces identical SHAP values for the same seed', () => {
-    const model = new XgboostMock(99);
+  it('XgboostSimulation produces identical SHAP values for the same seed', () => {
+    const model = new XgboostSimulation(99);
     model.train(SAMPLE_DATA);
     const results = model.predict(3, SAMPLE_DATA, undefined, FIXED_NOW);
 


### PR DESCRIPTION
Closes #634