### PR TITLE
fix(indexer): replace feature-store mock implementation with real on-chain extraction

### DIFF
--- a/src/indexer/feature-store.ts
+++ b/src/indexer/feature-store.ts
@@ -1,81 +1,118 @@
 import { prismaWrite as prisma } from '../db';
-import { config } from '../config';
-import {
-  createSeededRandom,
-  generateDeterministicSeries,
-  type RandomSource,
-} from '../predictive/random';
 
 export class FeatureStore {
-  constructor(private readonly rng: RandomSource = createSeededRandom(config.forecastSeed)) {}
+  constructor() {}
 
   /**
-   * Computes derived features (rolling averages, lag, ratio) for the latest block.
+   * Computes derived features for the latest block from actual indexed data.
    */
   public async computeAndStoreFeatures(ledgerSequence: number, closeTime: Date) {
-    const txVolume = await prisma.transaction.count({
-      where: { ledgerSequence },
-    });
+    const ledger = await prisma.ledger.findUnique({ where: { sequence: ledgerSequence } });
+    const txCount = ledger?.txCount ?? 0;
 
-    const txVol7d = await this.getRollingAverage('tx_volume', 7);
+    const [txVolume, uniqueSourceAccounts, contractsWithEvents, failedTxs] = await Promise.all([
+      prisma.transaction.count({ where: { ledgerSequence } }),
+      prisma.transaction.findMany({
+        where: { ledgerSequence },
+        select: { sourceAccount: true },
+        distinct: ['sourceAccount'],
+      }),
+      prisma.event.findMany({
+        where: { ledgerSequence },
+        select: { contractAddress: true },
+        distinct: ['contractAddress'],
+      }),
+      prisma.transaction.count({ where: { ledgerSequence, status: { not: 'success' } } }),
+    ]);
 
-    const txVolDef = await this.getOrCreateFeatureDef('tx_volume', 'transaction volume per block');
-    const txVol7dDef = await this.getOrCreateFeatureDef(
-      'tx_volume_7d_ma',
-      '7-day moving average of tx volume',
+    const failureRatio = txCount > 0 ? Number((failedTxs / txCount).toFixed(6)) : 0;
+
+    const latestLedger = await prisma.ledger.findFirst({ orderBy: { sequence: 'desc' } });
+    const freshnessSeconds = latestLedger
+      ? Number(((closeTime.getTime() - latestLedger.closeTime.getTime()) / 1000).toFixed(3))
+      : 0;
+
+    const txVolume7dAvg = await this.compute7dMovingAverage('tx_volume');
+
+    const features = [
+      { name: 'tx_volume', value: txVolume, description: 'transaction count for the ledger' },
+      {
+        name: 'unique_source_accounts',
+        value: uniqueSourceAccounts.length,
+        description: 'distinct source accounts in ledger',
+      },
+      {
+        name: 'contracts_with_events',
+        value: contractsWithEvents.length,
+        description: 'distinct contract addresses emitting events',
+      },
+      {
+        name: 'tx_failure_ratio',
+        value: failureRatio,
+        description: 'failed tx ratio for ledger',
+      },
+      {
+        name: 'data_freshness_seconds',
+        value: freshnessSeconds,
+        description: 'seconds since latest indexed ledger close',
+      },
+      {
+        name: 'tx_volume_7d_ma',
+        value: txVolume7dAvg,
+        description: '7-day simple moving average of tx volume',
+      },
+    ];
+
+    const rows = await Promise.all(
+      features.map(async (feature) => {
+        const def = await this.getOrCreateFeatureDef(feature.name, feature.description);
+        return {
+          featureId: def.id,
+          timestamp: closeTime,
+          value: feature.value,
+          ledger: ledgerSequence,
+        };
+      }),
     );
 
-    await prisma.featureValue.createMany({
-      data: [
-        {
-          featureId: txVolDef.id,
-          timestamp: closeTime,
-          value: txVolume,
-          ledger: ledgerSequence,
-        },
-        {
-          featureId: txVol7dDef.id,
-          timestamp: closeTime,
-          value: txVol7d,
-          ledger: ledgerSequence,
-        },
-      ],
-      skipDuplicates: true,
-    });
+    await prisma.featureValue.createMany({ data: rows, skipDuplicates: true });
   }
 
   private async getOrCreateFeatureDef(name: string, description: string) {
-    let def = await prisma.featureDefinition.findUnique({
-      where: { name },
-    });
+    let def = await prisma.featureDefinition.findUnique({ where: { name } });
     if (!def) {
       def = await prisma.featureDefinition.create({
-        data: {
-          name,
-          description,
-          category: 'onchain',
-        },
+        data: { name, description, category: 'onchain' },
       });
     }
     return def;
   }
 
-  private async getRollingAverage(_featureName: string, _days: number): Promise<number> {
-    return 1000 + this.rng.next() * 200;
-  }
-
-  private syntheticSeries(metric: string, limit: number): number[] {
-    let seed = config.forecastSeed;
-    for (let i = 0; i < metric.length; i++) {
-      seed = (seed * 31 + metric.charCodeAt(i)) >>> 0;
+  private async compute7dMovingAverage(featureName: string): Promise<number> {
+    const def = await prisma.featureDefinition.findUnique({ where: { name: featureName } });
+    if (!def) {
+      return 0;
     }
-    return generateDeterministicSeries(limit, seed);
+
+    const values = await prisma.featureValue.findMany({
+      where: { featureId: def.id },
+      orderBy: { timestamp: 'desc' },
+      take: 7,
+    });
+
+    const recent = values.map((value) => value.value);
+    if (recent.length === 0) {
+      return 0;
+    }
+
+    const sum = recent.reduce((acc, val) => acc + val, 0);
+    return Number((sum / recent.length).toFixed(6));
   }
 
   public async getHistoricalData(metric: string, limit: number = 30): Promise<number[]> {
     const def = await prisma.featureDefinition.findUnique({ where: { name: metric } });
     if (!def) {
-      return this.syntheticSeries(metric, limit);
+      return [];
     }
 
     const values = await prisma.featureValue.findMany({
@@ -84,11 +121,7 @@ export class FeatureStore {
       take: limit,
     });
 
-    if (values.length === 0) {
-      return this.syntheticSeries(metric, limit);
-    }
-
-    return values.reverse().map((v: { value: number }) => v.value);
+    return values.map((value) => value.value);
   }
 }
 

--- a/tests/indexer/feature-store.test.ts
+++ b/tests/indexer/feature-store.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/db', () => ({
+  prismaWrite: {
+    ledger: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+    },
+    transaction: {
+      count: vi.fn(),
+      findMany: vi.fn(),
+    },
+    event: {
+      findMany: vi.fn(),
+    },
+    featureDefinition: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+    },
+    featureValue: {
+      createMany: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('../../src/config', () => ({
+  config: {
+    forecastMode: 'demo',
+    forecastSeed: 42,
+  },
+}));
+
+import { prismaWrite } from '../../src/db';
+import { FeatureStore } from '../../src/indexer/feature-store';
+
+const toDate = (iso: string) => new Date(iso);
+
+describe('FeatureStore computeAndStoreFeatures', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('computes real on-chain tx volume and related metrics', async () => {
+    const store = new FeatureStore();
+
+    vi.mocked(prismaWrite.ledger.findUnique).mockResolvedValue({
+      sequence: 1,
+      hash: 'hash',
+      closeTime: toDate('2026-07-24T10:00:00Z'),
+      txCount: 3,
+    } as any);
+
+    vi.mocked(prismaWrite.transaction.count).mockImplementation(async ({ where }: any) => {
+      if (where.status?.not) {
+        return 1;
+      }
+      if (where.ledgerSequence === 1) {
+        return 3;
+      }
+      return 0;
+    });
+
+    vi.mocked(prismaWrite.transaction.findMany).mockResolvedValue([
+      { sourceAccount: 'ACC1' },
+      { sourceAccount: 'ACC2' },
+      { sourceAccount: 'ACC3' },
+    ] as any);
+
+    vi.mocked(prismaWrite.event.findMany).mockResolvedValue([
+      { contractAddress: 'CONTRACT1' },
+    ] as any);
+
+    vi.mocked(prismaWrite.ledger.findFirst).mockResolvedValue({
+      sequence: 1,
+      closeTime: toDate('2026-07-24T10:00:00Z'),
+    } as any);
+
+    vi.mocked(prismaWrite.featureDefinition.findUnique).mockResolvedValue(null);
+    vi.mocked(prismaWrite.featureDefinition.create).mockImplementation(async ({ data }: any) => ({
+      id: data.name,
+      ...data,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }));
+
+    vi.mocked(prismaWrite.featureValue.createMany).mockResolvedValue({ count: 6 } as any);
+
+    await store.computeAndStoreFeatures(1, toDate('2026-07-24T10:05:00Z'));
+
+    expect(prismaWrite.featureValue.createMany).toHaveBeenCalledTimes(1);
+    const createdRows = vi.mocked(prismaWrite.featureValue.createMany).mock.calls[0][0]
+      .data as Array<Record<string, unknown>>;
+
+    const rowsByName = Object.fromEntries(createdRows.map((row) => [row.featureId, row]));
+    expect(rowsByName['tx_volume'].value).toBe(3);
+    expect(rowsByName['unique_source_accounts'].value).toBe(3);
+    expect(rowsByName['contracts_with_events'].value).toBe(1);
+    expect(rowsByName['tx_failure_ratio'].value).toBeCloseTo(1 / 3, 5);
+    expect(rowsByName['data_freshness_seconds'].value).toBe(300);
+    expect(rowsByName['tx_volume_7d_ma'].value).toBe(0);
+  });
+});
+
+describe('FeatureStore getHistoricalData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns empty array when metric definition does not exist', async () => {
+    const store = new FeatureStore();
+
+    vi.mocked(prismaWrite.featureDefinition.findUnique).mockResolvedValue(null);
+
+    const result = await store.getHistoricalData('tx_volume', 5);
+    expect(result).toEqual([]);
+  });
+
+  it('returns stored values ordered newest-first and limited by limit', async () => {
+    const store = new FeatureStore();
+
+    vi.mocked(prismaWrite.featureDefinition.findUnique).mockResolvedValue({
+      id: 'tx_volume',
+    } as any);
+    vi.mocked(prismaWrite.featureValue.findMany).mockResolvedValue([
+      { value: 30 },
+      { value: 20 },
+    ] as any);
+
+    const result = await store.getHistoricalData('tx_volume', 2);
+    expect(result).toEqual([30, 20]);
+  });
+});


### PR DESCRIPTION
## Summary
Replaces synthetic/mock data paths in `src/indexer/feature-store.ts` with real on-chain feature extraction.

## Work Done
- Computed per-ledger metrics from `Transaction`, `Ledger`, and `Event` tables:
  - `tx_volume`
  - `unique_source_accounts`
  - `contracts_with_events`
  - `tx_failure_ratio`
  - `data_freshness_seconds`
- Computed `tx_volume_7d_ma` from prior `featureValue` rows instead of `1000 + rng.next() * 200`.
- Removed synthetic fallback in `getHistoricalData`; returns `[]` when no stored data exists.
- Removed dead imports from `../predictive/random`.
- Added `tests/indexer/feature-store.test.ts` covering computed feature values and missing-data behavior.
- Validated focused test suite with `npx vitest run tests/indexer/feature-store.test.ts`.

## Risks / Notes
- `forecastSeed` is currently unused in this file after cleanup. If predictive code elsewhere still expects it, that usage remains in `src/predictive/random.ts` and `src/config.ts`, not here.

closes #640