### PR TITLE
fix: replace hardcoded tokenMap with dynamic on-chain resolution via getTokenMetadata

### DIFF
--- a/src/feed/orchestrator.ts
+++ b/src/feed/orchestrator.ts
@@ -5,6 +5,7 @@ import { deliveryService } from './deliveryService';
 import { SubscriptionManager } from './subscriptionManager';
 import { FeedWebSocketServer } from './websocketServer';
 import { logger } from '../logger';
+import { getTokenMetadata } from '../indexer/token-metadata';
 
 export class FeedOrchestrator extends EventEmitter {
   private subscriptionManager = new SubscriptionManager();
@@ -169,12 +170,8 @@ export class FeedOrchestrator extends EventEmitter {
   }
 
   private async getTokenSymbol(address: string): Promise<string> {
-    // In real implementation, this would lookup token metadata
-    const tokenMap: Record<string, string> = {
-      native: 'XLM',
-      'CAQME...': 'USDC',
-    };
-    return tokenMap[address] || 'UNKNOWN';
+    const meta = await getTokenMetadata(address);
+    return meta?.symbol ?? 'UNKNOWN';
   }
 
   private startMetricsCollection() {


### PR DESCRIPTION
The getTokenSymbol method in FeedOrchestrator used a hardcoded map with only 2 entries (XLM and USDC), causing all other tokens to return 'UNKNOWN'.

Replaced with a call to the existing getTokenMetadata() from src/indexer/token-metadata.ts, which resolves token symbols dynamically through a 5-tier resolution chain:
  1. In-process LRU cache
  2. DB Contract table (isToken flag)
  3. DB SacMapping -> Horizon for classic assets
  4. Soroban RPC simulation of SEP-41 symbol() call
  5. Falls back to 'UNKNOWN' if no resolution

closes: #642