### PR TITLE
fix: replace mock chain data in leaderboard with real fetchProfileDat…

### DIFF
--- a/src/api/reputation.ts
+++ b/src/api/reputation.ts
@@ -133,19 +133,11 @@ reputationRouter.get(
     // Load all profiles from DB
     const profiles = await prismaRead.reputationProfile.findMany();
 
-    // Transform profiles back to ChainReputationData for calculation
-    const mockChainData: ChainReputationData[] = [];
-    for (const p of profiles) {
-      mockChainData.push({
-        chainId: p.chain,
-        address: p.address,
-        transactionCount: 10,
-        successfulTransactionCount: 10,
-        sybilRisk: p.combinedScore && p.combinedScore < 300 ? 0.8 : 0.1,
-      });
-    }
+    // Fetch real on-chain data for every address in parallel
+    const chainDataArrays = await Promise.all(profiles.map((p) => fetchProfileData(p.address)));
+    const allChainData: ChainReputationData[] = chainDataArrays.flat();
 
-    const leaderboard = createLeaderboard(mockChainData, category, limit);
+    const leaderboard = createLeaderboard(allChainData, category, limit);
     return res.json({ category, leaderboard });
   }),
 );


### PR DESCRIPTION
…a calls

The /leaderboard handler was building ChainReputationData with hardcoded values (transactionCount: 10, sybilRisk based on a rough score threshold) instead of querying actual on-chain activity.

Replace the mock loop with parallel fetchProfileData() calls so leaderboard scores are computed from real transaction counts, governance votes, contract interactions, attestations, trust edges, endorsements, and credentials indexed from the Stellar/Soroban chain.

Resolves the mockChainData issue reported at src/api/reputation.ts:73-84.
closes #635