### PR TITLE
fix(cold-storage): implement working parquet/glacier/archive fetchers #631

### DIFF
--- a/src/middleware/coldStorageRouter.ts
+++ b/src/middleware/coldStorageRouter.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
+import { existsSync } from 'fs';
 import { readFile, readdir, access, constants } from 'fs/promises';
 import { gunzip as gunzipCb } from 'zlib';
 import { promisify } from 'util';
@@ -141,6 +142,13 @@ class L2Cache {
     coldStorageL2CacheSize.set(this.store.size);
   }
 
+  clear(): void {
+    this.store.clear();
+    this.hits = 0;
+    this.misses = 0;
+    coldStorageL2CacheSize.set(0);
+  }
+
   hitRate(): number {
     const total = this.hits + this.misses;
     return total === 0 ? 1 : this.hits / total;
@@ -199,9 +207,27 @@ function isCircuitOpen(tier: string): boolean {
 
 // ── Archive Index ─────────────────────────────────────────────────────
 
+type ArchiveCompression = 'gzip' | 'none' | 'zstd';
+
+interface ArchiveIndexEntry {
+  path: string;
+  compression: ArchiveCompression;
+}
+
 interface ArchiveIndex {
   version: number;
-  entries: Record<number, { path: string; compression: 'gzip' | 'none' | 'zstd' }>;
+  /** Keys are `${dataType}:${ledgerSeq}` so transactions/events do not collide. */
+  entries: Record<string, ArchiveIndexEntry>;
+}
+
+function archiveIndexKey(dataType: string, ledgerSeq: number): string {
+  return `${dataType}:${ledgerSeq}`;
+}
+
+function normalizeRecords(parsed: unknown): any[] {
+  if (Array.isArray(parsed)) return parsed;
+  if (parsed === null || parsed === undefined) return [];
+  return [parsed];
 }
 
 class ArchiveIndexManager {
@@ -211,7 +237,8 @@ class ArchiveIndexManager {
   async load(): Promise<void> {
     try {
       const raw = await readFile(ARCHIVE_INDEX_PATH, 'utf-8');
-      this.index = JSON.parse(raw);
+      const parsed = JSON.parse(raw) as ArchiveIndex;
+      this.index = this.normalizeLoadedIndex(parsed);
       this.loaded = true;
       logger.info('[ColdStorage] Archive index loaded', {
         entries: Object.keys(this.index.entries).length,
@@ -223,9 +250,22 @@ class ArchiveIndexManager {
     }
   }
 
+  /** Accept legacy numeric keys (`"123"`) by mapping them to transactions. */
+  private normalizeLoadedIndex(parsed: ArchiveIndex): ArchiveIndex {
+    const entries: Record<string, ArchiveIndexEntry> = {};
+    for (const [key, value] of Object.entries(parsed.entries ?? {})) {
+      if (key.includes(':')) {
+        entries[key] = value;
+      } else if (/^\d+$/.test(key)) {
+        entries[archiveIndexKey('transactions', Number(key))] = value;
+      }
+    }
+    return { version: parsed.version ?? 1, entries };
+  }
+
   private async scanAndBuild(): Promise<void> {
     try {
-      const entries: Record<number, { path: string; compression: 'gzip' | 'none' | 'zstd' }> = {};
+      const entries: Record<string, ArchiveIndexEntry> = {};
       const dataTypes = ['transactions', 'events'];
       for (const dt of dataTypes) {
         const dir = path.join(ARCHIVE_DIR, dt);
@@ -236,8 +276,12 @@ class ArchiveIndexManager {
             if (match) {
               const seq = parseInt(match[1], 10);
               const ext = match[2];
-              const compression = ext === 'json.gz' ? 'gzip' : ext === 'json.zst' ? 'zstd' : 'none';
-              entries[seq] = { path: path.join(dir, file), compression };
+              const compression: ArchiveCompression =
+                ext === 'json.gz' ? 'gzip' : ext === 'json.zst' ? 'zstd' : 'none';
+              entries[archiveIndexKey(dt, seq)] = {
+                path: path.join(dir, file),
+                compression,
+              };
             }
           }
         } catch {
@@ -261,8 +305,8 @@ class ArchiveIndexManager {
     }
   }
 
-  lookup(ledgerSeq: number): { path: string; compression: 'gzip' | 'none' | 'zstd' } | null {
-    return this.index.entries[ledgerSeq] ?? null;
+  lookup(dataType: string, ledgerSeq: number): ArchiveIndexEntry | null {
+    return this.index.entries[archiveIndexKey(dataType, ledgerSeq)] ?? null;
   }
 }
 
@@ -345,11 +389,10 @@ function findParquetFile(ledgerSeq: number, dataType: string): string | null {
     path.join(baseDir, `ledger_${rangeStart}_${rangeEnd}_v2.parquet`),
   ];
   for (const fp of patterns) {
-    try {
-      access(fp, constants.R_OK);
+    // Must use sync existence check: access() from fs/promises returns a Promise
+    // and cannot be awaited from this sync helper.
+    if (existsSync(fp)) {
       return fp;
-    } catch {
-      continue;
     }
   }
   return null;
@@ -400,17 +443,14 @@ async function initiateGlacierRestore(key: string): Promise<void> {
   logger.info('[ColdStorage] Glacier restore initiated', { key });
 }
 
-async function pollRestoreComplete(key: string, maxRetries = 30): Promise<void> {
-  for (let i = 0; i < maxRetries; i++) {
-    const head = await s3.send(new HeadObjectCommand({ Bucket: S3_BUCKET, Key: key }));
-    const restoreStatus = head.Restore;
-    if (restoreStatus && restoreStatus.includes('ongoing-request="false"')) {
-      return;
-    }
-    const delay = Math.min(1000 * Math.pow(1.5, i), 30000);
-    await new Promise((r) => setTimeout(r, delay));
-  }
-  throw new AppError(503, 'Glacier restore did not complete within timeout');
+function isS3NotFound(err: any): boolean {
+  const name = err?.name ?? err?.Code ?? err?.code;
+  return (
+    name === 'NoSuchKey' ||
+    name === 'NotFound' ||
+    name === '404' ||
+    err?.$metadata?.httpStatusCode === 404
+  );
 }
 
 async function readFromS3(key: string): Promise<any[]> {
@@ -419,24 +459,26 @@ async function readFromS3(key: string): Promise<any[]> {
     const storageClass = head.StorageClass ?? 'STANDARD';
     if (storageClass === 'GLACIER' || storageClass === 'DEEP_ARCHIVE') {
       const restoreStatus = head.Restore;
-      if (!restoreStatus || restoreStatus.includes('ongoing-request="true"')) {
+      // Do not block HTTP requests on multi-hour Glacier restores.
+      if (!restoreStatus) {
         await initiateGlacierRestore(key);
-        await pollRestoreComplete(key);
+        throw new AppError(503, 'Glacier restore initiated; retry after restore completes');
+      }
+      if (restoreStatus.includes('ongoing-request="true"')) {
+        throw new AppError(503, 'Glacier restore in progress; retry later');
       }
     }
     const res = await s3.send(new GetObjectCommand({ Bucket: S3_BUCKET, Key: key }));
     const body = await res.Body!.transformToString();
-    return JSON.parse(body);
+    return normalizeRecords(JSON.parse(body));
   } catch (err: any) {
-    if (err.name === 'NoSuchKey') {
+    if (err instanceof AppError) throw err;
+    if (isS3NotFound(err)) {
       return [];
     }
     if (err.name === 'InvalidObjectState') {
       await initiateGlacierRestore(key);
-      await pollRestoreComplete(key);
-      const res = await s3.send(new GetObjectCommand({ Bucket: S3_BUCKET, Key: key }));
-      const body = await res.Body!.transformToString();
-      return JSON.parse(body);
+      throw new AppError(503, 'Glacier restore initiated; retry after restore completes');
     }
     throw err;
   }
@@ -494,7 +536,7 @@ async function readArchiveFile(
   } else {
     data = raw;
   }
-  return JSON.parse(data.toString('utf-8'));
+  return normalizeRecords(JSON.parse(data.toString('utf-8')));
 }
 
 // ── fetchFromColdStorage (exported) ───────────────────────────────────
@@ -568,7 +610,7 @@ async function fetchFromArchive(ledgerSeq: number, dataType: string): Promise<an
   const cached = l2Cache.get('archive', cacheKey);
   if (cached) return cached;
 
-  const entry = archiveIndex.lookup(ledgerSeq);
+  const entry = archiveIndex.lookup(dataType, ledgerSeq);
   if (!entry) {
     const dirPath = path.join(ARCHIVE_DIR, dataType);
     const filePath = path.join(dirPath, `${ledgerSeq}.json`);
@@ -726,4 +768,13 @@ export async function initializeColdStorage(): Promise<void> {
     l2CacheSize: L2_CACHE_MAX_SIZE,
     circuitBreakerThreshold: CB_THRESHOLD,
   });
+}
+
+/** Test-only: reset L2 cache and circuit breakers between cases. */
+export function __resetColdStorageStateForTests(): void {
+  l2Cache.clear();
+  breakerStates.clear();
+  for (const tier of ['parquet', 'glacier', 'archive'] as const) {
+    coldStorageCircuitBreakerState.set({ tier }, 0);
+  }
 }

--- a/tests/cold-storage-fetchers.test.ts
+++ b/tests/cold-storage-fetchers.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Verifies issue #631: cold storage fetchers return real data
+ * (not empty stub arrays) from Parquet, Glacier/S3, and local archive.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { gzipSync } from 'zlib';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ParquetSchema, ParquetWriter } from 'parquetjs-lite';
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cold-fetch-'));
+const parquetDir = path.join(tmpRoot, 'parquet');
+const archiveDir = path.join(tmpRoot, 'archive');
+
+process.env.PARQUET_DIR = parquetDir;
+process.env.ARCHIVE_DIR = archiveDir;
+process.env.ARCHIVE_INDEX_PATH = path.join(archiveDir, 'index.json');
+process.env.COLD_READ_TIMEOUT_MS = '10000';
+process.env.COLD_CB_THRESHOLD = '10';
+process.env.COLD_S3_PREFIX = 'cold';
+process.env.ARCHIVE_S3_BUCKET = 'test-cold-bucket';
+process.env.AWS_REGION = 'us-east-1';
+
+const { s3Send } = vi.hoisted(() => ({
+  s3Send: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-s3', () => ({
+  S3Client: vi.fn(() => ({ send: s3Send })),
+  GetObjectCommand: vi.fn((input: unknown) => ({ __type: 'GetObject', input })),
+  HeadObjectCommand: vi.fn((input: unknown) => ({ __type: 'HeadObject', input })),
+  RestoreObjectCommand: vi.fn((input: unknown) => ({ __type: 'RestoreObject', input })),
+  ListObjectsV2Command: vi.fn((input: unknown) => ({ __type: 'ListObjectsV2', input })),
+}));
+
+vi.mock('../src/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../src/middleware/errorHandler', () => {
+  class AppError extends Error {
+    statusCode: number;
+    constructor(statusCode: number, message: string) {
+      super(message);
+      this.name = 'AppError';
+      this.statusCode = statusCode;
+    }
+  }
+  return { AppError };
+});
+
+vi.mock('prom-client', () => {
+  const make = () => ({ observe: vi.fn(), inc: vi.fn(), set: vi.fn() });
+  return {
+    Histogram: vi.fn(make),
+    Counter: vi.fn(make),
+    Gauge: vi.fn(make),
+    register: { registerMetric: vi.fn() },
+  };
+});
+
+type ColdStorageModule = typeof import('../src/middleware/coldStorageRouter');
+
+let fetchFromColdStorage: ColdStorageModule['fetchFromColdStorage'];
+let initializeColdStorage: ColdStorageModule['initializeColdStorage'];
+let __resetColdStorageStateForTests: ColdStorageModule['__resetColdStorageStateForTests'];
+
+const LEDGER = 42_000;
+const SAMPLE_TX = {
+  hash: 'abc123',
+  ledgerSequence: LEDGER,
+  ledgerCloseTime: '2024-01-01T00:00:00Z',
+  sourceAccount: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567',
+  contractAddress: 'CCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  functionName: 'transfer',
+  functionArgs: '[]',
+  status: 'SUCCESS',
+  feeCharged: '100',
+  humanReadable: 'transfer()',
+};
+
+async function writeParquetFixture(): Promise<void> {
+  const dir = path.join(parquetDir, 'transactions');
+  fs.mkdirSync(dir, { recursive: true });
+  const rangeStart = Math.floor(LEDGER / 10000) * 10000;
+  const rangeEnd = rangeStart + 9999;
+  const filePath = path.join(
+    dir,
+    `ledger_${String(rangeStart).padStart(7, '0')}_${String(rangeEnd).padStart(7, '0')}.parquet`,
+  );
+
+  const schema = new ParquetSchema({
+    hash: { type: 'UTF8' },
+    ledgerSequence: { type: 'INT32' },
+    ledgerCloseTime: { type: 'UTF8' },
+    sourceAccount: { type: 'UTF8', optional: true },
+    contractAddress: { type: 'UTF8', optional: true },
+    functionName: { type: 'UTF8', optional: true },
+    functionArgs: { type: 'UTF8', optional: true },
+    status: { type: 'UTF8', optional: true },
+    feeCharged: { type: 'UTF8', optional: true },
+    humanReadable: { type: 'UTF8', optional: true },
+  });
+
+  const writer = await ParquetWriter.openFile(schema, filePath);
+  await writer.appendRow(SAMPLE_TX);
+  await writer.appendRow({
+    ...SAMPLE_TX,
+    hash: 'other',
+    ledgerSequence: LEDGER + 1,
+  });
+  await writer.close();
+}
+
+async function writeArchiveFixture(): Promise<void> {
+  const dir = path.join(archiveDir, 'events');
+  fs.mkdirSync(dir, { recursive: true });
+  const payload = [
+    { id: 'evt-1', ledgerSequence: LEDGER, type: 'contract' },
+    { id: 'evt-2', ledgerSequence: LEDGER, type: 'diagnostic' },
+  ];
+  fs.writeFileSync(path.join(dir, `${LEDGER}.json`), JSON.stringify(payload));
+
+  const gzDir = path.join(archiveDir, 'transactions');
+  fs.mkdirSync(gzDir, { recursive: true });
+  fs.writeFileSync(path.join(gzDir, `${LEDGER}.json.gz`), gzipSync(JSON.stringify([SAMPLE_TX])));
+}
+
+beforeAll(async () => {
+  await writeParquetFixture();
+  await writeArchiveFixture();
+
+  // Dynamic import AFTER env vars are set (static imports are hoisted).
+  const cold = await import('../src/middleware/coldStorageRouter');
+  fetchFromColdStorage = cold.fetchFromColdStorage;
+  initializeColdStorage = cold.initializeColdStorage;
+  __resetColdStorageStateForTests = cold.__resetColdStorageStateForTests;
+
+  await initializeColdStorage();
+});
+
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  __resetColdStorageStateForTests();
+  s3Send.mockReset();
+});
+
+describe('fetchFromParquet (via fetchFromColdStorage)', () => {
+  it('returns ledger rows from a real parquet file (not an empty stub)', async () => {
+    const rows = await fetchFromColdStorage('parquet', LEDGER, 'transactions');
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows[0].hash).toBe(SAMPLE_TX.hash);
+    expect(Number(rows[0].ledgerSequence)).toBe(LEDGER);
+  });
+
+  it('returns [] when no parquet file exists for the ledger range', async () => {
+    const rows = await fetchFromColdStorage('parquet', 1, 'transactions');
+    expect(rows).toEqual([]);
+  });
+});
+
+describe('fetchFromGlacier (via fetchFromColdStorage)', () => {
+  it('returns records from S3/Glacier when object is available', async () => {
+    const body = JSON.stringify([SAMPLE_TX]);
+    s3Send.mockImplementation(async (cmd: { __type?: string }) => {
+      if (cmd.__type === 'HeadObject') {
+        return { StorageClass: 'STANDARD' };
+      }
+      if (cmd.__type === 'GetObject') {
+        return { Body: { transformToString: async () => body } };
+      }
+      throw new Error(`unexpected command ${cmd.__type}`);
+    });
+
+    const rows = await fetchFromColdStorage('glacier', LEDGER, 'transactions');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].hash).toBe(SAMPLE_TX.hash);
+  });
+
+  it('returns [] when S3 HeadObject reports NotFound', async () => {
+    s3Send.mockImplementation(async () => {
+      const err = new Error('Not Found');
+      (err as any).name = 'NotFound';
+      (err as any).$metadata = { httpStatusCode: 404 };
+      throw err;
+    });
+
+    const rows = await fetchFromColdStorage('glacier', LEDGER, 'transactions');
+    expect(rows).toEqual([]);
+  });
+
+  it('initiates restore and returns 503 when object is in Glacier unrestored', async () => {
+    s3Send.mockImplementation(async (cmd: { __type?: string }) => {
+      if (cmd.__type === 'HeadObject') {
+        return { StorageClass: 'GLACIER' };
+      }
+      if (cmd.__type === 'RestoreObject') {
+        return {};
+      }
+      throw new Error(`unexpected command ${cmd.__type}`);
+    });
+
+    await expect(fetchFromColdStorage('glacier', LEDGER, 'transactions')).rejects.toMatchObject({
+      name: 'AppError',
+      statusCode: 503,
+    });
+    expect(s3Send.mock.calls.some((c) => c[0]?.__type === 'RestoreObject')).toBe(true);
+  });
+});
+
+describe('fetchFromArchive (via fetchFromColdStorage)', () => {
+  it('returns events from a local archive JSON file', async () => {
+    const rows = await fetchFromColdStorage('archive', LEDGER, 'events');
+    expect(rows).toHaveLength(2);
+    expect(rows[0].id).toBe('evt-1');
+  });
+
+  it('returns transactions from a gzipped archive file', async () => {
+    const rows = await fetchFromColdStorage('archive', LEDGER, 'transactions');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].hash).toBe(SAMPLE_TX.hash);
+  });
+
+  it('returns [] when archive file is missing', async () => {
+    const rows = await fetchFromColdStorage('archive', 999_999_999, 'events');
+    expect(rows).toEqual([]);
+  });
+});
+
+describe('fetchFromColdStorage("all")', () => {
+  it('returns first non-empty tier result', async () => {
+    s3Send.mockImplementation(async () => {
+      const err = new Error('Not Found');
+      (err as any).name = 'NotFound';
+      throw err;
+    });
+
+    const rows = await fetchFromColdStorage('all', LEDGER, 'transactions');
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows[0].hash).toBe(SAMPLE_TX.hash);
+  });
+});

--- a/tests/cold-storage-router.test.ts
+++ b/tests/cold-storage-router.test.ts
@@ -13,6 +13,17 @@ vi.mock('@aws-sdk/client-s3', () => ({
 vi.mock('../src/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
+vi.mock('../src/middleware/errorHandler', () => {
+  class AppError extends Error {
+    statusCode: number;
+    constructor(statusCode: number, message: string) {
+      super(message);
+      this.name = 'AppError';
+      this.statusCode = statusCode;
+    }
+  }
+  return { AppError };
+});
 vi.mock('prom-client', () => {
   const make = () => ({ observe: vi.fn(), inc: vi.fn(), set: vi.fn() });
   return {
@@ -28,6 +39,7 @@ import {
   isColdStorageRequest,
   getColdStorageType,
   getColdStorageConfig,
+  setCurrentLedger,
 } from '../src/middleware/coldStorageRouter';
 
 function makeReq(overrides: Partial<Request> = {}): Request {
@@ -44,6 +56,8 @@ describe('coldStorageRouter middleware', () => {
 
   beforeEach(() => {
     next = vi.fn();
+    // Threshold = currentLedger - recentLedgerCount; without this, everything looks "hot".
+    setCurrentLedger(100_000);
   });
 
   it('calls next with no ledger in request', () => {
@@ -121,6 +135,13 @@ describe('getColdStorageConfig', () => {
 
 // ── Security: injection in ledger param ──────────────────────────────────────
 describe('security', () => {
+  let next: NextFunction;
+
+  beforeEach(() => {
+    next = vi.fn();
+    setCurrentLedger(100_000);
+  });
+
   it('ignores SQL injection attempt in ledger query param', () => {
     const res = makeRes();
     const req = makeReq({ query: { ledger: '1; DROP TABLE transactions;--' } });


### PR DESCRIPTION
## Overview

This PR fixes cold storage so the Parquet, Glacier/S3, and local archive fetchers return real data instead of behaving as non-functional stubs (issue #631). Discovery, S3 not-found handling, Glacier restore flow, and archive indexing are corrected, with tests proving each tier returns records.

## Related Issue

Closes #631

## Changes

### 🧊 Cold Storage Fetchers

* **[FIX]** `src/middleware/coldStorageRouter.ts`
  * Parquet: use sync `existsSync` for range file discovery (async `access()` was never awaited, so the first path was always returned).
  * Glacier/S3: treat `NotFound` / 404 as empty; initiate restore and return `503` instead of blocking the request on multi-hour Glacier polls.
  * Archive: index keys are `${dataType}:${ledgerSeq}` so transactions and events no longer collide; normalize JSON payloads to arrays.
  * Add test-only `__resetColdStorageStateForTests()` for L2 cache / circuit-breaker isolation.

* **[ADD]** `tests/cold-storage-fetchers.test.ts`
  * End-to-end coverage for parquet, glacier, and archive tiers returning non-empty data (and empty / 503 paths).

* **[MODIFY]** `tests/cold-storage-router.test.ts`
  * Mock `errorHandler`, set `setCurrentLedger` for cold/hot threshold tests, and fix security suite `next` scope.

## Verification Results

```
npx vitest run tests/cold-storage-fetchers.test.ts tests/cold-storage-router.test.ts
✅ 22/22 passed

Fetcher acceptance check:
✅ Parquet returns ledger rows from a real .parquet fixture
✅ Glacier returns S3 JSON records when object is available
✅ Glacier returns [] on NotFound and 503 when unrestored Glacier object
✅ Archive returns JSON and gzipped JSON fixtures
✅ fetchFromColdStorage("all") returns first non-empty tier
```

| Acceptance Criteria | Status |
| --- | --- |
| `fetchFromParquet` returns real data (not always stub `[]`) | ✅ Reads filtered ledger rows from Parquet files |
| `fetchFromGlacier` returns real data from S3/Glacier | ✅ GetObject path + NotFound/restore handling |
| `fetchFromArchive` returns real data from archive nodes/files | ✅ Local JSON / gzip + dataType-aware index |
| Cold storage is functional end-to-end for the three tiers | ✅ Covered by fetcher + router tests (22 passing) |