### PR TITLE
feat: add composite indexes for cursor-based pagination

### DIFF
--- a/prisma/migrations/20260729000000_cursor_pagination_composite_indexes/migration.sql
+++ b/prisma/migrations/20260729000000_cursor_pagination_composite_indexes/migration.sql
@@ -1,0 +1,11 @@
+-- Composite indexes for cursor-based pagination on cursor-sorted fields.
+-- Event: [ledgerSequence, id] for paginating events in ledger order
+-- Transaction: [ledgerCloseTime, id] for time-based transaction pagination
+-- PauseEvent: [contractAddress, timestamp] for per-contract pause event pagination
+-- TokenPriceHistory already has [tokenAddress, timestamp(sort: Desc)]; no change needed.
+
+CREATE INDEX IF NOT EXISTS "Event_ledgerSequence_id_idx" ON "Event"("ledgerSequence", "id");
+
+CREATE INDEX IF NOT EXISTS "Transaction_ledgerCloseTime_id_idx" ON "Transaction"("ledgerCloseTime", "id");
+
+CREATE INDEX IF NOT EXISTS "PauseEvent_contractAddress_timestamp_idx" ON "PauseEvent"("contractAddress", "timestamp");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -88,6 +88,7 @@ model Transaction {
   @@index([sourceAccount, ledgerSequence, id])
   @@index([status, ledgerSequence, id])
   @@index([ledgerSequence, id])
+  @@index([ledgerCloseTime, id])
 }
 
 model Event {
@@ -116,6 +117,7 @@ model Event {
   @@index([contractAddress, topicSymbol])
   @@index([contractAddress, ledgerSequence, id])
   @@index([contractAddress, eventType, ledgerSequence])
+  @@index([ledgerSequence, id])
 }
 
 model EventDefinition {
@@ -815,6 +817,7 @@ model PauseEvent {
   @@index([eventType])
   @@index([timestamp])
   @@index([pauserAddress])
+  @@index([contractAddress, timestamp])
 }
 
 model PauserAnalysis {


### PR DESCRIPTION
Closes #727

---

Add composite indexes on cursor-sorted fields: Event [ledgerSequence,id], Transaction [ledgerCloseTime,id], PauseEvent [contractAddress,timestamp]. TokenPriceHistory already has [tokenAddress,timestamp]. Includes migration SQL.