### PR TITLE
fix(database): remove redundant composite index from FeatureValue model

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2204,7 +2204,6 @@ model FeatureValue {
   feature FeatureDefinition @relation(fields: [featureId], references: [id])
 
   @@index([featureId, timestamp])
-  @@index([featureId, timestamp, id])
   @@map("_feature_values")
 }
 


### PR DESCRIPTION
## Summary

- Removed redundant composite index `@@index([featureId, timestamp, id])` from the `FeatureValue` model in `prisma/schema.prisma`.
- Kept the primary composite index `@@index([featureId, timestamp])` to cover time-series feature lookups efficiently.

## Why

The `FeatureValue` model previously declared two overlapping composite indexes:
1. `@@index([featureId, timestamp])`
2. `@@index([featureId, timestamp, id])`

Since standard B-tree indexes cover left-prefix column lookups and `id` is already the primary key (`@id`), the secondary 3-column index created duplicate indexing overhead, increasing write latency and storage footprint during time-series data ingestion without providing additional query optimization.

## Implementation

- Modified [prisma/schema.prisma](file:///home/abujulaybeeb/Documents/Drips/Drips%206/Soroban-Smart-Block-Backend-/prisma/schema.prisma#L2196-L2209) to remove `@@index([featureId, timestamp, id])` from `FeatureValue`.
- Preserved `@@index([featureId, timestamp])` and table mapping `@@map("_feature_values")`.

## Testing

- Validated schema syntax and foreign-key indexing consistency via `scripts/audit-indexes.ts`.
- Verified diff to ensure only the redundant index was removed with zero side-effects on adjacent models.

## Scope / Risk

- **Scope**: Database schema definition for `FeatureValue` (`prisma/schema.prisma`).
- **Risk**: Low / None (zero functional or API changes; query lookups continue to utilize `[featureId, timestamp]` index).

## Issue

closes #739
