### PR TITLE
fix(database): remove duplicate errorMessage field from ExportJob model

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2469,7 +2469,6 @@ model ExportJob {
   fileUrl String? @map("file_url")
   filters Json? @map("filters")
   errorMsg String? @map("error_msg")
-  errorMessage String? @map("error_message")
   rowCount Int? @map("row_count")
   completedAt DateTime? @map("completed_at")
   totalRows Int? @map("total_rows")


### PR DESCRIPTION
## Summary

- Removed the duplicate `errorMessage` property from the `ExportJob` model in `prisma/schema.prisma`.
- Retained `errorMsg String? @map("error_msg")` as the canonical error message field for export jobs.

## Why

The `ExportJob` model previously defined two duplicate fields representing failure error descriptions:
1. `errorMsg String? @map("error_msg")`
2. `errorMessage String? @map("error_message")`

`src/indexer/csv-exporter.ts` actively populates `errorMsg` on failed jobs. Having both fields introduced schema redundancy and ambiguity in data storage.

## Implementation

- Updated [prisma/schema.prisma](file:///home/abujulaybeeb/Documents/Drips/Drips%206/Soroban-Smart-Block-Backend-/prisma/schema.prisma#L2462-L2480):
  - Removed `errorMessage String? @map("error_message")` from `ExportJob`.
  - Preserved `errorMsg String? @map("error_msg")`.
- Confirmed all backend references (e.g. `src/indexer/csv-exporter.ts`) use `errorMsg`.

## Testing

- Ran foreign-key and index validation via `scripts/audit-indexes.ts`.
- Reviewed schema diff to confirm zero collateral modifications.

## Scope / Risk

- **Scope**: Database schema definition for `ExportJob` (`prisma/schema.prisma`).
- **Risk**: None (all existing code writing failure status already writes to `errorMsg`).

## Issue

closes #741
