### PR TITLE
docs(database): document NULL behavior and uniqueness for SanctionsLi…

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -649,6 +649,7 @@ model SanctionsList {
   listVersion String @map("list_version") // version/date of the list
   listName String? @map("list_name")
   entityType String @map("entity_type") // "individual" | "entity" | "vessel" | "aircraft" | "unknown"
+  // On-chain address (if applicable). Nullable for non-crypto entities/individuals without a specific address; PostgreSQL permits multiple NULL values under standard UNIQUE constraints.
   address String? @map("address")
   addressPattern String? @map("address_pattern")
   name String? @map("name")
@@ -3545,6 +3546,7 @@ model PriceAlert {
 model VerifiableCredential {
   id String @map("id") @id @default(cuid())
   profileId String @map("profile_id")
+  // Unique credential identifier (W3C format or DID URI). Required and unique per credential instance.
   credentialId String @map("credential_id")
   context String? @map("context")
   type String? @map("type")


### PR DESCRIPTION
## Summary

- Documented `NULL` semantics and uniqueness behavior for `SanctionsList.address` and `VerifiableCredential.credentialId` in `prisma/schema.prisma`.

## Why

Nullable fields under unique indexes or with entity-level identifiers can cause ambiguity regarding database-specific `NULL` handling (e.g. how PostgreSQL treats multiple `NULL` entries vs non-null unique values). Documenting the explicit behavior eliminates ambiguity for contributors and migrations.

## Implementation

- Added schema documentation comment above `SanctionsList.address` explaining that non-crypto entities and individuals have null addresses, which are treated as distinct by the database.
- Added schema documentation comment above `VerifiableCredential.credentialId` explaining the credential identifier semantics and required format.

## Testing

- Inspected `prisma/schema.prisma` diff and verified syntax formatting.

## Scope / Risk

- **Scope**: `prisma/schema.prisma`
- **Risk**: None (documentation comments only, non-breaking).

## Issue

closes #742
