### PR TITLE
fix(database): add onDelete Cascade to MevEvent and ArbitrageOpportun…

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1439,8 +1439,8 @@ model MevEvent {
   flashLoanAlert Boolean? @map("flash_loan_alert")
   createdAt DateTime @map("created_at") @default(now())
 
-  victim   MevVictim?   @relation(fields: [victimAddress], references: [address], onUpdate: Cascade)
-  attacker MevAttacker? @relation(fields: [attackerAddress], references: [address], onUpdate: Cascade)
+  victim   MevVictim?   @relation(fields: [victimAddress], references: [address], onDelete: Cascade, onUpdate: Cascade)
+  attacker MevAttacker? @relation(fields: [attackerAddress], references: [address], onDelete: Cascade, onUpdate: Cascade)
 
   @@index([mevType])
   @@index([ledgerSeq])
@@ -1863,8 +1863,8 @@ model ArbitrageOpportunity {
   executionTxHash String? @map("execution_tx_hash") @db.VarChar(64)
   createdAt DateTime @map("created_at") @default(now())
 
-  buyPool    DexPool?             @relation(fields: [buyPoolId], references: [id], onUpdate: Cascade, name: "buyPool")
-  sellPool   DexPool?             @relation(fields: [sellPoolId], references: [id], onUpdate: Cascade, name: "sellPool")
+  buyPool    DexPool?             @relation(fields: [buyPoolId], references: [id], onDelete: Cascade, onUpdate: Cascade, name: "buyPool")
+  sellPool   DexPool?             @relation(fields: [sellPoolId], references: [id], onDelete: Cascade, onUpdate: Cascade, name: "sellPool")
   mevScore   MevOpportunityScore?
   executions ArbitrageExecution[]
 


### PR DESCRIPTION
 fix(database): add onDelete Cascade to critical MEV and arbitrage relations

  ## Summary
  - Add `onDelete: Cascade` to `MevEvent.victim` -> `MevVictim`
  - Add `onDelete: Cascade` to `MevEvent.attacker` -> `MevAttacker`
  - Add `onDelete: Cascade` to `ArbitrageOpportunity.buyPool` -> `DexPool`
  - Add `onDelete: Cascade` to `ArbitrageOpportunity.sellPool` -> `DexPool`

  These relations previously had no delete behavior defined, which left
  child records orphaned (or blocked deletes, depending on DB default)
  when a parent `MevVictim`, `MevAttacker`, or `DexPool` was removed.

  ## Verification
  - `prisma validate` passes
  - `prisma db push` materializes cleanly on a fresh database
  - `npm run validate:prisma` passes (no phantom field references)
  - `npm run lint` / `npm run format` pass
  - Full test suite passes (224/224)

  Closes #738