### PR TITLE
feat(flags): db-backed feature flags with gradual rollout and per-environment/per-developer toggles- #2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -306,22 +306,29 @@ BANXA_SECRET_KEY=
 # Stripe Crypto On-ramp (uses STRIPE_SECRET_KEY already defined above)
 STRIPE_RAMP_WEBHOOK_SECRET=
 
-# ─── Optional Feature Flags (#630) ────────────────────────────────────────────
-# Each flag enables one of the five background services that were gated on schema
-# availability. Set to 'true' to activate; omit or set to anything else to leave
-# the service disabled (it will be listed in /ready → disabledServices).
+# ─── Feature Flags ─────────────────────────────────────────────────────────────
+# DB-backed feature flags with per-environment + per-developer toggles and
+# gradual rollout. See docs/FEATURE_FLAGS.md and src/feature-flags/. Resolution
+# order: developer override > environment override > env var > rollout > default.
+#
+# The legacy ENABLE_* vars below remain the *per-environment bootstrap layer* —
+# they are honored at every boot and win over the DB default (but lose to DB
+# environment/developer overrides). Setting one to 'true' enables the feature in
+# this environment regardless of the DB default; omitting it defers to the DB.
+# Runtime toggles (no redeploy): /api/v1/admin/feature-flags (admin role).
+#
+# A feature is only started when its required tables exist (schema availability).
+# If the toggle is on but the tables are missing, it is reported as
+# "<service> (schema unavailable)" in /ready → disabledServices.
 #
 # Privacy WebSocket broadcaster  (/ws/v1/privacy  and  /ws/v1/privacy/alerts)
-# Streams privacy-protocol transactions and anomaly alerts to subscribers.
 # Requires: PrivacyTransaction model (already in schema).
 # ENABLE_PRIVACY_WS=true
 #
 # Composability WebSocket broadcaster  (/ws/composability/exploits)
-# Broadcasts cross-contract exploit-pattern alerts in real time.
 # ENABLE_COMPOSABILITY_WS=true
 #
 # Arbitrage WebSocket broadcaster  (/ws/arbitrage/opportunities)
-# Streams arbitrage opportunities detected by the arbitrage scanner.
 # ENABLE_ARBITRAGE_WS=true
 #
 # Pool Price Monitor
@@ -343,3 +350,5 @@ STRIPE_RAMP_WEBHOOK_SECRET=
 # Requires: FeeEvent, ProtocolRevenue, YieldSnapshot, ProtocolProfile,
 #           RevenueAlert models (added in migration 20260728000000).
 # ENABLE_FEE_AGGREGATOR=true
+#
+# Generic flags (no legacy var) use the FF_<KEY> convention, e.g. FF_BETA_ENDPOINT.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,8 @@ on:
   pull_request:
     branches: [main]
 
-# Explicit token scopes. `security-events: write` is required for CodeQL to
-# access the CodeQL API and upload SARIF results; without it the Security job
-# fails with "Resource not accessible by integration".
 permissions:
   contents: read
-  security-events: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -183,12 +179,3 @@ jobs:
 
       - name: Run npm audit
         run: npm audit --audit-level=high || true
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
-        with:
-          languages: javascript, typescript
-          config-file: .github/codeql/codeql-config.yml
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '30 6 * * 1' # weekly scan on main
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript, typescript
+          config-file: .github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4

--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -1,0 +1,130 @@
+# Feature Flags
+
+DB-backed feature flags with **per-environment** and **per-developer** toggles
+and **gradual rollout**, replacing the previous all-or-nothing gating of the
+optional background services.
+
+## Why
+
+Previously each optional service (pool monitor, arbitrage scanner, fee
+aggregator, and the privacy/composability/arbitrage WebSockets) was either fully
+on or fully off, decided at boot by a single `ENABLE_*` env var that operators
+set only after the required schema migration was applied. There was no way to:
+
+- turn a feature on for a subset of accounts (gradual rollout),
+- toggle a feature at runtime without a redeploy,
+- override a feature per environment or per developer,
+- distinguish "flag is off" from "schema is missing" in `/ready`.
+
+## Resolution order
+
+For a given flag, the most specific source wins:
+
+| # | Source | Scope | Example |
+|---|--------|-------|---------|
+| 1 | DB `FeatureFlagOverride` (scopeType `developer`) | one developer | `PUT /api/v1/admin/feature-flags/poolMonitor/overrides/developer/<developerId>` |
+| 2 | DB `FeatureFlagOverride` (scopeType `environment`) | one environment | override keyed by Stellar network name (`testnet`, `mainnet`, `devnet`) |
+| 3 | Env var (`ENABLE_*` legacy or `FF_<KEY>` generic) | this deployment | `ENABLE_POOL_MONITOR=true` in the ConfigMap |
+| 4 | Gradual rollout (`rolloutPercent`) | stable per-account bucket | 10 → ~10% of developers on, monotonically |
+| 5 | DB `FeatureFlag.defaultEnabled` | all | `defaultEnabled=false` |
+
+Anonymous callers (no `developerId`) skip the rollout bucket and fall through
+to the default — a rollout needs a stable identity to target.
+
+### Rollout semantics
+
+`rolloutPercent` (0–100) on the flag row. Bucketing uses a stable FNV-1a hash
+of `"{flagKey}:{developerId}"` mapped to 1–100, so:
+
+- the same developer always lands in the same bucket (no flapping),
+- raising the percentage only ever *adds* accounts (monotonic),
+- 0 = off, 100 = fully on.
+
+## Schema availability
+
+Each flag in `src/feature-flags/registry.ts` may declare `requiredTables`. A
+feature whose tables are missing (migration not yet applied) is **never
+started**, no matter what the toggle says. This is the old "gated on schema
+availability" behavior, now explicit:
+
+- `/ready` reports the service as `"<service> (schema unavailable)"` instead of
+  silently crashing, and
+- `featureFlags.isAvailableSync(key)` / `featureFlags.shouldStartSync(key)` let
+  callers distinguish "flag off" from "can't run yet".
+
+## Code layout
+
+| File | Responsibility |
+|------|----------------|
+| `src/feature-flags/registry.ts` | Declarative flag definitions (keys, descriptions, legacy env vars, required tables, built-in defaults) |
+| `src/feature-flags/evaluate.ts` | Pure layered evaluation + deterministic rollout bucketing (no I/O) |
+| `src/feature-flags/store.ts` | DB load/write with a 30 s TTL cache; seeds rows for registered flags |
+| `src/feature-flags/schema.ts` | Cached `information_schema` table-existence checks |
+| `src/feature-flags/index.ts` | Public `featureFlags` singleton: `isEnabledSync`, `isEnabled`, `isEnabledForDeveloper`, `isAvailableSync`, `shouldStartSync`, `list`, admin writes |
+| `prisma/schema.prisma` | `FeatureFlag` + `FeatureFlagOverride` models (migration `20260825000000_feature_flags`) |
+| `src/api/feature-flags.ts` | Admin API router (`/api/v1/admin/feature-flags`) |
+
+## Usage
+
+### Boot-time services (`src/services.ts`, `src/server.ts`)
+
+```ts
+if (featureFlags.shouldStartSync('poolMonitor')) {
+  startPoolPriceMonitorImpl();
+}
+// else: reported in /ready → disabledServices as
+//   "poolMonitor (flag off)"            — toggle is off
+//   "poolMonitor (schema unavailable)"  — tables missing
+```
+
+`src/index.ts` calls `featureFlags.bootstrap()` before the servers start to
+warm the cache and the schema check. It is best-effort: if the DB is
+unreachable the system falls back to env vars + registry defaults (the old
+behavior), so boot never blocks on the flag store.
+
+### Request-scoped, per-developer gates
+
+```ts
+// after apiKeyAuth has populated req.apiKey.developerId
+if (featureFlags.isEnabledForDeveloper('betaEndpoint', req.apiKey.developerId)) {
+  // serve the beta behavior for this developer only
+}
+```
+
+### Admin API (admin role; runtime, no redeploy)
+
+All endpoints require a session with the `admin` role (`requireAuth` +
+`requireRole('admin')`).
+
+- `GET  /api/v1/admin/feature-flags` — list flags with resolved state, reason, availability, and overrides.
+- `PUT  /api/v1/admin/feature-flags/:key` — body `{ "defaultEnabled": true }` and/or `{ "rolloutPercent": 10 }`.
+- `PUT  /api/v1/admin/feature-flags/:key/overrides/:scopeType/:scopeValue` — body `{ "enabled": true }`; `scopeType` ∈ `environment` \| `developer`.
+- `DELETE /api/v1/admin/feature-flags/:key/overrides/:scopeType/:scopeValue` — remove an override.
+
+Example — enable the pool monitor for the whole `testnet` environment, then
+ramp it to 10% of developers everywhere else:
+
+```bash
+# environment override (testnet)
+curl -X PUT localhost:3000/api/v1/admin/feature-flags/poolMonitor/overrides/environment/testnet \
+  -H 'Authorization: Bearer <admin token>' -H 'Content-Type: application/json' \
+  -d '{"enabled": true}'
+
+# gradual rollout for everyone else
+curl -X PUT localhost:3000/api/v1/admin/feature-flags/poolMonitor \
+  -H 'Authorization: Bearer <admin token>' -H 'Content-Type: application/json' \
+  -d '{"rolloutPercent": 10}'
+```
+
+### Environments
+
+The "environment" scope key is the active Stellar network
+(`config.stellarNetwork`: `testnet` / `mainnet` / `devnet`), matching the
+per-network profile overlays in `k8s/configmap.yaml`.
+
+## Caching / propagation
+
+Flag rows and the schema table set are cached in-process for 30 s. Admin writes
+invalidate the local cache immediately; other instances pick the change up
+within the TTL. This is the standard tradeoff for a small, hot cache — use the
+DB directly for anything that needs stronger consistency.

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -36,7 +36,12 @@ data:
   # CORS — set to your frontend domain in production
   # CORS_ALLOWED_ORIGINS: "https://explorer.example.com"
 
-  # Feature flags — set to 'true' to enable each optional service
+  # Feature flags — per-environment bootstrap layer for the DB-backed flag
+  # system (see docs/FEATURE_FLAGS.md). 'true' forces the feature on in this
+  # environment; the DB default applies when unset. Runtime toggles (no
+  # redeploy) live in the _feature_flags / _feature_flag_overrides tables via
+  # /api/v1/admin/feature-flags (admin role). A feature whose required tables
+  # are missing reports "(schema unavailable)" in /ready and is not started.
   ENABLE_PRIVACY_WS: "false"
   ENABLE_COMPOSABILITY_WS: "false"
   ENABLE_ARBITRAGE_WS: "false"

--- a/prisma/migrations/20260825000000_feature_flags/migration.sql
+++ b/prisma/migrations/20260825000000_feature_flags/migration.sql
@@ -1,0 +1,39 @@
+-- Feature flag system: registry + per-environment/per-developer overrides.
+-- Hand-authored (matches the schema in prisma/schema.prisma). The default
+-- values for default_enabled / rollout_percent mirror the built-in registry
+-- defaults in src/feature-flags/registry.ts.
+
+CREATE TABLE "_feature_flags" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "description" TEXT NOT NULL DEFAULT '',
+    "default_enabled" BOOLEAN NOT NULL DEFAULT false,
+    "rollout_percent" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "_feature_flags_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "_feature_flags_key_key" ON "_feature_flags"("key");
+
+CREATE TABLE "_feature_flag_overrides" (
+    "id" TEXT NOT NULL,
+    "flag_key" TEXT NOT NULL,
+    "scope_type" TEXT NOT NULL,
+    "scope_value" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "_feature_flag_overrides_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "_feature_flag_overrides_flag_key_scope_type_scope_value_key"
+    ON "_feature_flag_overrides"("flag_key", "scope_type", "scope_value");
+
+CREATE INDEX "_feature_flag_overrides_flag_key_scope_type_idx"
+    ON "_feature_flag_overrides"("flag_key", "scope_type");
+
+ALTER TABLE "_feature_flag_overrides"
+    ADD CONSTRAINT "_feature_flag_overrides_flag_key_fkey"
+    FOREIGN KEY ("flag_key") REFERENCES "_feature_flags"("key")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5043,3 +5043,41 @@ model SearchIndexEntry {
   @@index([content])
   @@map("_search_index_entries")
 }
+
+// ── Feature Flags (gradual rollout, per-environment + per-developer toggles) ──
+// Backs the runtime feature-flag system in src/feature-flags. Each row is one
+// registered flag; overrides layer on top (developer > environment > env var
+// > rollout > default). Schema availability of required tables is checked
+// separately at runtime and is not stored here.
+model FeatureFlag {
+  id             String   @map("id") @id @default(cuid())
+  key            String   @map("key") @unique
+  description    String   @map("description") @default("")
+  defaultEnabled Boolean  @map("default_enabled") @default(false)
+  // Gradual rollout target (0-100). Applied to a stable per-account bucket
+  // when no explicit override or env var is set. 0 = off, 100 = fully on.
+  rolloutPercent Int      @map("rollout_percent") @default(0)
+  createdAt      DateTime @map("created_at") @default(now())
+  updatedAt      DateTime @map("updated_at") @updatedAt
+
+  overrides FeatureFlagOverride[]
+
+  @@map("_feature_flags")
+}
+
+model FeatureFlagOverride {
+  id         String   @map("id") @id @default(cuid())
+  flagKey    String   @map("flag_key")
+  // 'environment' (scopeValue = network name) or 'developer' (scopeValue = developerId)
+  scopeType  String   @map("scope_type")
+  scopeValue String   @map("scope_value")
+  enabled    Boolean  @map("enabled")
+  createdAt  DateTime @map("created_at") @default(now())
+  updatedAt  DateTime @map("updated_at") @updatedAt
+
+  flag FeatureFlag @relation(fields: [flagKey], references: [key], onDelete: Cascade)
+
+  @@unique([flagKey, scopeType, scopeValue])
+  @@index([flagKey, scopeType])
+  @@map("_feature_flag_overrides")
+}

--- a/src/api/feature-flags.ts
+++ b/src/api/feature-flags.ts
@@ -8,13 +8,16 @@
  *   - per-environment and per-developer overrides (runtime, no redeploy)
  *
  * All endpoints require authentication + the admin role (see requireRole in
- * auth/middleware), matching the other admin routers (e.g. admin/errors).
+ * auth/middleware), matching the other admin routers (e.g. admin/errors), and
+ * are rate-limited per IP via express-rate-limit.
  */
 
 import { Router } from 'express';
 import { z } from 'zod';
+import rateLimit from 'express-rate-limit';
 import { requireAuth, requireRole } from '../auth/middleware';
 import { asyncHandler } from '../middleware/asyncHandler';
+import { config } from '../config';
 import { featureFlags } from '../feature-flags';
 import { findFlagDefinition } from '../feature-flags/registry';
 
@@ -22,6 +25,22 @@ export const featureFlagsAdminRouter = Router();
 
 featureFlagsAdminRouter.use(requireAuth);
 featureFlagsAdminRouter.use(requireRole('admin'));
+
+// Explicit limiter for this auth-gated router. The global tieredRateLimit in
+// app.ts throttles every request at runtime, but CodeQL's
+// js/missing-rate-limiting query only recognizes a rate limiter applied
+// directly to the route handler, so apply express-rate-limit here as well.
+featureFlagsAdminRouter.use(
+  rateLimit({
+    windowMs: config.rateLimitWindowMs,
+    max: config.rateLimitMax,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: (_req, res) => {
+      res.status(429).json({ error: 'Rate limit exceeded' });
+    },
+  }),
+);
 
 const FLAG_SCOPE_TYPES = ['environment', 'developer'] as const;
 type FlagScopeType = (typeof FLAG_SCOPE_TYPES)[number];

--- a/src/api/feature-flags.ts
+++ b/src/api/feature-flags.ts
@@ -23,13 +23,12 @@ import { findFlagDefinition } from '../feature-flags/registry';
 
 export const featureFlagsAdminRouter = Router();
 
-featureFlagsAdminRouter.use(requireAuth);
-featureFlagsAdminRouter.use(requireRole('admin'));
-
 // Explicit limiter for this auth-gated router. The global tieredRateLimit in
 // app.ts throttles every request at runtime, but CodeQL's
 // js/missing-rate-limiting query only recognizes a rate limiter applied
 // directly to the route handler, so apply express-rate-limit here as well.
+// It is registered before the auth middleware so that it also guards the
+// requireAuth/requireRole handlers themselves.
 featureFlagsAdminRouter.use(
   rateLimit({
     windowMs: config.rateLimitWindowMs,
@@ -41,6 +40,9 @@ featureFlagsAdminRouter.use(
     },
   }),
 );
+
+featureFlagsAdminRouter.use(requireAuth);
+featureFlagsAdminRouter.use(requireRole('admin'));
 
 const FLAG_SCOPE_TYPES = ['environment', 'developer'] as const;
 type FlagScopeType = (typeof FLAG_SCOPE_TYPES)[number];

--- a/src/api/feature-flags.ts
+++ b/src/api/feature-flags.ts
@@ -1,0 +1,117 @@
+/**
+ * Feature Flag Admin API
+ *
+ * Operator endpoints for the DB-backed feature-flag system at
+ * /api/v1/admin/feature-flags. Supports:
+ *   - listing all registered flags with resolved state
+ *   - adjusting a flag's default toggle + gradual-rollout percentage
+ *   - per-environment and per-developer overrides (runtime, no redeploy)
+ *
+ * All endpoints require authentication + the admin role (see requireRole in
+ * auth/middleware), matching the other admin routers (e.g. admin/errors).
+ */
+
+import { Router } from 'express';
+import { z } from 'zod';
+import { requireAuth, requireRole } from '../auth/middleware';
+import { asyncHandler } from '../middleware/asyncHandler';
+import { featureFlags } from '../feature-flags';
+import { findFlagDefinition } from '../feature-flags/registry';
+
+export const featureFlagsAdminRouter = Router();
+
+featureFlagsAdminRouter.use(requireAuth);
+featureFlagsAdminRouter.use(requireRole('admin'));
+
+const FLAG_SCOPE_TYPES = ['environment', 'developer'] as const;
+type FlagScopeType = (typeof FLAG_SCOPE_TYPES)[number];
+
+function isRegisteredKey(key: string): boolean {
+  return findFlagDefinition(key) !== undefined;
+}
+
+// GET /api/v1/admin/feature-flags — list all flags with resolved state
+featureFlagsAdminRouter.get(
+  '/',
+  asyncHandler(async (_req, res) => {
+    const flags = await featureFlags.list();
+    res.json({ flags });
+  }),
+);
+
+// PUT /api/v1/admin/feature-flags/:key — update default toggle / rollout
+const updateBodySchema = z
+  .object({
+    defaultEnabled: z.boolean().optional(),
+    rolloutPercent: z.number().int().min(0).max(100).optional(),
+    description: z.string().optional(),
+  })
+  .refine((v) => Object.keys(v).length > 0, {
+    message: 'Provide at least one of defaultEnabled, rolloutPercent, or description',
+  });
+
+featureFlagsAdminRouter.put(
+  '/:key',
+  asyncHandler(async (req, res) => {
+    const { key } = req.params;
+    if (!isRegisteredKey(key)) {
+      return res.status(404).json({ error: `Unknown feature flag: ${key}` });
+    }
+    const parsed = updateBodySchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return res.status(400).json({ error: parsed.error.issues[0]?.message ?? 'Invalid body' });
+    }
+    const flag = await featureFlags.updateFlag(key, parsed.data);
+    res.json({ flag });
+  }),
+);
+
+// PUT /api/v1/admin/feature-flags/:key/overrides/:scopeType/:scopeValue
+const overrideBodySchema = z.object({ enabled: z.boolean() });
+
+featureFlagsAdminRouter.put(
+  '/:key/overrides/:scopeType/:scopeValue',
+  asyncHandler(async (req, res) => {
+    const { key, scopeType, scopeValue } = req.params;
+    if (!isRegisteredKey(key)) {
+      return res.status(404).json({ error: `Unknown feature flag: ${key}` });
+    }
+    if (!FLAG_SCOPE_TYPES.includes(scopeType as FlagScopeType)) {
+      return res
+        .status(400)
+        .json({ error: `scopeType must be one of: ${FLAG_SCOPE_TYPES.join(', ')}` });
+    }
+    if (!scopeValue) {
+      return res.status(400).json({ error: 'scopeValue is required' });
+    }
+    const parsed = overrideBodySchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return res.status(400).json({ error: 'enabled must be a boolean' });
+    }
+    const flag = await featureFlags.setOverride(
+      key,
+      scopeType as FlagScopeType,
+      scopeValue,
+      parsed.data.enabled,
+    );
+    res.json({ flag });
+  }),
+);
+
+// DELETE /api/v1/admin/feature-flags/:key/overrides/:scopeType/:scopeValue
+featureFlagsAdminRouter.delete(
+  '/:key/overrides/:scopeType/:scopeValue',
+  asyncHandler(async (req, res) => {
+    const { key, scopeType, scopeValue } = req.params;
+    if (!isRegisteredKey(key)) {
+      return res.status(404).json({ error: `Unknown feature flag: ${key}` });
+    }
+    if (!FLAG_SCOPE_TYPES.includes(scopeType as FlagScopeType)) {
+      return res
+        .status(400)
+        .json({ error: `scopeType must be one of: ${FLAG_SCOPE_TYPES.join(', ')}` });
+    }
+    await featureFlags.clearOverride(key, scopeType as FlagScopeType, scopeValue);
+    res.json({ ok: true });
+  }),
+);

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -72,6 +72,7 @@ import { sacTrustlinesRouter } from './sac-trustlines';
 
 // ── Admin ─────────────────────────────────────────────────────────────────────
 import { adminErrorsRouter } from './admin/errors';
+import { featureFlagsAdminRouter } from './feature-flags';
 // ── CSV Exports ───────────────────────────────────────────────────────────────
 import { requireApiKey, requireKeyTier } from '../middleware/apiKeyAuth';
 import { compilerRouter } from './compiler-router';
@@ -151,6 +152,7 @@ router.use('/sac-trustlines', sacTrustlinesRouter);
 
 // ── Admin Dashboards ──────────────────────────────────────────────────────────
 router.use('/admin/errors', adminErrorsRouter);
+router.use('/admin/feature-flags', featureFlagsAdminRouter);
 // ── Bridge Tracker ─────────────────────────────────────────────────────────────
 import { bridgeTrackerRouter } from './bridge-tracker';
 router.use('/bridge-tracker', bridgeTrackerRouter);

--- a/src/feature-flags/evaluate.ts
+++ b/src/feature-flags/evaluate.ts
@@ -1,0 +1,104 @@
+/**
+ * Pure feature-flag evaluation
+ *
+ * Resolution order (most specific wins):
+ *   1. Developer override   (per-account, DB)
+ *   2. Environment override (per-environment, DB)
+ *   3. Env var              (per-environment bootstrap config, e.g. ENABLE_*)
+ *   4. Gradual rollout      (deterministic per-account bucket when 0 < pct < 100)
+ *   5. DB default           (FeatureFlag.defaultEnabled)
+ *
+ * Kept free of I/O so it can be unit-tested exhaustively; the store in
+ * store.ts loads state, this module decides.
+ */
+
+export interface FlagSnapshot {
+  key: string;
+  defaultEnabled: boolean;
+  /** Gradual rollout target (0-100). */
+  rolloutPercent: number;
+  environmentOverrides: Map<string, boolean>;
+  developerOverrides: Map<string, boolean>;
+}
+
+export interface FlagOverrides {
+  environment: Map<string, boolean>;
+  developer: Map<string, boolean>;
+}
+
+export interface EvaluateInput {
+  snapshot: FlagSnapshot;
+  overrides: FlagOverrides;
+  environment: string;
+  developerId?: string;
+  /** Raw env var string; undefined means unset. */
+  envVarValue?: string;
+}
+
+export type EvaluationReason =
+  'developer_override' | 'environment_override' | 'env_var' | 'rollout' | 'default';
+
+export interface EvaluationResult {
+  enabled: boolean;
+  reason: EvaluationReason;
+}
+
+/**
+ * FNV-1a 32-bit hash — stable across runs and processes, so a given
+ * (flag, account) pair always lands in the same rollout bucket.
+ */
+export function stableHash(input: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+/**
+ * Whether `developerId` falls inside the rollout for `key` at `percent` (0-100).
+ * Buckets are 1..100 and the bucket is derived from the stable hash, so an
+ * account that is "in" at 10% is also in at 20% — increasing the percentage
+ * only ever adds accounts (monotonic rollout).
+ */
+export function inRollout(key: string, developerId: string, percent: number): boolean {
+  if (percent >= 100) return true;
+  if (percent <= 0) return false;
+  const bucket = (stableHash(`${key}:${developerId}`) % 100) + 1;
+  return bucket <= percent;
+}
+
+export function evaluateFlag(input: EvaluateInput): EvaluationResult {
+  const { snapshot, overrides, environment, developerId, envVarValue } = input;
+
+  // 1. Per-account override — most specific.
+  if (developerId && overrides.developer.has(developerId)) {
+    return { enabled: overrides.developer.get(developerId)!, reason: 'developer_override' };
+  }
+
+  // 2. Per-environment override.
+  if (overrides.environment.has(environment)) {
+    return { enabled: overrides.environment.get(environment)!, reason: 'environment_override' };
+  }
+
+  // 3. Env var — legacy ENABLE_* / generic FF_* per-environment bootstrap.
+  if (envVarValue !== undefined) {
+    const v = envVarValue.trim().toLowerCase();
+    return { enabled: v === 'true' || v === '1', reason: 'env_var' };
+  }
+
+  // 4. Gradual rollout — stable per-account bucket. Without a developerId there
+  //    is no stable bucket, so anonymous callers fall through to the default.
+  const { rolloutPercent } = snapshot;
+  if (rolloutPercent > 0 && rolloutPercent < 100) {
+    if (developerId) {
+      return { enabled: inRollout(snapshot.key, developerId, rolloutPercent), reason: 'rollout' };
+    }
+  } else if (rolloutPercent >= 100) {
+    return { enabled: true, reason: 'rollout' };
+  }
+
+  // 5. DB default.
+  return { enabled: snapshot.defaultEnabled, reason: 'default' };
+}

--- a/src/feature-flags/index.ts
+++ b/src/feature-flags/index.ts
@@ -1,0 +1,207 @@
+/**
+ * Feature flags — public API
+ *
+ * Layered, DB-backed feature flags with per-environment and per-developer
+ * toggles plus gradual rollout. Resolution order:
+ *
+ *   developer override > environment override > env var > rollout > default
+ *
+ * Backward compatible: the legacy ENABLE_* env vars keep working unchanged
+ * (they are the per-environment bootstrap layer), and a feature is only ever
+ * started when its required tables exist (schema availability), now reported
+ * explicitly instead of silently crashing.
+ *
+ * Usage:
+ *   boot:        await featureFlags.bootstrap();            // warm cache
+ *   boot gate:   featureFlags.isEnabledSync('poolMonitor')
+ *                featureFlags.isAvailableSync('poolMonitor')
+ *   request:     featureFlags.isEnabled('betaEndpoint', { developerId })
+ */
+
+import { config } from '../config';
+import { logger } from '../logger';
+import { prismaRead, prismaWrite } from '../db';
+import { findFlagDefinition, envVarFor, listFlagDefinitions, type FlagScopeType } from './registry';
+import { evaluateFlag, type FlagSnapshot, type FlagOverrides } from './evaluate';
+import { FeatureFlagStore, type FlagUpdate } from './store';
+import { loadExistingTables, tablesExistSync, invalidateSchemaCache } from './schema';
+
+export { FEATURE_FLAG_DEFINITIONS, listFlagDefinitions, findFlagDefinition } from './registry';
+export type { FlagScopeType } from './registry';
+export type { EvaluationReason } from './evaluate';
+export { inRollout, stableHash } from './evaluate';
+
+export interface FlagContext {
+  developerId?: string;
+  /** Defaults to the active Stellar network (per-environment scope). */
+  environment?: string;
+}
+
+export interface ResolvedFlag {
+  key: string;
+  description: string;
+  defaultEnabled: boolean;
+  rolloutPercent: number;
+  requiredTables: string[];
+  envVar?: string;
+  enabled: boolean;
+  available: boolean;
+  reason: string;
+  overrides: {
+    environment: Record<string, boolean>;
+    developer: Record<string, boolean>;
+  };
+}
+
+export class FeatureFlags {
+  private readonly store = new FeatureFlagStore(prismaRead, prismaWrite);
+
+  get environment(): string {
+    return config.stellarNetwork;
+  }
+
+  /** Warm the cache + schema availability before serving. Best-effort. */
+  async bootstrap(): Promise<void> {
+    try {
+      await this.store.ensureRegisteredFlags();
+      await this.store.load();
+      await loadExistingTables();
+    } catch (err) {
+      logger.warn('[feature-flags] bootstrap failed; falling back to env vars + defaults', {
+        error: String(err),
+      });
+    }
+  }
+
+  /** Reload flag state from the DB (e.g. after a manual change). */
+  async refresh(): Promise<void> {
+    this.store.invalidate();
+    invalidateSchemaCache();
+    await this.store.load();
+    await loadExistingTables();
+  }
+
+  /**
+   * Evaluate a flag synchronously from the cache. Safe on the boot path after
+   * `bootstrap()`; also safe before (falls back to env var + registry default,
+   * matching the pre-feature-flag behavior).
+   */
+  isEnabledSync(key: string, ctx: FlagContext = {}): boolean {
+    return this.evaluate(key, ctx).enabled;
+  }
+
+  /** Evaluate a flag, ensuring the cache is loaded first. */
+  async isEnabled(key: string, ctx: FlagContext = {}): Promise<boolean> {
+    await this.store.load();
+    return this.isEnabledSync(key, ctx);
+  }
+
+  /** Per-account evaluation for request-scoped features. */
+  isEnabledForDeveloper(
+    key: string,
+    developerId: string,
+    ctx: Omit<FlagContext, 'developerId'> = {},
+  ): boolean {
+    return this.isEnabledSync(key, { ...ctx, developerId });
+  }
+
+  /**
+   * Whether the feature's required tables exist. A feature that is enabled but
+   * not available must not be started.
+   */
+  isAvailableSync(key: string): boolean {
+    const def = findFlagDefinition(key);
+    if (!def?.requiredTables?.length) return true;
+    return tablesExistSync(def.requiredTables);
+  }
+
+  async isAvailable(key: string): Promise<boolean> {
+    const def = findFlagDefinition(key);
+    if (!def?.requiredTables?.length) return true;
+    await loadExistingTables();
+    return tablesExistSync(def.requiredTables);
+  }
+
+  /** Start the feature iff the toggle is on AND the schema prerequisite exists. */
+  shouldStartSync(key: string, ctx: FlagContext = {}): boolean {
+    return this.isEnabledSync(key, ctx) && this.isAvailableSync(key);
+  }
+
+  /** List all registered flags with resolved state (admin API / diagnostics). */
+  async list(): Promise<ResolvedFlag[]> {
+    await this.store.load();
+    await loadExistingTables();
+    return listFlagDefinitions().map((def) => this.resolve(def.key));
+  }
+
+  async updateFlag(key: string, patch: FlagUpdate): Promise<ResolvedFlag> {
+    await this.store.updateFlag(key, patch);
+    return this.resolve(key);
+  }
+
+  async setOverride(
+    key: string,
+    scopeType: FlagScopeType,
+    scopeValue: string,
+    enabled: boolean,
+  ): Promise<ResolvedFlag> {
+    await this.store.setOverride(key, scopeType, scopeValue, enabled);
+    return this.resolve(key);
+  }
+
+  async clearOverride(key: string, scopeType: FlagScopeType, scopeValue: string): Promise<void> {
+    await this.store.clearOverride(key, scopeType, scopeValue);
+  }
+
+  // ── internals ──────────────────────────────────────────────────────────────
+
+  private resolve(key: string): ResolvedFlag {
+    const def = findFlagDefinition(key);
+    const result = this.evaluate(key);
+    const cached = this.store.getCachedSync(key);
+    return {
+      key,
+      description: def?.description ?? '',
+      defaultEnabled: cached?.defaultEnabled ?? def?.defaultEnabled ?? false,
+      rolloutPercent: cached?.rolloutPercent ?? def?.rolloutPercent ?? 0,
+      requiredTables: def?.requiredTables ?? [],
+      envVar: def ? envVarFor(def) : undefined,
+      enabled: result.enabled,
+      available: this.isAvailableSync(key),
+      reason: result.reason,
+      overrides: {
+        environment: Object.fromEntries(cached?.environmentOverrides ?? new Map()),
+        developer: Object.fromEntries(cached?.developerOverrides ?? new Map()),
+      },
+    };
+  }
+
+  private evaluate(key: string, ctx: FlagContext = {}): { enabled: boolean; reason: string } {
+    const def = findFlagDefinition(key);
+    const snapshot: FlagSnapshot = this.store.getCachedSync(key) ?? {
+      key,
+      defaultEnabled: def?.defaultEnabled ?? false,
+      rolloutPercent: def?.rolloutPercent ?? 0,
+      environmentOverrides: new Map(),
+      developerOverrides: new Map(),
+    };
+
+    const overrides: FlagOverrides = {
+      environment: snapshot.environmentOverrides,
+      developer: snapshot.developerOverrides,
+    };
+
+    const envVarValue = def ? process.env[envVarFor(def)] : undefined;
+    const result = evaluateFlag({
+      snapshot,
+      overrides,
+      environment: ctx.environment ?? this.environment,
+      developerId: ctx.developerId,
+      envVarValue,
+    });
+    return { enabled: result.enabled, reason: result.reason };
+  }
+}
+
+/** Process-wide singleton. */
+export const featureFlags = new FeatureFlags();

--- a/src/feature-flags/registry.ts
+++ b/src/feature-flags/registry.ts
@@ -1,0 +1,107 @@
+/**
+ * Feature flag registry
+ *
+ * Declarative list of every feature flag the platform knows about. Each entry
+ * carries:
+ *  - `envVar`            — legacy/per-environment bootstrap env var (e.g. the
+ *                          ENABLE_* vars that previously gated these services).
+ *  - `requiredTables`    — Postgres tables that must exist for the feature to
+ *                          be *available* (schema availability). If any table is
+ *                          missing the feature reports "schema unavailable" and
+ *                          is never started, regardless of the toggle state.
+ *  - `defaultEnabled`    — built-in fallback used when no DB row exists and the
+ *                          env var is unset. Schema-gated features default off.
+ *  - `rolloutPercent`    — built-in gradual-rollout target (0-100) when no DB
+ *                          row exists.
+ *
+ * The DB row (prisma FeatureFlag) is the source of truth once it exists; the
+ * values here are only the fallback until the row is seeded (see
+ * FeatureFlagStore.ensureRegisteredFlags).
+ */
+
+export type FlagScopeType = 'environment' | 'developer';
+
+export interface FlagDefinition {
+  key: string;
+  description: string;
+  /** Legacy per-environment env var (checked at eval time). */
+  envVar?: string;
+  /** Tables that must exist for the feature to be available. */
+  requiredTables?: string[];
+  /** Fallback when no DB row exists and no env var is set. */
+  defaultEnabled: boolean;
+  /** Fallback rollout target (0-100) when no DB row exists. */
+  rolloutPercent?: number;
+}
+
+export const FEATURE_FLAG_DEFINITIONS: FlagDefinition[] = [
+  {
+    key: 'privacyWs',
+    description:
+      'Privacy WebSocket broadcaster (/ws/v1/privacy and /ws/v1/privacy/alerts); streams privacy-protocol transactions and anomaly alerts.',
+    envVar: 'ENABLE_PRIVACY_WS',
+    requiredTables: ['_privacy_transactions'],
+    defaultEnabled: false,
+  },
+  {
+    key: 'composabilityWs',
+    description:
+      'Composability WebSocket broadcaster (/ws/composability/exploits); broadcasts cross-contract exploit-pattern alerts.',
+    envVar: 'ENABLE_COMPOSABILITY_WS',
+    defaultEnabled: false,
+  },
+  {
+    key: 'arbitrageWs',
+    description:
+      'Arbitrage WebSocket broadcaster (/ws/arbitrage/opportunities); streams arbitrage opportunities detected by the scanner.',
+    envVar: 'ENABLE_ARBITRAGE_WS',
+    requiredTables: ['_arbitrage_opportunities'],
+    defaultEnabled: false,
+  },
+  {
+    key: 'poolMonitor',
+    description:
+      'Pool price monitor; polls active DexPool rows, writes PoolPrice rows, computes TWAP, flags cross-DEX price deviations.',
+    envVar: 'ENABLE_POOL_MONITOR',
+    requiredTables: ['_dex_pools', '_pool_prices', '_price_deviations'],
+    defaultEnabled: false,
+  },
+  {
+    key: 'arbitrageScanner',
+    description:
+      'Arbitrage scanner; runs direct + triangular arbitrage detection and persists ArbitrageOpportunity rows.',
+    envVar: 'ENABLE_ARBITRAGE_SCANNER',
+    requiredTables: ['_dex_pools', '_pool_prices', '_arbitrage_opportunities'],
+    defaultEnabled: false,
+  },
+  {
+    key: 'feeAggregator',
+    description:
+      'Fee aggregator; classifies on-chain fee events into FeeEvent rows and aggregates ProtocolRevenue / YieldSnapshot buckets.',
+    envVar: 'ENABLE_FEE_AGGREGATOR',
+    requiredTables: [
+      '_fee_events',
+      '_protocol_revenues',
+      '_yield_snapshots',
+      '_protocol_profiles',
+      '_revenue_alerts',
+    ],
+    defaultEnabled: false,
+  },
+];
+
+const byKey = new Map(FEATURE_FLAG_DEFINITIONS.map((def) => [def.key, def]));
+
+export function findFlagDefinition(key: string): FlagDefinition | undefined {
+  return byKey.get(key);
+}
+
+export function listFlagDefinitions(): FlagDefinition[] {
+  return FEATURE_FLAG_DEFINITIONS;
+}
+
+/** Generic env-var convention for flags that don't declare a legacy var: FF_<KEY>. */
+export function envVarFor(def: FlagDefinition): string {
+  if (def.envVar) return def.envVar;
+  return `FF_${def.key.replace(/[A-Z]/g, (c) => `_${c}`).toUpperCase()}`;
+}

--- a/src/feature-flags/schema.ts
+++ b/src/feature-flags/schema.ts
@@ -1,0 +1,70 @@
+/**
+ * Schema availability for feature flags
+ *
+ * A feature whose required tables are missing (migration not yet applied) must
+ * never start — previously this was the *only* gate. Here it becomes a hard
+ * capability check layered under the toggle: the toggle decides whether the
+ * feature *should* run, schema availability decides whether it *can*.
+ *
+ * The table list is cached briefly so per-request evaluation stays cheap and
+ * the boot path can read it synchronously after an async warm-up.
+ */
+
+import type { PrismaClient } from '@prisma/client';
+import { prismaRead } from '../db';
+import { logger } from '../logger';
+
+const CACHE_TTL_MS = 30_000;
+
+let cachedTables: Set<string> | null = null;
+let cacheLoadedAt = 0;
+
+export async function loadExistingTables(client: PrismaClient = prismaRead): Promise<Set<string>> {
+  const now = Date.now();
+  if (cachedTables !== null && now - cacheLoadedAt < CACHE_TTL_MS) {
+    return cachedTables;
+  }
+  try {
+    const rows = await client.$queryRawUnsafe<Array<{ table_name: string }>>(
+      "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'",
+    );
+    cachedTables = new Set(rows.map((r) => r.table_name));
+    cacheLoadedAt = now;
+    return cachedTables;
+  } catch (err) {
+    // DB unreachable — treat every table as missing (fail safe) so features
+    // report "schema unavailable" instead of crashing mid-run.
+    logger.warn('[feature-flags] schema availability check failed; treating tables as missing', {
+      error: String(err),
+    });
+    cachedTables = new Set();
+    cacheLoadedAt = now;
+    return cachedTables;
+  }
+}
+
+export function invalidateSchemaCache(): void {
+  cachedTables = null;
+  cacheLoadedAt = 0;
+}
+
+/** Async check: every required table must exist. */
+export async function tablesExist(
+  tables: string[],
+  client: PrismaClient = prismaRead,
+): Promise<boolean> {
+  if (tables.length === 0) return true;
+  const existing = await loadExistingTables(client);
+  return tables.every((t) => existing.has(t));
+}
+
+/**
+ * Sync check against the cached table set. Safe to call on the boot path after
+ * `loadExistingTables()` has been warmed; a cold cache (no warm-up yet) is
+ * treated as unavailable.
+ */
+export function tablesExistSync(tables: string[]): boolean {
+  if (tables.length === 0) return true;
+  if (cachedTables === null) return false;
+  return tables.every((t) => cachedTables.has(t));
+}

--- a/src/feature-flags/store.ts
+++ b/src/feature-flags/store.ts
@@ -1,0 +1,184 @@
+/**
+ * DB-backed feature flag store
+ *
+ * Loads FeatureFlag rows (with their overrides) into an in-memory cache so
+ * per-request evaluation is synchronous and cheap. Writes (admin API) go
+ * through this store and invalidate the cache immediately; other instances
+ * pick changes up after the TTL, which is the standard multi-instance tradeoff
+ * for a cache this size.
+ *
+ * The store degrades gracefully: if the DB is unreachable at load time it
+ * returns an empty snapshot map, so evaluation falls back to env vars and the
+ * registry defaults — the same behavior as before this system existed.
+ */
+
+import type { PrismaClient } from '@prisma/client';
+import { prismaRead, prismaWrite } from '../db';
+import { findFlagDefinition, listFlagDefinitions, type FlagScopeType } from './registry';
+import type { FlagSnapshot } from './evaluate';
+
+export const FLAG_CACHE_TTL_MS = 30_000;
+
+interface CacheEntry {
+  flags: Map<string, FlagSnapshot>;
+  loadedAt: number;
+}
+
+export interface FlagUpdate {
+  defaultEnabled?: boolean;
+  rolloutPercent?: number;
+  description?: string;
+}
+
+export class FeatureFlagStore {
+  private cache: CacheEntry | null = null;
+
+  constructor(
+    private readonly read: PrismaClient = prismaRead,
+    private readonly write: PrismaClient = prismaWrite,
+  ) {}
+
+  invalidate(): void {
+    this.cache = null;
+  }
+
+  private isFresh(): boolean {
+    return this.cache !== null && Date.now() - this.cache.loadedAt < FLAG_CACHE_TTL_MS;
+  }
+
+  /** Sync access to the cached snapshot (undefined if cache is cold/empty). */
+  getCachedSync(key: string): FlagSnapshot | undefined {
+    return this.cache?.flags.get(key);
+  }
+
+  /** Warm the cache (or refresh it if stale). Never throws. */
+  async load(): Promise<Map<string, FlagSnapshot>> {
+    if (this.isFresh()) return this.cache!.flags;
+    try {
+      const rows = await this.read.featureFlag.findMany({ include: { overrides: true } });
+      const flags = new Map<string, FlagSnapshot>();
+      for (const row of rows) {
+        const environmentOverrides = new Map<string, boolean>();
+        const developerOverrides = new Map<string, boolean>();
+        for (const o of row.overrides) {
+          if (o.scopeType === 'environment') environmentOverrides.set(o.scopeValue, o.enabled);
+          else if (o.scopeType === 'developer') developerOverrides.set(o.scopeValue, o.enabled);
+        }
+        flags.set(row.key, {
+          key: row.key,
+          defaultEnabled: row.defaultEnabled,
+          rolloutPercent: row.rolloutPercent,
+          environmentOverrides,
+          developerOverrides,
+        });
+      }
+      this.cache = { flags, loadedAt: Date.now() };
+      return flags;
+    } catch (err) {
+      // DB unavailable → empty snapshot map; env vars + registry defaults apply.
+      this.cache = { flags: new Map(), loadedAt: Date.now() };
+      return this.cache.flags;
+    }
+  }
+
+  /**
+   * Ensure a DB row exists for every registered flag (seeded with the registry
+   * defaults) so operators can manage all known flags from the admin API even
+   * before any flag has been touched. Existing rows are left intact.
+   */
+  async ensureRegisteredFlags(): Promise<void> {
+    for (const def of listFlagDefinitions()) {
+      await this.write.featureFlag.upsert({
+        where: { key: def.key },
+        create: {
+          key: def.key,
+          description: def.description,
+          defaultEnabled: def.defaultEnabled,
+          rolloutPercent: def.rolloutPercent ?? 0,
+        },
+        update: { description: def.description },
+      });
+    }
+    this.invalidate();
+  }
+
+  async updateFlag(key: string, patch: FlagUpdate): Promise<FlagSnapshot> {
+    const row = await this.write.featureFlag.upsert({
+      where: { key },
+      create: {
+        key,
+        description: patch.description ?? findFlagDefinition(key)?.description ?? '',
+        defaultEnabled: patch.defaultEnabled ?? false,
+        rolloutPercent: patch.rolloutPercent ?? 0,
+      },
+      update: {
+        ...(patch.defaultEnabled !== undefined ? { defaultEnabled: patch.defaultEnabled } : {}),
+        ...(patch.rolloutPercent !== undefined ? { rolloutPercent: patch.rolloutPercent } : {}),
+        ...(patch.description !== undefined ? { description: patch.description } : {}),
+      },
+      include: { overrides: true },
+    });
+    this.invalidate();
+    return this.toSnapshot(row);
+  }
+
+  async setOverride(
+    flagKey: string,
+    scopeType: FlagScopeType,
+    scopeValue: string,
+    enabled: boolean,
+  ): Promise<FlagSnapshot> {
+    await this.write.featureFlagOverride.upsert({
+      where: { flagKey_scopeType_scopeValue: { flagKey, scopeType, scopeValue } },
+      create: { flagKey, scopeType, scopeValue, enabled },
+      update: { enabled },
+    });
+    this.invalidate();
+    return this.load().then((flags) => this.withFallback(flags.get(flagKey), flagKey));
+  }
+
+  async clearOverride(
+    flagKey: string,
+    scopeType: FlagScopeType,
+    scopeValue: string,
+  ): Promise<void> {
+    await this.write.featureFlagOverride
+      .deleteMany({ where: { flagKey, scopeType, scopeValue } })
+      .catch(() => {});
+    this.invalidate();
+  }
+
+  /** Snapshot for a key, synthesizing from the registry when no DB row exists. */
+  private withFallback(snapshot: FlagSnapshot | undefined, key: string): FlagSnapshot {
+    if (snapshot) return snapshot;
+    const def = findFlagDefinition(key);
+    return {
+      key,
+      defaultEnabled: def?.defaultEnabled ?? false,
+      rolloutPercent: def?.rolloutPercent ?? 0,
+      environmentOverrides: new Map(),
+      developerOverrides: new Map(),
+    };
+  }
+
+  private toSnapshot(row: {
+    key: string;
+    defaultEnabled: boolean;
+    rolloutPercent: number;
+    overrides: Array<{ scopeType: string; scopeValue: string; enabled: boolean }>;
+  }): FlagSnapshot {
+    const environmentOverrides = new Map<string, boolean>();
+    const developerOverrides = new Map<string, boolean>();
+    for (const o of row.overrides) {
+      if (o.scopeType === 'environment') environmentOverrides.set(o.scopeValue, o.enabled);
+      else if (o.scopeType === 'developer') developerOverrides.set(o.scopeValue, o.enabled);
+    }
+    return {
+      key: row.key,
+      defaultEnabled: row.defaultEnabled,
+      rolloutPercent: row.rolloutPercent,
+      environmentOverrides,
+      developerOverrides,
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { cacheClose } from './cache';
 import { dbConnectionStatus, cacheBackendStatus } from './metrics';
 import { eventBus } from './events/eventBus';
 import { logger } from './logger';
+import { featureFlags } from './feature-flags';
 
 let isShuttingDown = false;
 const SERVICE_START_TIME = Date.now();
@@ -172,6 +173,11 @@ async function main() {
 
   registerShutdownHandlers();
   await validateStateDumpPath();
+
+  // Warm the feature-flag cache (DB-backed toggles + schema availability) before
+  // the HTTP/WebSocket servers attach. Best-effort: on failure the flags fall
+  // back to env vars + registry defaults, so boot never blocks on the flag DB.
+  await featureFlags.bootstrap();
 
   const app = createApp({
     isShuttingDown: () => isShuttingDown,

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import { attachPrivacyWebSocket as attachPrivacyWebSocketReal } from './ws/priva
 import { attachComposabilityWebSocket as attachComposabilityWebSocketImpl } from './ws/composabilityBroadcaster';
 import { attachArbitrageWebSocket as attachArbitrageWebSocketImpl } from './ws/arbitrageBroadcaster';
 import { attachAuditWebSocket } from './ws/auditBroadcaster';
+import { featureFlags } from './feature-flags';
 
 export interface HttpServerHandle {
   httpServer: Server;
@@ -25,40 +26,45 @@ export function createHttpServer(app: Express, disabledServices: string[]): Http
   const httpServer: Server = createServer(app);
   const wssRef = attachWebSocketServer(httpServer);
 
-  const enablePrivacyWs = process.env.ENABLE_PRIVACY_WS === 'true';
-  const enableComposabilityWs = process.env.ENABLE_COMPOSABILITY_WS === 'true';
-  const enableArbitrageWs = process.env.ENABLE_ARBITRAGE_WS === 'true';
-
-  if (enablePrivacyWs) {
+  if (featureFlags.shouldStartSync('privacyWs')) {
     attachPrivacyWebSocketReal(httpServer);
     logger.info('Privacy WebSocket attached');
+  } else if (!featureFlags.isEnabledSync('privacyWs')) {
+    disabledServices.push('privacyWS (flag off)');
+    logger.debug('Privacy WebSocket disabled (feature flag privacyWs off)');
   } else {
-    disabledServices.push('privacyWS');
-    logger.debug('Privacy WebSocket disabled (ENABLE_PRIVACY_WS not set)');
+    disabledServices.push('privacyWS (schema unavailable)');
+    logger.debug('Privacy WebSocket disabled (required tables missing)');
   }
 
-  if (enableComposabilityWs) {
+  if (featureFlags.shouldStartSync('composabilityWs')) {
     try {
       attachComposabilityWebSocketImpl(httpServer);
       logger.info('Composability WebSocket attached');
     } catch (err) {
       logger.warn('Composability WebSocket attachment failed', { error: String(err) });
     }
+  } else if (!featureFlags.isEnabledSync('composabilityWs')) {
+    disabledServices.push('composabilityWS (flag off)');
+    logger.debug('Composability WebSocket disabled (feature flag composabilityWs off)');
   } else {
-    disabledServices.push('composabilityWS');
-    logger.debug('Composability WebSocket disabled (ENABLE_COMPOSABILITY_WS not set)');
+    disabledServices.push('composabilityWS (schema unavailable)');
+    logger.debug('Composability WebSocket disabled (required tables missing)');
   }
 
-  if (enableArbitrageWs) {
+  if (featureFlags.shouldStartSync('arbitrageWs')) {
     try {
       attachArbitrageWebSocketImpl(httpServer);
       logger.info('Arbitrage WebSocket attached');
     } catch (err) {
       logger.warn('Arbitrage WebSocket attachment failed', { error: String(err) });
     }
+  } else if (!featureFlags.isEnabledSync('arbitrageWs')) {
+    disabledServices.push('arbitrageWS (flag off)');
+    logger.debug('Arbitrage WebSocket disabled (feature flag arbitrageWs off)');
   } else {
-    disabledServices.push('arbitrageWS');
-    logger.debug('Arbitrage WebSocket disabled (ENABLE_ARBITRAGE_WS not set)');
+    disabledServices.push('arbitrageWS (schema unavailable)');
+    logger.debug('Arbitrage WebSocket disabled (required tables missing)');
   }
 
   // /ws/audit — score alerts, finding alerts, signals

--- a/src/services.ts
+++ b/src/services.ts
@@ -30,6 +30,7 @@ import { startPriceUpdater } from './services/pricing';
 import { feedOrchestrator } from './feed/orchestrator';
 import { eventBus } from './events/eventBus';
 import { startGraphqlEventBridge } from './graphql/subscriptions';
+import { featureFlags } from './feature-flags';
 
 export async function initializeServices(disabledServices: string[]): Promise<void> {
   await initRateLimitStore();
@@ -66,45 +67,50 @@ export async function initializeServices(disabledServices: string[]): Promise<vo
     markReady('indexer');
   }
 
-  const enablePoolMonitor = process.env.ENABLE_POOL_MONITOR === 'true';
-  const enableArbitrageScanner = process.env.ENABLE_ARBITRAGE_SCANNER === 'true';
-  const enableFeeAggregator = process.env.ENABLE_FEE_AGGREGATOR === 'true';
-
   if (!process.env.DISABLE_INDEXER) {
-    if (enablePoolMonitor) {
+    if (featureFlags.shouldStartSync('poolMonitor')) {
       try {
         startPoolPriceMonitorImpl();
         logger.info('Pool price monitor started');
       } catch (err) {
         logger.warn('Pool price monitor failed to start', { error: String(err) });
       }
+    } else if (!featureFlags.isEnabledSync('poolMonitor')) {
+      disabledServices.push('poolMonitor (flag off)');
+      logger.debug('Pool price monitor disabled (feature flag poolMonitor off)');
     } else {
-      disabledServices.push('poolMonitor');
-      logger.debug('Pool price monitor disabled (ENABLE_POOL_MONITOR not set)');
+      disabledServices.push('poolMonitor (schema unavailable)');
+      logger.debug('Pool price monitor disabled (required tables missing)');
     }
 
-    if (enableArbitrageScanner) {
+    if (featureFlags.shouldStartSync('arbitrageScanner')) {
       try {
         startArbitrageScannerImpl();
         logger.info('Arbitrage scanner started');
       } catch (err) {
         logger.warn('Arbitrage scanner failed to start', { error: String(err) });
       }
+    } else if (!featureFlags.isEnabledSync('arbitrageScanner')) {
+      disabledServices.push('arbitrageScanner (flag off)');
+      logger.debug('Arbitrage scanner disabled (feature flag arbitrageScanner off)');
     } else {
-      disabledServices.push('arbitrageScanner');
-      logger.debug('Arbitrage scanner disabled (ENABLE_ARBITRAGE_SCANNER not set)');
+      disabledServices.push('arbitrageScanner (schema unavailable)');
+      logger.debug('Arbitrage scanner disabled (required tables missing)');
     }
 
-    if (enableFeeAggregator) {
+    if (featureFlags.shouldStartSync('feeAggregator')) {
       try {
         startFeeAggregatorImpl();
         logger.info('Fee aggregator started');
       } catch (err) {
         logger.warn('Fee aggregator failed to start', { error: String(err) });
       }
+    } else if (!featureFlags.isEnabledSync('feeAggregator')) {
+      disabledServices.push('feeAggregator (flag off)');
+      logger.debug('Fee aggregator disabled (feature flag feeAggregator off)');
     } else {
-      disabledServices.push('feeAggregator');
-      logger.debug('Fee aggregator disabled (ENABLE_FEE_AGGREGATOR not set)');
+      disabledServices.push('feeAggregator (schema unavailable)');
+      logger.debug('Fee aggregator disabled (required tables missing)');
     }
 
     try {

--- a/tests/feature-flags/admin-api.test.ts
+++ b/tests/feature-flags/admin-api.test.ts
@@ -165,4 +165,30 @@ describe('feature flags admin API', () => {
     expect(res.body).toEqual({ ok: true });
     expect(mocks.clearOverride).toHaveBeenCalledWith('poolMonitor', 'developer', 'dev-1');
   });
+
+  it('rate limits requests beyond the configured max', async () => {
+    // The router reads rate-limit settings from config at import time, so
+    // re-import it with a low RATE_LIMIT_MAX to exercise the 429 path.
+    const prevMax = process.env.RATE_LIMIT_MAX;
+    process.env.RATE_LIMIT_MAX = '2';
+    vi.resetModules();
+    const { featureFlagsAdminRouter: limitedRouter } = await import('../../src/api/feature-flags');
+    const app = express();
+    app.use(express.json());
+    app.use('/api/v1/admin/feature-flags', limitedRouter);
+
+    const first = await request(app).get('/api/v1/admin/feature-flags');
+    expect(first.status).toBe(200);
+    const second = await request(app).get('/api/v1/admin/feature-flags');
+    expect(second.status).toBe(200);
+    const third = await request(app).get('/api/v1/admin/feature-flags');
+    expect(third.status).toBe(429);
+    expect(third.body.error).toBe('Rate limit exceeded');
+
+    if (prevMax === undefined) {
+      delete process.env.RATE_LIMIT_MAX;
+    } else {
+      process.env.RATE_LIMIT_MAX = prevMax;
+    }
+  });
 });

--- a/tests/feature-flags/admin-api.test.ts
+++ b/tests/feature-flags/admin-api.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const mocks = vi.hoisted(() => ({
+  requireAuth: vi.fn((_req: unknown, _res: unknown, next: () => void) => next()),
+  requireRole: vi.fn(() => (_req: unknown, _res: unknown, next: () => void) => next()),
+  list: vi.fn(),
+  updateFlag: vi.fn(),
+  setOverride: vi.fn(),
+  clearOverride: vi.fn(),
+}));
+
+vi.mock('../../src/auth/middleware', () => ({
+  requireAuth: mocks.requireAuth,
+  requireRole: mocks.requireRole,
+}));
+
+vi.mock('../../src/feature-flags', () => ({
+  featureFlags: {
+    list: mocks.list,
+    updateFlag: mocks.updateFlag,
+    setOverride: mocks.setOverride,
+    clearOverride: mocks.clearOverride,
+  },
+}));
+
+import { featureFlagsAdminRouter } from '../../src/api/feature-flags';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/admin/feature-flags', featureFlagsAdminRouter);
+  return app;
+}
+
+function allowAdmin() {
+  mocks.requireAuth.mockImplementation((_req: unknown, _res: unknown, next: () => void) => next());
+  mocks.requireRole.mockImplementation(
+    () => (_req: unknown, _res: unknown, next: () => void) => next(),
+  );
+}
+
+function resolvedFlag(overrides: Record<string, unknown> = {}) {
+  return {
+    key: 'poolMonitor',
+    description: 'Pool price monitor',
+    defaultEnabled: false,
+    rolloutPercent: 0,
+    requiredTables: ['_dex_pools'],
+    enabled: false,
+    available: true,
+    reason: 'default',
+    overrides: { environment: {}, developer: {} },
+    ...overrides,
+  };
+}
+
+describe('feature flags admin API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    allowAdmin();
+    mocks.list.mockResolvedValue([resolvedFlag()]);
+    mocks.updateFlag.mockResolvedValue(resolvedFlag({ defaultEnabled: true, reason: 'default' }));
+    mocks.setOverride.mockResolvedValue(
+      resolvedFlag({
+        enabled: true,
+        reason: 'developer_override',
+        overrides: { environment: {}, developer: { 'dev-1': true } },
+      }),
+    );
+    mocks.clearOverride.mockResolvedValue(undefined);
+  });
+
+  it('blocks non-admin callers', async () => {
+    // The router captures requireRole('admin') at import time, so re-import it
+    // after swapping the mock to a 403 enforcer.
+    mocks.requireRole.mockImplementation(
+      () => (_req: unknown, res: { status: (n: number) => { json: (b: unknown) => unknown } }) =>
+        res.status(403).json({ error: 'Forbidden' }),
+    );
+    vi.resetModules();
+    const { featureFlagsAdminRouter: blockedRouter } = await import('../../src/api/feature-flags');
+    const app = express();
+    app.use(express.json());
+    app.use('/api/v1/admin/feature-flags', blockedRouter);
+
+    const res = await request(app).get('/api/v1/admin/feature-flags');
+    expect(res.status).toBe(403);
+    expect(mocks.list).not.toHaveBeenCalled();
+  });
+
+  it('lists all flags with resolved state', async () => {
+    const res = await request(buildApp()).get('/api/v1/admin/feature-flags');
+    expect(res.status).toBe(200);
+    expect(res.body.flags).toHaveLength(1);
+    expect(res.body.flags[0].key).toBe('poolMonitor');
+    expect(mocks.list).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates a flag default and rollout percent', async () => {
+    const res = await request(buildApp())
+      .put('/api/v1/admin/feature-flags/poolMonitor')
+      .send({ defaultEnabled: true, rolloutPercent: 10 });
+    expect(res.status).toBe(200);
+    expect(mocks.updateFlag).toHaveBeenCalledWith('poolMonitor', {
+      defaultEnabled: true,
+      rolloutPercent: 10,
+    });
+    expect(res.body.flag.defaultEnabled).toBe(true);
+  });
+
+  it('rejects unknown flag keys on update', async () => {
+    const res = await request(buildApp())
+      .put('/api/v1/admin/feature-flags/nope')
+      .send({ defaultEnabled: true });
+    expect(res.status).toBe(404);
+    expect(mocks.updateFlag).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty update body and out-of-range rollout', async () => {
+    const empty = await request(buildApp()).put('/api/v1/admin/feature-flags/poolMonitor').send({});
+    expect(empty.status).toBe(400);
+
+    const badRollout = await request(buildApp())
+      .put('/api/v1/admin/feature-flags/poolMonitor')
+      .send({ rolloutPercent: 101 });
+    expect(badRollout.status).toBe(400);
+  });
+
+  it('sets a per-developer override', async () => {
+    const res = await request(buildApp())
+      .put('/api/v1/admin/feature-flags/poolMonitor/overrides/developer/dev-1')
+      .send({ enabled: true });
+    expect(res.status).toBe(200);
+    expect(mocks.setOverride).toHaveBeenCalledWith('poolMonitor', 'developer', 'dev-1', true);
+    expect(res.body.flag.overrides.developer['dev-1']).toBe(true);
+  });
+
+  it('sets a per-environment override', async () => {
+    const res = await request(buildApp())
+      .put('/api/v1/admin/feature-flags/poolMonitor/overrides/environment/mainnet')
+      .send({ enabled: false });
+    expect(res.status).toBe(200);
+    expect(mocks.setOverride).toHaveBeenCalledWith('poolMonitor', 'environment', 'mainnet', false);
+  });
+
+  it('rejects invalid scope types and non-boolean enabled', async () => {
+    const badScope = await request(buildApp())
+      .put('/api/v1/admin/feature-flags/poolMonitor/overrides/team/eng')
+      .send({ enabled: true });
+    expect(badScope.status).toBe(400);
+
+    const badEnabled = await request(buildApp())
+      .put('/api/v1/admin/feature-flags/poolMonitor/overrides/developer/dev-1')
+      .send({ enabled: 'yes' });
+    expect(badEnabled.status).toBe(400);
+  });
+
+  it('clears an override', async () => {
+    const res = await request(buildApp()).delete(
+      '/api/v1/admin/feature-flags/poolMonitor/overrides/developer/dev-1',
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(mocks.clearOverride).toHaveBeenCalledWith('poolMonitor', 'developer', 'dev-1');
+  });
+});

--- a/tests/feature-flags/evaluate.test.ts
+++ b/tests/feature-flags/evaluate.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateFlag,
+  inRollout,
+  stableHash,
+  type FlagSnapshot,
+} from '../../src/feature-flags/evaluate';
+
+function snapshot(partial: Partial<FlagSnapshot> = {}): FlagSnapshot {
+  return {
+    key: 'poolMonitor',
+    defaultEnabled: false,
+    rolloutPercent: 0,
+    environmentOverrides: new Map(),
+    developerOverrides: new Map(),
+    ...partial,
+  };
+}
+
+function evalWith(
+  snap: FlagSnapshot,
+  opts: {
+    environment?: string;
+    developerId?: string;
+    envVarValue?: string;
+    envOverrides?: Record<string, boolean>;
+    devOverrides?: Record<string, boolean>;
+  } = {},
+) {
+  return evaluateFlag({
+    snapshot: {
+      ...snap,
+      environmentOverrides: new Map(Object.entries(opts.envOverrides ?? {})),
+      developerOverrides: new Map(Object.entries(opts.devOverrides ?? {})),
+    },
+    overrides: {
+      environment: new Map(Object.entries(opts.envOverrides ?? {})),
+      developer: new Map(Object.entries(opts.devOverrides ?? {})),
+    },
+    environment: opts.environment ?? 'testnet',
+    developerId: opts.developerId,
+    envVarValue: opts.envVarValue,
+  });
+}
+
+describe('evaluateFlag', () => {
+  it('falls back to the DB default when nothing else is set', () => {
+    expect(evalWith(snapshot({ defaultEnabled: false }))).toEqual({
+      enabled: false,
+      reason: 'default',
+    });
+    expect(evalWith(snapshot({ defaultEnabled: true }))).toEqual({
+      enabled: true,
+      reason: 'default',
+    });
+  });
+
+  it('developer override beats environment override, env var, rollout, and default', () => {
+    const result = evalWith(snapshot({ defaultEnabled: false, rolloutPercent: 100 }), {
+      developerId: 'dev-1',
+      devOverrides: { 'dev-1': true },
+      envOverrides: { testnet: false },
+      envVarValue: 'false',
+    });
+    expect(result).toEqual({ enabled: true, reason: 'developer_override' });
+  });
+
+  it('developer override only applies to that developer', () => {
+    const result = evalWith(snapshot(), {
+      developerId: 'dev-2',
+      devOverrides: { 'dev-1': true },
+    });
+    expect(result.enabled).toBe(false);
+  });
+
+  it('environment override beats env var, rollout, and default', () => {
+    const result = evalWith(snapshot({ defaultEnabled: false, rolloutPercent: 100 }), {
+      envOverrides: { testnet: true },
+      envVarValue: 'false',
+    });
+    expect(result).toEqual({ enabled: true, reason: 'environment_override' });
+  });
+
+  it('environment override is scoped to the matching environment', () => {
+    const result = evalWith(snapshot(), {
+      environment: 'mainnet',
+      envOverrides: { testnet: true },
+    });
+    expect(result.enabled).toBe(false);
+  });
+
+  it('env var forces on with true/1 and off with anything else', () => {
+    for (const v of ['true', '1', ' TRUE ', '1']) {
+      expect(evalWith(snapshot({ defaultEnabled: false }), { envVarValue: v }).enabled).toBe(true);
+    }
+    for (const v of ['false', '0', 'banana', '']) {
+      expect(evalWith(snapshot({ defaultEnabled: true }), { envVarValue: v }).enabled).toBe(false);
+    }
+    expect(evalWith(snapshot({ defaultEnabled: false }), { envVarValue: undefined }).enabled).toBe(
+      false,
+    );
+  });
+
+  it('env var loses to environment override but wins over rollout', () => {
+    const snap = snapshot({ defaultEnabled: false, rolloutPercent: 100 });
+    const envResult = evalWith(snap, { envVarValue: 'false', envOverrides: { testnet: true } });
+    expect(envResult.reason).toBe('environment_override');
+    const rolloutResult = evalWith(snapshot({ defaultEnabled: false, rolloutPercent: 0 }), {
+      envVarValue: 'true',
+      developerId: 'dev-1',
+    });
+    expect(rolloutResult).toEqual({ enabled: true, reason: 'env_var' });
+  });
+
+  it('rolloutPercent 100 is on, 0 is off, without touching the hash', () => {
+    expect(
+      evalWith(snapshot({ defaultEnabled: false, rolloutPercent: 100 }), {
+        developerId: 'anyone',
+      }).reason,
+    ).toBe('rollout');
+    expect(evalWith(snapshot({ defaultEnabled: true, rolloutPercent: 0 })).enabled).toBe(true);
+  });
+
+  it('rollout is bucketed per developerId and skipped for anonymous callers', () => {
+    const snap = snapshot({ defaultEnabled: false, rolloutPercent: 50 });
+    // Anonymous → no stable bucket → default.
+    expect(evalWith(snap).enabled).toBe(false);
+    // Named developer → bucket decides.
+    const r = evalWith(snap, { developerId: 'dev-abc' });
+    expect(r.reason).toBe('rollout');
+    expect(typeof r.enabled).toBe('boolean');
+  });
+});
+
+describe('inRollout / stableHash', () => {
+  it('is deterministic for the same (key, developerId)', () => {
+    const a = inRollout('poolMonitor', 'dev-1', 42);
+    const b = inRollout('poolMonitor', 'dev-1', 42);
+    expect(a).toBe(b);
+  });
+
+  it('is monotonic: an account in at pct is also in at a higher pct', () => {
+    let changed = 0;
+    for (let i = 0; i < 500; i++) {
+      const dev = `dev-${i}`;
+      const low = inRollout('poolMonitor', dev, 20);
+      const high = inRollout('poolMonitor', dev, 80);
+      if (low && !high) changed++;
+      expect(!low || high).toBe(true);
+    }
+    expect(changed).toBe(0);
+  });
+
+  it('roughly respects the percentage across many accounts', () => {
+    const total = 2000;
+    const in10 = Array.from({ length: total }, (_, i) =>
+      inRollout('feeAggregator', `dev-${i}`, 10),
+    ).filter(Boolean).length;
+    expect(in10).toBeGreaterThan(total * 0.05);
+    expect(in10).toBeLessThan(total * 0.15);
+  });
+
+  it('buckets differ across flags for the same developer', () => {
+    const buckets = new Set<number>();
+    for (let i = 0; i < 100; i++) {
+      buckets.add(stableHash(`${'flagA'}:dev-x`) === stableHash(`${'flagA'}:dev-x`) ? 0 : 1);
+    }
+    // identical inputs → identical hash
+    expect(stableHash('flagA:dev-x')).toBe(stableHash('flagA:dev-x'));
+    expect(stableHash('flagA:dev-x')).not.toBe(stableHash('flagB:dev-x'));
+  });
+});

--- a/tests/feature-flags/schema.test.ts
+++ b/tests/feature-flags/schema.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// schema.ts pulls prismaRead from db.ts → config.ts → profile validation, which
+// requires DATABASE_URL. All checks here inject their own client, so stub the
+// module to keep this unit test standalone.
+vi.mock('../../src/db', () => ({
+  prismaRead: {},
+}));
+
+import {
+  loadExistingTables,
+  tablesExist,
+  tablesExistSync,
+  invalidateSchemaCache,
+} from '../../src/feature-flags/schema';
+
+describe('feature-flag schema availability', () => {
+  let client: { $queryRawUnsafe: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    invalidateSchemaCache();
+    client = { $queryRawUnsafe: vi.fn() };
+  });
+
+  afterEach(() => {
+    invalidateSchemaCache();
+    vi.restoreAllMocks();
+  });
+
+  it('returns true when every required table exists', async () => {
+    client.$queryRawUnsafe.mockResolvedValue([
+      { table_name: '_dex_pools' },
+      { table_name: '_pool_prices' },
+      { table_name: '_price_deviations' },
+    ]);
+    expect(
+      await tablesExist(['_dex_pools', '_pool_prices', '_price_deviations'], client as never),
+    ).toBe(true);
+  });
+
+  it('returns false when any required table is missing', async () => {
+    client.$queryRawUnsafe.mockResolvedValue([{ table_name: '_dex_pools' }]);
+    expect(await tablesExist(['_dex_pools', '_pool_prices'], client as never)).toBe(false);
+  });
+
+  it('treats an empty table list as always available', async () => {
+    expect(await tablesExist([], client as never)).toBe(true);
+  });
+
+  it('caches the table list within the TTL', async () => {
+    client.$queryRawUnsafe.mockResolvedValue([{ table_name: '_dex_pools' }]);
+    await tablesExist(['_dex_pools'], client as never);
+    await tablesExist(['_dex_pools'], client as never);
+    expect(client.$queryRawUnsafe).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails safe (all tables missing) when the DB errors', async () => {
+    client.$queryRawUnsafe.mockRejectedValue(new Error('db down'));
+    expect(await tablesExist(['_dex_pools'], client as never)).toBe(false);
+    // sync view agrees after the failed load
+    expect(tablesExistSync(['_dex_pools'])).toBe(false);
+  });
+
+  it('tablesExistSync reflects the cached list after a warm-up', async () => {
+    client.$queryRawUnsafe.mockResolvedValue([
+      { table_name: '_dex_pools' },
+      { table_name: '_pool_prices' },
+    ]);
+    await loadExistingTables(client as never);
+    expect(tablesExistSync(['_dex_pools', '_pool_prices'])).toBe(true);
+    expect(tablesExistSync(['_fee_events'])).toBe(false);
+  });
+
+  it('tablesExistSync reports unavailable while the cache is cold', () => {
+    expect(tablesExistSync(['_dex_pools'])).toBe(false);
+  });
+});

--- a/tests/feature-flags/service.test.ts
+++ b/tests/feature-flags/service.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../src/config', () => ({
+  config: { stellarNetwork: 'testnet' },
+}));
+
+vi.mock('../../src/db', () => ({
+  prismaRead: {
+    featureFlag: { findMany: vi.fn() },
+    $queryRawUnsafe: vi.fn(),
+  },
+  prismaWrite: {
+    featureFlag: { upsert: vi.fn() },
+    featureFlagOverride: { upsert: vi.fn(), deleteMany: vi.fn() },
+  },
+}));
+
+import { prismaRead, prismaWrite } from '../../src/db';
+import { featureFlags } from '../../src/feature-flags';
+import { invalidateSchemaCache } from '../../src/feature-flags/schema';
+
+function flagRow(
+  overrides: Array<Record<string, unknown>> = [],
+  extra: Partial<{ defaultEnabled: boolean; rolloutPercent: number }> = {},
+) {
+  return {
+    key: 'poolMonitor',
+    defaultEnabled: false,
+    rolloutPercent: 0,
+    overrides,
+    ...extra,
+  };
+}
+
+describe('FeatureFlags service', () => {
+  beforeEach(() => {
+    invalidateSchemaCache();
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    (prismaRead.featureFlag.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (prismaWrite.featureFlag.upsert as ReturnType<typeof vi.fn>).mockResolvedValue(
+      flagRow() as never,
+    );
+    (prismaWrite.featureFlagOverride.upsert as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (prismaWrite.featureFlagOverride.deleteMany as ReturnType<typeof vi.fn>).mockResolvedValue({
+      count: 0,
+    });
+    (prismaRead.$queryRawUnsafe as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { table_name: '_dex_pools' },
+      { table_name: '_pool_prices' },
+      { table_name: '_price_deviations' },
+      { table_name: '_arbitrage_opportunities' },
+    ]);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    invalidateSchemaCache();
+  });
+
+  it('falls back to the legacy env var when the DB cache is empty (no rows)', async () => {
+    // Cache cold + DB returns no rows → env var decides.
+    vi.stubEnv('ENABLE_POOL_MONITOR', 'true');
+    expect(featureFlags.isEnabledSync('poolMonitor')).toBe(true);
+    vi.stubEnv('ENABLE_POOL_MONITOR', 'false');
+    expect(featureFlags.isEnabledSync('poolMonitor')).toBe(false);
+    vi.unstubAllEnvs();
+    expect(featureFlags.isEnabledSync('poolMonitor')).toBe(false);
+  });
+
+  it('uses the DB default once a row exists and no env var is set', async () => {
+    (prismaRead.featureFlag.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([flagRow()]);
+    await featureFlags.bootstrap();
+    expect(featureFlags.isEnabledSync('poolMonitor')).toBe(false);
+
+    (prismaRead.featureFlag.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      flagRow([], { defaultEnabled: true }),
+    ]);
+    await featureFlags.refresh();
+    expect(featureFlags.isEnabledSync('poolMonitor')).toBe(true);
+  });
+
+  it('honors a developer override from the DB (per-account toggle)', async () => {
+    (prismaRead.featureFlag.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      flagRow([
+        { scopeType: 'developer', scopeValue: 'dev-1', enabled: true },
+        { scopeType: 'developer', scopeValue: 'dev-2', enabled: false },
+      ]),
+    ]);
+    await featureFlags.bootstrap();
+    expect(featureFlags.isEnabledSync('poolMonitor')).toBe(false);
+    expect(featureFlags.isEnabledForDeveloper('poolMonitor', 'dev-1')).toBe(true);
+    expect(featureFlags.isEnabledForDeveloper('poolMonitor', 'dev-2')).toBe(false);
+    expect(featureFlags.isEnabledSync('poolMonitor', { developerId: 'dev-1' })).toBe(true);
+  });
+
+  it('honors an environment override scoped to the current network', async () => {
+    (prismaRead.featureFlag.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      flagRow([{ scopeType: 'environment', scopeValue: 'testnet', enabled: true }]),
+    ]);
+    await featureFlags.bootstrap();
+    expect(featureFlags.isEnabledSync('poolMonitor')).toBe(true);
+    // Other environments are unaffected.
+    expect(featureFlags.isEnabledSync('poolMonitor', { environment: 'mainnet' })).toBe(false);
+  });
+
+  it('applies gradual rollout to named developers only', async () => {
+    (prismaRead.featureFlag.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      flagRow([], { defaultEnabled: false, rolloutPercent: 50 }),
+    ]);
+    await featureFlags.bootstrap();
+    // Anonymous callers skip the bucket and get the default.
+    expect(featureFlags.isEnabledSync('poolMonitor')).toBe(false);
+
+    // Named developers are bucketed — some on, some off, stable across calls.
+    const inBucket = new Set<boolean>();
+    for (let i = 0; i < 200; i++) {
+      const on = featureFlags.isEnabledForDeveloper('poolMonitor', `dev-${i}`);
+      expect(on).toBe(featureFlags.isEnabledForDeveloper('poolMonitor', `dev-${i}`));
+      inBucket.add(on);
+    }
+    expect(inBucket.has(true)).toBe(true);
+    expect(inBucket.has(false)).toBe(true);
+  });
+
+  it('shouldStartSync requires the toggle AND schema availability', async () => {
+    (prismaRead.featureFlag.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      flagRow([], { defaultEnabled: true }),
+    ]);
+    await featureFlags.bootstrap();
+
+    // Tables exist → start.
+    expect(featureFlags.isAvailableSync('poolMonitor')).toBe(true);
+    expect(featureFlags.shouldStartSync('poolMonitor')).toBe(true);
+
+    // Missing required table → flag on but schema unavailable → do not start.
+    (prismaRead.$queryRawUnsafe as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { table_name: '_dex_pools' },
+    ]);
+    await featureFlags.refresh();
+    expect(featureFlags.isEnabledSync('poolMonitor')).toBe(true);
+    expect(featureFlags.isAvailableSync('poolMonitor')).toBe(false);
+    expect(featureFlags.shouldStartSync('poolMonitor')).toBe(false);
+  });
+
+  it('a flag without requiredTables is always available', async () => {
+    expect(featureFlags.isAvailableSync('composabilityWs')).toBe(true);
+    expect(featureFlags.shouldStartSync('composabilityWs')).toBe(false); // default off
+  });
+});

--- a/tests/feature-flags/store.test.ts
+++ b/tests/feature-flags/store.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The store's default clients import db.ts → config.ts → profile validation,
+// which requires DATABASE_URL. The store under test injects its own clients, so
+// stub the module to keep this unit test standalone.
+vi.mock('../../src/db', () => ({
+  prismaRead: {},
+  prismaWrite: {},
+}));
+
+import { FeatureFlagStore, FLAG_CACHE_TTL_MS } from '../../src/feature-flags/store';
+import { listFlagDefinitions } from '../../src/feature-flags/registry';
+
+// Narrow helper types for the mocks used by the store.
+type MockClient = {
+  featureFlag: {
+    findMany: ReturnType<typeof vi.fn>;
+    upsert: ReturnType<typeof vi.fn>;
+  };
+  featureFlagOverride: {
+    upsert: ReturnType<typeof vi.fn>;
+    deleteMany: ReturnType<typeof vi.fn>;
+  };
+};
+function makeRead(): MockClient {
+  return {
+    featureFlag: { findMany: vi.fn(), upsert: vi.fn() },
+    featureFlagOverride: { upsert: vi.fn(), deleteMany: vi.fn() },
+  };
+}
+function makeWrite(): MockClient {
+  return {
+    featureFlag: { findMany: vi.fn(), upsert: vi.fn() },
+    featureFlagOverride: { upsert: vi.fn(), deleteMany: vi.fn() },
+  };
+}
+
+describe('FeatureFlagStore', () => {
+  let read: MockClient;
+  let write: MockClient;
+  let store: FeatureFlagStore;
+
+  beforeEach(() => {
+    read = makeRead();
+    write = makeWrite();
+    read.featureFlag.findMany.mockResolvedValue([]);
+    write.featureFlag.upsert.mockImplementation(
+      async (args: {
+        create: {
+          key: string;
+          defaultEnabled: boolean;
+          rolloutPercent: number;
+          description?: string;
+        };
+      }) => ({
+        key: args.create.key,
+        defaultEnabled: args.create.defaultEnabled,
+        rolloutPercent: args.create.rolloutPercent,
+        overrides: [],
+      }),
+    );
+    write.featureFlagOverride.upsert.mockResolvedValue({});
+    write.featureFlagOverride.deleteMany.mockResolvedValue({ count: 0 });
+    store = new FeatureFlagStore(read as never, write as never);
+  });
+
+  it('loads flag rows and groups overrides by scope type', async () => {
+    read.featureFlag.findMany.mockResolvedValue([
+      {
+        key: 'poolMonitor',
+        defaultEnabled: false,
+        rolloutPercent: 25,
+        overrides: [
+          { scopeType: 'environment', scopeValue: 'testnet', enabled: true },
+          { scopeType: 'developer', scopeValue: 'dev-1', enabled: true },
+          { scopeType: 'developer', scopeValue: 'dev-2', enabled: false },
+        ],
+      },
+    ]);
+
+    const flags = await store.load();
+    const snap = flags.get('poolMonitor');
+    expect(snap?.defaultEnabled).toBe(false);
+    expect(snap?.rolloutPercent).toBe(25);
+    expect(snap?.environmentOverrides.get('testnet')).toBe(true);
+    expect(snap?.developerOverrides.get('dev-1')).toBe(true);
+    expect(snap?.developerOverrides.get('dev-2')).toBe(false);
+  });
+
+  it('caches within TTL and reloads after invalidation', async () => {
+    read.featureFlag.findMany.mockResolvedValue([
+      { key: 'poolMonitor', defaultEnabled: false, rolloutPercent: 0, overrides: [] },
+    ]);
+    await store.load();
+    await store.load();
+    expect(read.featureFlag.findMany).toHaveBeenCalledTimes(1);
+
+    read.featureFlag.findMany.mockResolvedValue([
+      { key: 'poolMonitor', defaultEnabled: true, rolloutPercent: 0, overrides: [] },
+    ]);
+    store.invalidate();
+    await store.load();
+    expect(read.featureFlag.findMany).toHaveBeenCalledTimes(2);
+    expect(store.getCachedSync('poolMonitor')?.defaultEnabled).toBe(true);
+  });
+
+  it('treats a stale cache as fresh for only FLAG_CACHE_TTL_MS', async () => {
+    expect(FLAG_CACHE_TTL_MS).toBeGreaterThan(0);
+    const snap = await store.load();
+    expect(snap.size).toBe(0);
+    expect(store.getCachedSync('poolMonitor')).toBeUndefined();
+  });
+
+  it('returns an empty snapshot map when the DB read fails (graceful degradation)', async () => {
+    read.featureFlag.findMany.mockRejectedValue(new Error('db down'));
+    const flags = await store.load();
+    expect(flags.size).toBe(0);
+    expect(store.getCachedSync('poolMonitor')).toBeUndefined();
+  });
+
+  it('ensureRegisteredFlags seeds a row per registered definition and keeps operator values', async () => {
+    await store.ensureRegisteredFlags();
+    const keys = write.featureFlag.upsert.mock.calls.map(
+      (c) => (c[0] as { create: { key: string } }).create.key,
+    );
+    expect(keys.sort()).toEqual(
+      listFlagDefinitions()
+        .map((d) => d.key)
+        .sort(),
+    );
+    // update only touches description, never default/rollout
+    for (const call of write.featureFlag.upsert.mock.calls) {
+      expect(call[0].update).toEqual({ description: expect.any(String) });
+    }
+  });
+
+  it('updateFlag upserts and returns a snapshot, invalidating the cache', async () => {
+    write.featureFlag.upsert.mockResolvedValue({
+      key: 'poolMonitor',
+      defaultEnabled: true,
+      rolloutPercent: 10,
+      overrides: [],
+    });
+    const snap = await store.updateFlag('poolMonitor', {
+      defaultEnabled: true,
+      rolloutPercent: 10,
+    });
+    expect(snap.defaultEnabled).toBe(true);
+    expect(snap.rolloutPercent).toBe(10);
+    // cache was invalidated → next load hits the DB
+    read.featureFlag.findMany.mockResolvedValue([
+      { key: 'poolMonitor', defaultEnabled: true, rolloutPercent: 10, overrides: [] },
+    ]);
+    await store.load();
+    expect(read.featureFlag.findMany).toHaveBeenCalled();
+  });
+
+  it('setOverride upserts with the unique compound key and invalidates', async () => {
+    await store.setOverride('poolMonitor', 'developer', 'dev-1', true);
+    expect(write.featureFlagOverride.upsert).toHaveBeenCalledWith({
+      where: {
+        flagKey_scopeType_scopeValue: {
+          flagKey: 'poolMonitor',
+          scopeType: 'developer',
+          scopeValue: 'dev-1',
+        },
+      },
+      create: {
+        flagKey: 'poolMonitor',
+        scopeType: 'developer',
+        scopeValue: 'dev-1',
+        enabled: true,
+      },
+      update: { enabled: true },
+    });
+  });
+
+  it('clearOverride deletes the matching row and invalidates', async () => {
+    await store.clearOverride('poolMonitor', 'environment', 'testnet');
+    expect(write.featureFlagOverride.deleteMany).toHaveBeenCalledWith({
+      where: { flagKey: 'poolMonitor', scopeType: 'environment', scopeValue: 'testnet' },
+    });
+  });
+});


### PR DESCRIPTION

Closes #750

## Summary

Implements the review finding on the optional background services: features were **either fully on or off**, gated only by boot-time `ENABLE_*` env vars tied to schema availability — no gradual rollout, no runtime control, no per-account or per-environment toggles.

This PR introduces a **DB-backed feature-flag system** with **per-environment** and **per-developer** toggles plus **deterministic gradual rollout**, while keeping the legacy `ENABLE_*` vars working unchanged as the per-environment bootstrap layer.

## What changed

**New feature-flag core (`src/feature-flags/`)**
- `registry.ts` — declarative definitions for the six optional services (pool monitor, arbitrage scanner, fee aggregator, privacy/composability/arbitrage WebSockets) with legacy env vars and required tables.
- `evaluate.ts` — pure layered evaluation: **developer override > environment override > env var > rollout % > default**, with stable FNV-1a per-account bucketing (monotonic rollouts).
- `store.ts` — cached (30 s TTL) DB load/write, auto-seeds rows for registered flags, degrades gracefully when the DB is unreachable.
- `schema.ts` — cached `information_schema` table checks; a feature whose required tables are missing is never started.
- `index.ts` — public `featureFlags` singleton (`isEnabledSync`, `isEnabled`, `isEnabledForDeveloper`, `isAvailableSync`, `shouldStartSync`, `list`, admin writes).

**Data model (migration `20260825000000_feature_flags`)**
- `FeatureFlag` — per-flag `defaultEnabled` + `rolloutPercent`.
- `FeatureFlagOverride` — `(flag_key, scope_type, scope_value)` rows for `environment` (Stellar network) and `developer` scopes.

**Wiring**
- `src/services.ts` / `src/server.ts` — the six services now gate on `shouldStartSync(flag)`; `/ready` distinguishes `"<service> (flag off)"` from `"<service> (schema unavailable)"`.
- `src/index.ts` — `featureFlags.bootstrap()` warms the cache before servers attach (best-effort; boot never blocks on the flag DB).

**Admin API** (`/api/v1/admin/feature-flags`, admin role)
- `GET /` — list flags with resolved state, reason, availability, overrides.
- `PUT /:key` — set `defaultEnabled` / `rolloutPercent`.
- `PUT|DELETE /:key/overrides/:scopeType/:scopeValue` — per-environment / per-developer toggles, applied at runtime without a redeploy.

**Docs/config** — `docs/FEATURE_FLAGS.md`, updated `.env.example` and `k8s/configmap.yaml`.

## Backward compatibility

- Existing `ENABLE_*` vars keep their meaning (now the env-var layer, evaluated per boot).
- Without a DB row and without an env var, behavior is identical to today (features default off).
- `/ready` still lists disabled services under `disabledServices` (with a reason suffix).

## Testing

- **44 new tests** in `tests/feature-flags/` covering: precedence layering, env-var semantics, rollout determinism/monotonicity/thresholds, anonymous fallthrough, store caching + override writes, schema availability, and the admin API (auth enforcement, validation, CRUD).
- Existing default suite passes: **224/224** (`npm test`).
- ESLint clean on all new/changed files; `tsc --noEmit` clean for changed files.

## Rollout

1. Deploy the migration (`prisma migrate deploy`) — the new tables are additive.
2. Flags are seeded on first boot from the registry defaults.
3. Use the admin API or env vars to enable/ramp features per environment; per-developer overrides enable beta access for specific accounts.

## Related docs

- `docs/FEATURE_FLAGS.md` — resolution order, rollout semantics, admin API examples, caching notes.
