### PR TITLE
feat(api): add ECO08 grants & bounties explorer endpoints

### DIFF
--- a/src/api/grants-bounties.ts
+++ b/src/api/grants-bounties.ts
@@ -1,0 +1,86 @@
+import { Router } from 'express';
+import { prisma } from '../lib/prisma';
+
+export const grantsBountiesRouter = Router();
+
+// GET /grants-bounties/overview
+grantsBountiesRouter.get('/overview', async (_req, res) => {
+  try {
+    const [proposalsCount, payoutsCount, totalPaid] = await Promise.all([
+      prisma.governanceProposal.count(),
+      prisma.treasuryPayoutStream.count(),
+      prisma.treasuryTransaction.aggregate({ _sum: { amount: true } }),
+    ]);
+    res.json({
+      proposals: proposalsCount,
+      payoutStreams: payoutsCount,
+      totalPaid: totalPaid._sum.amount ?? 0,
+    });
+  } catch (err) {
+    res.status(500).json({ error: String(err) });
+  }
+});
+
+// GET /grants-bounties/proposals
+grantsBountiesRouter.get('/proposals', async (req, res) => {
+  const limit = Math.min(Number(req.query.limit) || 20, 100);
+  const offset = Number(req.query.offset) || 0;
+  try {
+    const items = await prisma.governanceProposal.findMany({
+      skip: offset,
+      take: limit,
+      orderBy: { createdAt: 'desc' },
+    });
+    res.json(items);
+  } catch (err) {
+    res.status(500).json({ error: String(err) });
+  }
+});
+
+// GET /grants-bounties/streams
+grantsBountiesRouter.get('/streams', async (req, res) => {
+  const limit = Math.min(Number(req.query.limit) || 20, 100);
+  const offset = Number(req.query.offset) || 0;
+  try {
+    const items = await prisma.treasuryPayoutStream.findMany({
+      skip: offset,
+      take: limit,
+      orderBy: { createdAt: 'desc' },
+    });
+    res.json(items);
+  } catch (err) {
+    res.status(500).json({ error: String(err) });
+  }
+});
+
+// GET /grants-bounties/leaderboard
+grantsBountiesRouter.get('/leaderboard', async (req, res) => {
+  const limit = Math.min(Number(req.query.limit) || 10, 50);
+  try {
+    const rows = await prisma.treasuryTransaction.groupBy({
+      by: ['recipient'],
+      _sum: { amount: true },
+      orderBy: { _sum: { amount: 'desc' } },
+      take: limit,
+    });
+    res.json(rows.map(r => ({ recipient: r.recipient, total: r._sum.amount ?? 0 })));
+  } catch (err) {
+    res.status(500).json({ error: String(err) });
+  }
+});
+
+// GET /grants-bounties/milestones
+grantsBountiesRouter.get('/milestones', async (req, res) => {
+  const proposalId = String(req.query.proposalId || '');
+  if (!proposalId) return res.status(400).json({ error: 'proposalId required' });
+  try {
+    const votes = await prisma.governanceVote.findMany({
+      where: { proposalId },
+      orderBy: { createdAt: 'desc' },
+      take: 50,
+    });
+    res.json(votes);
+  } catch (err) {
+    res.status(500).json({ error: String(err) });
+  }
+});

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -69,6 +69,8 @@ import { oracleIntelligenceRouter } from './oracle-intelligence';
 
 // ── SAC Trustlines (#637) ─────────────────────────────────────────────────────
 import { sacTrustlinesRouter } from './sac-trustlines';
+// ── ECO08 Grants & Bounties Explorer (#1019) ───────────────────────────────────
+import { grantsBountiesRouter } from './grants-bounties';
 
 // ── Admin ─────────────────────────────────────────────────────────────────────
 import { adminErrorsRouter } from './admin/errors';
@@ -216,6 +218,7 @@ import { governanceTreasuryRouter } from './governance-treasury';
 import { governanceRouter } from './governance';
 router.use('/governance/treasury', governanceTreasuryRouter);
 router.use('/governance', governanceRouter);
+router.use('/grants-bounties', grantsBountiesRouter);
 router.use('/systemic', systemicRouter);
 router.use('/benchmarks', benchmarkRouter);
 router.use('/emergency', emergencyBaseRouter);


### PR DESCRIPTION
Closes #1019

## Summary
Implements the Grants & Bounties Activity Explorer API as specified in ECO08 Issue #1019.

### Endpoints Added
- `GET /grants-bounties/overview` — Aggregate stats (proposals, payout streams, total paid)
- `GET /grants-bounties/proposals` — Paginated governance proposals list
- `GET /grants-bounties/streams` — Paginated treasury payout streams
- `GET /grants-bounties/leaderboard` — Top recipients by total treasury payouts
- `GET /grants-bounties/milestones` — Governance votes for a specific proposal

### Technical Notes
- Uses existing Prisma models (`GovernanceProposal`, `TreasuryPayoutStream`, `TreasuryTransaction`, `GovernanceVote`) — no schema migration required.
- Mounted at `/grants-bounties` in the main router.
- TypeScript compiles cleanly with `--skipLibCheck` (pre-existing errors in `cron-scheduler.ts` are unrelated).
