### PR TITLE
feat(observability,performance): RPC/cron/error-queue metrics + per-route cache TTLs (Closes #910, #911, #912, #917)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -455,15 +455,13 @@ model LedgerGap {
   @@map("_ledger_gaps")
 }
 
-/**
- * Persists per-batch progress for parallel catch-up workers (issue #881).
- * Each row records one [rangeStart, rangeEnd] chunk assigned to a worker.
- * On crash-restart the indexer resumes from `lastCommittedLedger` rather
- * than re-fetching from `rangeStart`.
- *
- * Composite unique key: (rangeStart, rangeEnd) so concurrent workers
- * targeting the same chunk upsert rather than create duplicate rows.
- */
+/// Persists per-batch progress for parallel catch-up workers (issue #881).
+/// Each row records one [rangeStart, rangeEnd] chunk assigned to a worker.
+/// On crash-restart the indexer resumes from `lastCommittedLedger` rather
+/// than re-fetching from `rangeStart`.
+///
+/// Composite unique key: (rangeStart, rangeEnd) so concurrent workers
+/// targeting the same chunk upsert rather than create duplicate rows.
 model CatchUpCheckpoint {
   id                  String   @map("id") @id @default(cuid())
   /// First ledger of the worker's assigned chunk

--- a/scripts/validate-routes.ts
+++ b/scripts/validate-routes.ts
@@ -80,7 +80,6 @@ const PENDING_SCHEMA_ROUTERS = new Set([
   'tax.ts',
   'tip.ts',
   'treasury.ts',
-  'upgrade-trace.ts',
   'virtualList.ts',
   'yield.ts',
 ]);
@@ -148,16 +147,28 @@ function findMountedRouters(): Set<string> {
 }
 
 /**
- * Extract router.use() prefixes from router.ts
+ * Extract router.use() prefixes from router.ts.
+ *
+ * Only mounts that pass a real router (an argument identifier ending in
+ * "Router"/"router") are recorded. Middleware-only mounts such as
+ * `router.use('/admin', adminRateLimit)` (#889) legitimately share a prefix
+ * with a real router mount without being a router themselves — counting them
+ * would raise a false "exact duplicate" route conflict.
  */
 function extractMountedPrefixes(): string[] {
   const content = fs.readFileSync(ROUTER_FILE, 'utf-8');
-  const useRegex = /router\.use\(['"]([^'"]+)['"]/g;
+  const useCallRegex = /router\.use\(\s*['"]([^'"]+)['"]\s*([\s\S]*?)\)\s*;/g;
   const prefixes: string[] = [];
 
-  let match;
-  while ((match = useRegex.exec(content)) !== null) {
-    prefixes.push(match[1]);
+  let match: RegExpExecArray | null;
+  while ((match = useCallRegex.exec(content)) !== null) {
+    const args = match[2] ?? '';
+    const hasRouterArg =
+      /[A-Za-z0-9_$]*[Rr]outer[s]?[^A-Za-z0-9_$]/.test(args) ||
+      /(^|[^A-Za-z0-9_$])[A-Za-z0-9_$]*[Rr]outer[s]?$/.test(args);
+    if (hasRouterArg) {
+      prefixes.push(match[1]);
+    }
   }
 
   return prefixes;

--- a/src/cache-ttl.ts
+++ b/src/cache-ttl.ts
@@ -1,0 +1,68 @@
+/**
+ * #917 — Per-route cache TTL policy registry.
+ *
+ * Single source of truth for intended cache freshness per resource. Previously
+ * most cacheSet() calls relied on module defaults: in-memory entries expired
+ * after CACHE_MEMORY_TTL (300s) and Redis entries without an explicit TTL
+ * never expired — so volatile data (latest ledger, prices, fee stats) could be
+ * served stale for up to 5 minutes while stable data (ABIs, contract metadata)
+ * was either unbounded or thrashed by expiring too soon. Tuning was ad-hoc and
+ * impossible to audit.
+ *
+ * Every cache key's first `:`-delimited segment is mapped to a resource here;
+ * cacheSet() resolves the TTL from this registry when the caller doesn't pass
+ * an explicit one (explicit TTLs always win). Volatile resources get short
+ * TTLs (seconds), stable resources long TTLs (hours–days).
+ */
+export const RESOURCE_TTL_SECONDS = {
+  // ── Volatile resources — seconds ─────────────────────────────────────────
+  // Market/chain data that goes stale within seconds-to-a-minute.
+  cg_price: 30, // CoinGecko price feed
+  cmc_price: 30, // CoinMarketCap price feed
+  se_price: 30, // StellarExpert price feed
+  chain_price: 30, // on-chain derived cross-chain price
+  dex_price: 5, // DEX pool price (real-time)
+  composite_price: 5, // composite oracle price (real-time)
+  arbitrage: 5, // arbitrage opportunities / graph (real-time)
+  graph: 5, // arbitrage engine graph snapshot
+  fee: 60, // fee stats / gas estimates
+
+  // ── Stable resources — minutes to days ────────────────────────────────────
+  // Immutable or slowly-changing data that benefits from long TTLs.
+  abi: 7 * 86400, // contract ABIs are immutable — 7 days
+  'token-metadata': 3600, // token symbol/name/decimals — 1 hour
+  'classic-asset': 86400, // classic asset metadata — 1 day
+  ledger: 86400, // historical ledger snapshots are immutable — 1 day
+  proof: 86400, // deterministic audit proofs — 1 day
+  'audit-verify': 3600, // audit verification results — 1 hour
+  'audit-anchor': 600, // anchor audit tree — 10 minutes
+  'audit-embed': 300, // embedded audit snippet — 5 minutes
+  'audit-auditors': 3600, // auditor directory — 1 hour
+  'contract-audit': 120, // per-contract audit result — 2 minutes
+  'audit-benchmark': 600, // benchmark snapshots — 10 minutes
+  'audit-bot': 120, // bot audit results — 2 minutes
+  'materialized-views': 300, // analytics materialized view cache — 5 minutes
+  auth: 3600, // auth keys/sessions — 1 hour
+  profile: 3600, // IPFS profiles — 1 hour
+  challenge: 60, // auth challenges are short-lived by nature — 1 minute
+  flow: 60, // auth flows are short-lived by nature — 1 minute
+  p2p: 60, // p2p distributed cache default — 1 minute
+
+  // ── Legacy default ────────────────────────────────────────────────────────
+  // Resources not yet classified keep the historical 5-minute default so the
+  // registry is safe to adopt incrementally.
+  default: 300,
+} as const;
+
+export type CacheResource = keyof typeof RESOURCE_TTL_SECONDS;
+
+/** Map a cache key to its resource namespace (first `:`-delimited segment). */
+export function cacheResourceFor(key: string): CacheResource {
+  const namespace = String(key).split(':')[0] ?? 'default';
+  return (namespace in RESOURCE_TTL_SECONDS ? namespace : 'default') as CacheResource;
+}
+
+/** Resolve the policy TTL (seconds) for a resource; falls back to the legacy default. */
+export function ttlForResource(resource: string): number {
+  return RESOURCE_TTL_SECONDS[resource as CacheResource] ?? RESOURCE_TTL_SECONDS.default;
+}

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,8 +1,9 @@
-import { config } from './config';
+import { createHash } from 'crypto';
 import { config } from './config';
 import type { RedisClientType } from 'redis';
 import { logger } from './logger';
 import { cacheBackendStatus } from './metrics';
+import { cacheResourceFor, ttlForResource } from './cache-ttl';
 
 const CACHE_URL = config.cacheUrl ?? 'memory://';
 const CACHE_MODE = config.cacheMode ?? 'standalone'; // 'standalone' or 'sentinel'
@@ -520,12 +521,18 @@ export async function cacheSet<T>(
   value: T,
   ttlSeconds?: number | null,
 ): Promise<void> {
+  // #917 — when the caller doesn't specify a TTL, resolve one from the
+  // per-route TTL registry (src/cache-ttl.ts) keyed by the resource namespace
+  // (first `:`-delimited segment of the key). Explicit TTLs always win, so
+  // existing tuned call sites are untouched.
+  const resolvedTtl = ttlSeconds === undefined ? ttlForResource(cacheResourceFor(key)) : ttlSeconds;
+
   const normalizedKey = `${CACHE_SCHEMA_VERSION}:${normalizeKeyInput(key)}`;
   const payload = JSON.stringify(value);
   const versionHash = computeVersionHash(payload);
   lruSet(normalizedKey, {
     payload,
-    expiresAt: buildExpiry(ttlSeconds),
+    expiresAt: buildExpiry(resolvedTtl),
     versionHash,
   });
 
@@ -534,9 +541,9 @@ export async function cacheSet<T>(
 
   try {
     const multi = client.multi();
-    if (ttlSeconds && ttlSeconds > 0) {
-      multi.set(normalizedKey, payload, { EX: ttlSeconds });
-      multi.set(versionKey(normalizedKey), versionHash, { EX: ttlSeconds });
+    if (resolvedTtl && resolvedTtl > 0) {
+      multi.set(normalizedKey, payload, { EX: resolvedTtl });
+      multi.set(versionKey(normalizedKey), versionHash, { EX: resolvedTtl });
     } else {
       multi.set(normalizedKey, payload);
       multi.set(versionKey(normalizedKey), versionHash);

--- a/src/indexer/errorQueue.ts
+++ b/src/indexer/errorQueue.ts
@@ -1,6 +1,8 @@
 import { prismaWrite as prisma } from '../db';
 import { Prisma } from '@prisma/client';
 import { logger } from '../logger';
+import { indexerErrorQueueDepth, indexerErrorRetriesTotal, indexerErrorDlqTotal } from '../metrics';
+import { parseFailureReasonFromString } from './failure-parser';
 
 const MAX_RETRIES = 3;
 const DEFAULT_BATCH_SIZE = 50;
@@ -39,9 +41,28 @@ export function isPoisonError(error: unknown): boolean {
     'poison',
   ];
 
-  return poisonIndicators.some(
-    (indicator) => msg.includes(indicator) || stack.includes(indicator),
-  );
+  return poisonIndicators.some((indicator) => msg.includes(indicator) || stack.includes(indicator));
+}
+
+/**
+ * #912 — derive a bounded, low-cardinality reason label for DLQ/retry metrics
+ * from a raw error. Uses failure-parser.ts's translation layer where possible
+ * (so labels reflect the parsed failure category) but buckets into a fixed set
+ * to keep Prometheus label cardinality under control.
+ */
+export function classifyFailureReason(error: unknown): string {
+  if (isPoisonError(error)) return 'poison';
+
+  const msg = error instanceof Error ? error.message : String(error ?? '');
+  const parsed = parseFailureReasonFromString(msg).toLowerCase();
+
+  if (/parse|malformed|xdr|decode|unparseable/i.test(parsed)) return 'parse_error';
+  if (/timeout|timed out/i.test(parsed)) return 'timeout';
+  if (/rate limit|429/i.test(parsed)) return 'rate_limit';
+  if (/network|econn|socket|fetch failed|enotfound/i.test(parsed)) return 'network';
+  if (/budget|resource limit/i.test(parsed)) return 'resource_limit';
+  if (/auth|unauthorized/i.test(parsed)) return 'auth';
+  return 'other';
 }
 
 /** Persist a failed decode item. Idempotent — increments retryCount on conflict. */
@@ -58,6 +79,8 @@ export async function enqueueFailure(item: FailedItemInput): Promise<void> {
 
   if (existing) {
     currentRetryCount = existing.retryCount + 1;
+    // #912 — each re-enqueue is one retry; count it per item type.
+    indexerErrorRetriesTotal.inc({ type: item.itemType });
     if (currentRetryCount >= MAX_RETRIES || poisonDetected) {
       isDead = true;
     }
@@ -111,6 +134,7 @@ export async function enqueueFailure(item: FailedItemInput): Promise<void> {
       errorMsg: err.message,
       errorStack: err.stack ?? null,
       retryCount: currentRetryCount,
+      reason: poisonDetected ? 'poison' : 'retry_exhausted',
       payload: { ...item.context, isPoison: poisonDetected, isolationReason: reason },
     });
   } else {
@@ -129,8 +153,13 @@ export async function moveToDeadLetter(dlData: {
   errorMsg: string;
   errorStack?: string | null;
   retryCount: number;
+  /** Bounded reason label for metrics (defaults to classifyFailureReason(errorMsg)). */
+  reason?: string;
   payload?: Record<string, unknown> | null;
 }): Promise<void> {
+  // #912 — dead-letter events are permanent failures; count them by reason so
+  // operators can see poison-vs-exhaustion mix and alert on DLQ rate.
+  indexerErrorDlqTotal.inc({ reason: dlData.reason ?? classifyFailureReason(dlData.errorMsg) });
   await prisma.deadLetterItem.create({
     data: {
       itemType: dlData.itemType,
@@ -191,12 +220,31 @@ export async function purgeDeadLetterItems(ids?: string[]): Promise<number> {
   return deleted.count;
 }
 
+/**
+ * #912 — refresh the indexer_error_queue_depth gauges from the database.
+ * Called from getQueueBackpressureStatus() and at the end of every
+ * retryFailures() cycle so /metrics reflects queue reality between scans.
+ */
+export async function updateErrorQueueMetrics(): Promise<void> {
+  const [pendingCount, deadCount] = await Promise.all([
+    prisma.failedItem.count({ where: { dead: false } }),
+    prisma.deadLetterItem.count(),
+  ]);
+
+  indexerErrorQueueDepth.set({ queue: 'pending' }, pendingCount);
+  indexerErrorQueueDepth.set({ queue: 'dead' }, deadCount);
+}
+
 /** Get queue depth and backpressure status metrics */
 export async function getQueueBackpressureStatus() {
   const [pendingCount, deadCount] = await Promise.all([
     prisma.failedItem.count({ where: { dead: false } }),
     prisma.deadLetterItem.count(),
   ]);
+
+  // #912 — keep the depth gauges in sync with every backpressure read.
+  indexerErrorQueueDepth.set({ queue: 'pending' }, pendingCount);
+  indexerErrorQueueDepth.set({ queue: 'dead' }, deadCount);
 
   return {
     pendingCount,
@@ -263,6 +311,7 @@ export async function retryFailures(
               errorMsg: item.errorMsg,
               errorStack: item.errorStack ?? null,
               retryCount: item.retryCount,
+              reason: 'poison',
               payload: { context: item.context, isPoison: true },
             });
             failed += 1;
@@ -287,6 +336,9 @@ export async function retryFailures(
       }),
     );
   }
+
+  // #912 — refresh depth gauges at the end of each retry-scan cycle.
+  await updateErrorQueueMetrics();
 
   return { processed: pending.length, succeeded, failed };
 }

--- a/src/indexer/rpc.ts
+++ b/src/indexer/rpc.ts
@@ -3,6 +3,13 @@ import { xdr, SorobanRpc } from '@stellar/stellar-sdk';
 import { config } from '../config';
 import { cacheGet, cacheSet } from '../cache';
 import { logger } from '../logger';
+import {
+  rpcCallDuration,
+  rpcCallErrorsTotal,
+  rpcCallRetriesTotal,
+  horizonCallDuration,
+  horizonCallErrorsTotal,
+} from '../metrics';
 
 const isDevnet = config.profile.name === 'devnet';
 
@@ -56,13 +63,25 @@ function isRateLimitError(error: unknown): boolean {
   return status === 429 || getMessage(error).includes('429');
 }
 
-async function retry<T>(fn: () => Promise<T>): Promise<T> {
+/**
+ * #910 — run `fn` while recording outbound RPC latency, error rate, and
+ * retry activity on the shared Prometheus registry. Every call site goes
+ * through here so all RPC operations are instrumented for free.
+ */
+async function retry<T>(operation: string, fn: () => Promise<T>): Promise<T> {
   let attempt = 0;
   // eslint-disable-next-line no-constant-condition
   while (true) {
+    const startTime = Date.now();
     try {
-      return await fn();
+      const result = await fn();
+      rpcCallDuration.observe({ operation, status: 'success' }, (Date.now() - startTime) / 1000);
+      return result;
     } catch (error: unknown) {
+      rpcCallDuration.observe({ operation, status: 'error' }, (Date.now() - startTime) / 1000);
+      const type = isRateLimitError(error) ? 'rate_limit' : 'error';
+      rpcCallErrorsTotal.inc({ operation, type });
+
       if (!isRateLimitError(error) || attempt >= MAX_RETRY_ATTEMPTS) {
         throw error;
       }
@@ -70,14 +89,33 @@ async function retry<T>(fn: () => Promise<T>): Promise<T> {
       const backoff = Math.min(16000, 500 * 2 ** attempt);
       const jitter = Math.floor(Math.random() * 300);
       attempt += 1;
+      rpcCallRetriesTotal.inc({ operation });
       logger.warn(`RPC rate limit hit, retrying in ${backoff + jitter}ms (attempt ${attempt})`);
       await sleep(backoff + jitter);
     }
   }
 }
 
+/**
+ * #910 — time a Horizon REST API call and record latency/errors on the shared
+ * Prometheus registry. Horizon is the indexer's fallback external dependency
+ * (transactions and ledger metadata when RPC can't answer).
+ */
+async function horizonCall<T>(operation: string, fn: () => Promise<T>): Promise<T> {
+  const startTime = Date.now();
+  try {
+    const result = await fn();
+    horizonCallDuration.observe({ operation, status: 'success' }, (Date.now() - startTime) / 1000);
+    return result;
+  } catch (error) {
+    horizonCallDuration.observe({ operation, status: 'error' }, (Date.now() - startTime) / 1000);
+    horizonCallErrorsTotal.inc({ operation, type: 'error' });
+    throw error;
+  }
+}
+
 async function fetchEventsPage(startLedger: number, cursor?: string) {
-  return retry(() =>
+  return retry('getEvents', () =>
     rpc.getEvents({
       startLedger,
       filters: [{ type: 'contract' }],
@@ -166,7 +204,7 @@ export async function fetchEvents(startLedger: number, endLedger: number): Promi
  * Fetch the latest ledger number from the RPC node.
  */
 export async function getLatestLedger(): Promise<number> {
-  const info = await retry(() => rpc.getLatestLedger());
+  const info = await retry('getLatestLedger', () => rpc.getLatestLedger());
   return Number(info.sequence);
 }
 
@@ -180,7 +218,7 @@ export async function getLedger(ledgerSequence: number): Promise<unknown> {
   if (cached !== null) return cached;
 
   const rpcClient = rpc as any;
-  const ledger = await retry(() => rpcClient.getLedger(ledgerSequence));
+  const ledger = await retry('getLedger', () => rpcClient.getLedger(ledgerSequence));
   const ttl = ledgerSequence === 0 ? null : 60 * 60 * 24;
   await cacheSet(cacheKey, ledger, ttl);
   return ledger;
@@ -190,7 +228,7 @@ export async function getLedger(ledgerSequence: number): Promise<unknown> {
  * Fetch a transaction by hash.
  */
 export async function getTransaction(hash: string) {
-  return retry(() => rpc.getTransaction(hash));
+  return retry('getTransaction', () => rpc.getTransaction(hash));
 }
 
 /**
@@ -198,16 +236,18 @@ export async function getTransaction(hash: string) {
  * Maps Horizon fields to the same shape used by the RPC result.
  */
 export async function getTransactionFromHorizon(hash: string) {
-  const axios = (await import('axios')).default;
-  const { data } = await axios.get(`${config.horizonUrl}/transactions/${hash}`);
-  return {
-    status: data.successful ? 'SUCCESS' : 'FAILED',
-    sourceAccount: data.source_account as string,
-    feeCharged: String(data.fee_charged ?? ''),
-    envelopeXdr: {
-      toXDR: (enc: string) => (enc === 'base64' ? data.envelope_xdr : data.envelope_xdr),
-    },
-  };
+  return horizonCall('transactions', async () => {
+    const axios = (await import('axios')).default;
+    const { data } = await axios.get(`${config.horizonUrl}/transactions/${hash}`);
+    return {
+      status: data.successful ? 'SUCCESS' : 'FAILED',
+      sourceAccount: data.source_account as string,
+      feeCharged: String(data.fee_charged ?? ''),
+      envelopeXdr: {
+        toXDR: (enc: string) => (enc === 'base64' ? data.envelope_xdr : data.envelope_xdr),
+      },
+    };
+  });
 }
 
 export function getRpcWebsocketUrl(): string {
@@ -223,8 +263,11 @@ export async function fetchLedgerMetadata(sequence: number): Promise<{
 }> {
   // First attempt: try Horizon because it has stable, standardized JSON structure
   try {
-    const axios = (await import('axios')).default;
-    const { data } = await axios.get(`${config.horizonUrl}/ledgers/${sequence}`);
+    const data = await horizonCall('ledgers', async () => {
+      const axios = (await import('axios')).default;
+      const res = await axios.get(`${config.horizonUrl}/ledgers/${sequence}`);
+      return res.data;
+    });
     if (data && data.hash) {
       return {
         sequence: Number(data.sequence),

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -119,3 +119,99 @@ export const replicaLagCheckErrors = new Counter({
   help: 'Total number of replica lag-check failures (forces primary selection)',
   registers: [registry],
 });
+
+// ── Outbound RPC / Horizon calls (#910) ──────────────────────────────────────
+// The indexer's primary external dependency is the Stellar RPC node (and
+// Horizon as a REST fallback). These metrics track outbound call latency,
+// error rates, and retry activity so RPC degradation is distinguishable
+// from DB write speed, and retry storms (each retry = another RPC call,
+// burning quota) are countable.
+export const rpcCallDuration = new Histogram({
+  name: 'rpc_call_duration_seconds',
+  help: 'Duration of outbound Stellar RPC calls in seconds',
+  labelNames: ['operation', 'status'],
+  buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30],
+  registers: [registry],
+});
+
+export const rpcCallErrorsTotal = new Counter({
+  name: 'rpc_call_errors_total',
+  help: 'Total number of outbound Stellar RPC call errors',
+  labelNames: ['operation', 'type'],
+  registers: [registry],
+});
+
+export const rpcCallRetriesTotal = new Counter({
+  name: 'rpc_call_retries_total',
+  help: 'Total number of RPC call retries performed (rate-limit backoff)',
+  labelNames: ['operation'],
+  registers: [registry],
+});
+
+export const horizonCallDuration = new Histogram({
+  name: 'horizon_call_duration_seconds',
+  help: 'Duration of outbound Horizon REST API calls in seconds',
+  labelNames: ['operation', 'status'],
+  buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30],
+  registers: [registry],
+});
+
+export const horizonCallErrorsTotal = new Counter({
+  name: 'horizon_call_errors_total',
+  help: 'Total number of outbound Horizon REST API call errors',
+  labelNames: ['operation', 'type'],
+  registers: [registry],
+});
+
+// ── Background job / cron metrics (#911) ─────────────────────────────────────
+// Recurring jobs (price updates, audit pipeline, key rotation, aggregation
+// snapshots) previously exposed no per-job metrics — job health was only
+// visible in logs. These make silently failing jobs detectable and feed the
+// worker health check so /health reflects reality.
+export const cronJobRunsTotal = new Counter({
+  name: 'cron_job_runs_total',
+  help: 'Total number of cron job executions by job and outcome',
+  labelNames: ['job', 'status'],
+  registers: [registry],
+});
+
+export const cronJobDurationSeconds = new Histogram({
+  name: 'cron_job_duration_seconds',
+  help: 'Duration of cron job executions in seconds',
+  labelNames: ['job'],
+  buckets: [0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 300, 900],
+  registers: [registry],
+});
+
+export const cronJobLastSuccessTimestamp = new Gauge({
+  name: 'cron_job_last_success_timestamp',
+  help: 'Unix timestamp (seconds) of the last successful run of each cron job',
+  labelNames: ['job'],
+  registers: [registry],
+});
+
+// ── Indexer error queue / DLQ (#912) ─────────────────────────────────────────
+// Failed ledgers/transactions are retried through the error queue; without
+// these, a ledger failing 50 times is indistinguishable from a one-off error.
+// Gauges expose queue depth for backpressure decisions; counters expose
+// retry activity and permanent (dead-lettered) failures by reason.
+export const indexerErrorQueueDepth = new Gauge({
+  name: 'indexer_error_queue_depth',
+  help: 'Number of items currently in the indexer error queue by queue type',
+  labelNames: ['queue'],
+  registers: [registry],
+});
+
+export const indexerErrorRetriesTotal = new Counter({
+  name: 'indexer_error_retries_total',
+  help: 'Total number of retries performed for failed indexer items',
+  labelNames: ['type'],
+  registers: [registry],
+});
+
+export const indexerErrorDlqTotal = new Counter({
+  name: 'indexer_error_dlq_total',
+  help: 'Total number of items dead-lettered by reason',
+  labelNames: ['reason'],
+  registers: [registry],
+});

--- a/src/scheduler/cron-scheduler.ts
+++ b/src/scheduler/cron-scheduler.ts
@@ -10,6 +10,7 @@
 
 import * as cron from 'node-cron';
 import { logger } from '../logger';
+import { cronJobRunsTotal, cronJobDurationSeconds, cronJobLastSuccessTimestamp } from '../metrics';
 
 export interface ScheduledJob {
   id: string;
@@ -70,9 +71,10 @@ export interface WorkerHealthSummary {
  * Best-effort parse of common cron shorthand into an approximate interval in
  * milliseconds, for staleness detection when a job doesn't supply
  * `expectedIntervalMs` explicitly. Handles the "every N seconds/minutes"
- * patterns actually used in this codebase (`* * * * *`, `*/N * * * *`,
- * 6-field `*/N * * * * *`); anything else (day-of-week/month schedules)
- * returns null, meaning "don't flag this job as stale".
+ * patterns actually used in this codebase (the five-field every-minute form,
+ * the every-N-minutes form, and their six-field second equivalents); anything
+ * else (day-of-week/month schedules) returns null, meaning "don't flag this
+ * job as stale".
  */
 export function approxCronIntervalMs(expression: string): number | null {
   const parts = expression.trim().split(/\s+/);
@@ -116,6 +118,15 @@ class CronScheduler {
     status: 'success' | 'failure',
     meta?: { taskName?: string; expectedIntervalMs?: number },
   ): void {
+    // #911 — emit per-job metrics for externally-managed recurring tasks too
+    // (price updates, key rotation, reconciliation sweeps) so their health is
+    // visible in /metrics, not just logs. Duration is only tracked for
+    // scheduler-managed jobs (executeJob has the start time).
+    cronJobRunsTotal.inc({ job: id, status });
+    if (status === 'success') {
+      cronJobLastSuccessTimestamp.set({ job: id }, Date.now() / 1000);
+    }
+
     const existing = this.healthRegistry.get(id);
     const consecutiveFailures = status === 'failure' ? (existing?.consecutiveFailures ?? 0) + 1 : 0;
 
@@ -254,10 +265,18 @@ class CronScheduler {
       jobInstance.lastError = undefined;
       jobInstance.executionCount++;
 
+      // #911 — per-job Prometheus metrics. Runs/outcome counters and the
+      // last-success timestamp are emitted centrally in recordHeartbeat()
+      // (the single funnel for scheduler-managed AND externally-managed
+      // jobs); only the duration needs the start time captured here.
+      cronJobDurationSeconds.observe({ job: jobConfig.id }, duration / 1000);
+
       this.recordHeartbeat(jobConfig.id, 'success', {
         taskName: jobConfig.taskName,
         expectedIntervalMs:
-          jobConfig.expectedIntervalMs ?? approxCronIntervalMs(jobConfig.cronExpression) ?? undefined,
+          jobConfig.expectedIntervalMs ??
+          approxCronIntervalMs(jobConfig.cronExpression) ??
+          undefined,
       });
 
       logger.info(
@@ -267,13 +286,19 @@ class CronScheduler {
       const duration = Date.now() - startTime;
       const errorMessage = error instanceof Error ? error.message : String(error);
 
+      // #911 — per-job Prometheus metrics (see success path; runs/outcome
+      // counters flow through recordHeartbeat()).
+      cronJobDurationSeconds.observe({ job: jobConfig.id }, duration / 1000);
+
       jobInstance.lastError = error instanceof Error ? error : new Error(String(error));
       jobInstance.executionCount++;
 
       this.recordHeartbeat(jobConfig.id, 'failure', {
         taskName: jobConfig.taskName,
         expectedIntervalMs:
-          jobConfig.expectedIntervalMs ?? approxCronIntervalMs(jobConfig.cronExpression) ?? undefined,
+          jobConfig.expectedIntervalMs ??
+          approxCronIntervalMs(jobConfig.cronExpression) ??
+          undefined,
       });
 
       logger.error(
@@ -438,6 +463,10 @@ class CronScheduler {
     }
 
     this.jobs.clear();
+    // Reset the flag so the scheduler can be reused (tests and hot-reloads
+    // shut down and re-register jobs against the same singleton). Without
+    // this, every later run is skipped and shutdown calls short-circuit.
+    this.isShuttingDown = false;
     logger.info('[scheduler] Graceful shutdown complete');
   }
 }

--- a/src/services/pricing/composite-price.ts
+++ b/src/services/pricing/composite-price.ts
@@ -107,7 +107,8 @@ export async function computeCompositePrice(
     breakdown,
   };
 
-  await cacheSet(cacheKey, result, 5);
+  // #917 — TTL resolved from the per-route registry (composite_price → 5s).
+  await cacheSet(cacheKey, result);
 
   if (selectedPrice > 0) {
     await persistPrice(tokenAddress, result, selectedSource);

--- a/src/services/pricing/correlation.ts
+++ b/src/services/pricing/correlation.ts
@@ -41,7 +41,8 @@ async function fetchChainPrice(
       if (data.status === '1' && data.result) {
         const price = parseFloat(data.result);
         if (price > 0) {
-          await cacheSet(cacheKey, price, 300);
+          // #917 — TTL resolved from the per-route registry (chain_price → 30s).
+          await cacheSet(cacheKey, price);
           return price;
         }
       }
@@ -53,7 +54,8 @@ async function fetchChainPrice(
       if (!res.ok) return null;
       const data = (await res.json()) as { priceUsdt?: number };
       if (data.priceUsdt && data.priceUsdt > 0) {
-        await cacheSet(cacheKey, data.priceUsdt, 300);
+        // #917 — TTL resolved from the per-route registry (chain_price → 30s).
+        await cacheSet(cacheKey, data.priceUsdt);
         return data.priceUsdt;
       }
     }

--- a/src/services/pricing/dex-price-source.ts
+++ b/src/services/pricing/dex-price-source.ts
@@ -240,7 +240,8 @@ export async function discoverDexPrice(tokenAddress: string): Promise<DexPrice |
     twap24h,
   };
 
-  await cacheSet<DexPrice>(cacheKey, result, 5);
+  // #917 — TTL resolved from the per-route registry (dex_price → 5s).
+  await cacheSet<DexPrice>(cacheKey, result);
   return result;
 }
 

--- a/src/services/pricing/external-api-source.ts
+++ b/src/services/pricing/external-api-source.ts
@@ -90,9 +90,8 @@ async function fetchCoinGeckoPrice(tokenSymbol: string): Promise<ExternalPrice |
       priceChange1h: 0,
       source: 'coingecko',
       confidence: 0.85,
-    };
-
-    await cacheSet(cacheKey, result, 300);
+    }; // #917 — TTL resolved from the per-route registry (se_price → 30s).
+    await cacheSet(cacheKey, result);
     return result;
   } catch {
     return null;
@@ -152,7 +151,8 @@ async function fetchCoinMarketCapPrice(tokenSymbol: string): Promise<ExternalPri
       confidence: 0.9,
     };
 
-    await cacheSet(cacheKey, result, 300);
+    // #917 — TTL resolved from the per-route registry (cmc_price → 30s).
+    await cacheSet(cacheKey, result);
     return result;
   } catch {
     return null;
@@ -178,9 +178,8 @@ async function fetchStellarExpertPrice(tokenAddress: string): Promise<ExternalPr
       priceUsd: parseFloat(data.price),
       source: 'stellarexpert',
       confidence: 0.6,
-    };
-
-    await cacheSet(cacheKey, result, 300);
+    }; // #917 — TTL resolved from the per-route registry (se_price → 30s).
+    await cacheSet(cacheKey, result);
     return result;
   } catch {
     return null;

--- a/tests/cache-ttl.test.ts
+++ b/tests/cache-ttl.test.ts
@@ -1,0 +1,106 @@
+/**
+ * #917 — Per-route cache TTL policy: a single TTL registry must exist,
+ * volatile routes (prices, fees, arbitrage) must use short TTLs while stable
+ * routes (ABIs, metadata, proofs) use long TTLs, and cacheSet() must resolve
+ * the TTL from the registry when the caller passes none.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// Force in-memory mode so TTL expiry is driven by the mocked clock.
+vi.stubEnv('CACHE_URL', 'memory://');
+
+const VOLATILE_NAMESPACES = [
+  'cg_price',
+  'cmc_price',
+  'se_price',
+  'chain_price',
+  'dex_price',
+  'composite_price',
+  'arbitrage',
+  'graph',
+  'fee',
+];
+
+const STABLE_NAMESPACES = ['abi', 'token-metadata', 'classic-asset', 'ledger', 'proof'];
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('cache TTL registry (#917)', () => {
+  it('gives volatile resources short TTLs (seconds)', async () => {
+    const { ttlForResource } = await import('../src/cache-ttl');
+    for (const ns of VOLATILE_NAMESPACES) {
+      expect(ttlForResource(ns), `${ns} should be <= 60s`).toBeLessThanOrEqual(60);
+    }
+  });
+
+  it('gives stable resources long TTLs (hours-days)', async () => {
+    const { ttlForResource } = await import('../src/cache-ttl');
+    for (const ns of STABLE_NAMESPACES) {
+      expect(ttlForResource(ns), `${ns} should be >= 1h`).toBeGreaterThanOrEqual(3600);
+    }
+  });
+
+  it('maps unknown namespaces to the legacy default', async () => {
+    const { cacheResourceFor, ttlForResource } = await import('../src/cache-ttl');
+    expect(cacheResourceFor('some-new-route:123')).toBe('default');
+    expect(ttlForResource(cacheResourceFor('some-new-route:123'))).toBe(300);
+  });
+
+  it('resolves the resource namespace from the key prefix', async () => {
+    const { cacheResourceFor } = await import('../src/cache-ttl');
+    expect(cacheResourceFor('abi:CA3D...')).toBe('abi');
+    expect(cacheResourceFor('cg_price:USDC')).toBe('cg_price');
+    expect(cacheResourceFor('ledger:12345')).toBe('ledger');
+  });
+
+  it('applies registry TTLs when cacheSet receives no explicit TTL', async () => {
+    vi.resetModules();
+    const mod = await import('../src/cache');
+    mod.cacheClear();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+    await mod.cacheSet('abi:CA3D...', { abi: true }); // registry: 7 days
+    await mod.cacheSet('cg_price:USDC', 1.23); // registry: 30s
+
+    // Both readable within the volatile window...
+    vi.setSystemTime(new Date('2026-01-01T00:00:29Z'));
+    expect(await mod.cacheGet('abi:CA3D...')).toEqual({ abi: true });
+    expect(await mod.cacheGet('cg_price:USDC')).toBe(1.23);
+
+    // ...after 30s the price is gone, the stable ABI survives.
+    vi.setSystemTime(new Date('2026-01-01T00:00:31Z'));
+    expect(await mod.cacheGet('cg_price:USDC')).toBeNull();
+    expect(await mod.cacheGet('abi:CA3D...')).toEqual({ abi: true });
+  });
+
+  it('still honours an explicit TTL over the registry', async () => {
+    vi.resetModules();
+    const mod = await import('../src/cache');
+    mod.cacheClear();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+    await mod.cacheSet('abi:CA3D...', 'x', 2); // explicit 2s beats registry 7d
+    vi.setSystemTime(new Date('2026-01-01T00:00:03Z'));
+    expect(await mod.cacheGet('abi:CA3D...')).toBeNull();
+  });
+
+  it('keeps null TTL semantics (no expiry)', async () => {
+    vi.resetModules();
+    const mod = await import('../src/cache');
+    mod.cacheClear();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+    await mod.cacheSet('ledger:0', 'immutable', null);
+    vi.setSystemTime(new Date('2026-01-02T00:00:00Z'));
+    expect(await mod.cacheGet('ledger:0')).toBe('immutable');
+  });
+});

--- a/tests/cron-metrics.test.ts
+++ b/tests/cron-metrics.test.ts
@@ -1,0 +1,108 @@
+/**
+ * #911 — Cron-scheduled jobs must expose success/failure metrics and
+ * last-run tracking (cron_job_runs_total, cron_job_duration_seconds,
+ * cron_job_last_success_timestamp). These tests drive the real scheduler
+ * with fake timers and assert the metrics land on the shared Prometheus
+ * registry, for both scheduler-managed jobs and externally-managed
+ * recurring tasks that report through scheduler.recordHeartbeat().
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { scheduler, type ScheduledJob } from '../src/scheduler/cron-scheduler';
+import { registry } from '../src/metrics';
+
+vi.mock('../src/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+async function metricText(name: string): Promise<string> {
+  return registry.getSingleMetricAsString(name);
+}
+
+describe('cron scheduler metrics (#911)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registry.resetMetrics();
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await scheduler.gracefulShutdown();
+  });
+
+  it('emits runs_total, duration, and last_success on a successful run', async () => {
+    // 0 * * * * * fires once per minute — exactly one run per 61s advance.
+    const job: ScheduledJob = {
+      id: 'metrics-success-job',
+      cronExpression: '0 * * * * *',
+      taskName: 'Metrics Success Job',
+      execute: vi.fn().mockResolvedValue(undefined),
+    };
+    scheduler.register(job);
+    await vi.advanceTimersByTimeAsync(61_000);
+
+    const runs = await metricText('cron_job_runs_total');
+    expect(runs).toContain('cron_job_runs_total{job="metrics-success-job",status="success"} 1');
+    expect(runs).not.toContain('status="failure"');
+
+    const durations = await metricText('cron_job_duration_seconds');
+    expect(durations).toContain('cron_job_duration_seconds_count{job="metrics-success-job"} 1');
+
+    const lastSuccess = await metricText('cron_job_last_success_timestamp');
+    expect(lastSuccess).toContain('cron_job_last_success_timestamp{job="metrics-success-job"}');
+  });
+
+  it('emits failure outcome and no last-success update on failure', async () => {
+    const job: ScheduledJob = {
+      id: 'metrics-fail-job',
+      cronExpression: '0 * * * * *',
+      taskName: 'Metrics Fail Job',
+      execute: vi.fn().mockRejectedValue(new Error('boom')),
+    };
+    scheduler.register(job);
+    await vi.advanceTimersByTimeAsync(61_000);
+
+    const runs = await metricText('cron_job_runs_total');
+    expect(runs).toContain('cron_job_runs_total{job="metrics-fail-job",status="failure"} 1');
+    expect(runs).not.toContain('cron_job_runs_total{job="metrics-fail-job",status="success"}');
+
+    const lastSuccess = await metricText('cron_job_last_success_timestamp');
+    expect(lastSuccess).not.toContain('metrics-fail-job');
+  });
+
+  it('records metrics for externally-managed jobs via recordHeartbeat', async () => {
+    scheduler.recordHeartbeat('price-updater:active', 'success');
+    scheduler.recordHeartbeat('price-updater:active', 'success');
+    scheduler.recordHeartbeat('price-updater:active', 'failure');
+
+    const runs = await metricText('cron_job_runs_total');
+    expect(runs).toContain('cron_job_runs_total{job="price-updater:active",status="success"} 2');
+    expect(runs).toContain('cron_job_runs_total{job="price-updater:active",status="failure"} 1');
+
+    const lastSuccess = await metricText('cron_job_last_success_timestamp');
+    expect(lastSuccess).toContain('cron_job_last_success_timestamp{job="price-updater:active"}');
+  });
+
+  it('keeps runs_total and last_success in sync with health registry heartbeats', async () => {
+    // Every scheduler-managed run funnels through recordHeartbeat(), so a
+    // failing job must NOT be double-counted as a success.
+    const job: ScheduledJob = {
+      id: 'metrics-sync-job',
+      cronExpression: '0 * * * * *',
+      taskName: 'Metrics Sync Job',
+      execute: vi.fn().mockRejectedValue(new Error('always fails')),
+    };
+    scheduler.register(job);
+    await vi.advanceTimersByTimeAsync(61_000);
+
+    const runs = await metricText('cron_job_runs_total');
+    expect(runs).toContain('cron_job_runs_total{job="metrics-sync-job",status="failure"} 1');
+    // Exactly one run total — no duplicate count from executeJob + recordHeartbeat.
+    const failureCount = runs.match(
+      /cron_job_runs_total\{job="metrics-sync-job",status="failure"\} (\d+)/,
+    );
+    expect(failureCount).not.toBeNull();
+    expect(Number(failureCount![1])).toBe(1);
+  });
+});

--- a/tests/cron-scheduler.test.ts
+++ b/tests/cron-scheduler.test.ts
@@ -151,6 +151,11 @@ describe('CronScheduler - Job Execution', () => {
     scheduler.register(job);
 
     await vi.advanceTimersByTimeAsync(61000);
+    // Stop new ticks and let the in-flight execution's maxDuration timeout
+    // fire so gracefulShutdown in afterEach doesn't wait on an abandoned
+    // fake-timer promise (which would hang the hook for 30s).
+    scheduler.stop('timeout-test');
+    await vi.advanceTimersByTimeAsync(1500);
 
     const status = scheduler.getStatus('timeout-test');
     expect((status as any).lastError).toBeDefined();
@@ -194,10 +199,13 @@ describe('CronScheduler - Backpressure Handling', () => {
 
     expect(mockExecute).toHaveBeenCalledTimes(1);
 
+    // Resolve the final in-flight execution (its resolver was captured when
+    // the last tick started it) and stop new ticks so gracefulShutdown in
+    // afterEach doesn't wait on an abandoned fake-timer promise.
     if (resolveExecution) {
       resolveExecution();
     }
-
+    scheduler.stop('backpressure-test');
     await vi.advanceTimersByTimeAsync(1000);
 
     expect(mockExecute).toHaveBeenCalled();
@@ -224,9 +232,11 @@ describe('CronScheduler - Retry Logic', () => {
       }
     });
 
+    // 0 * * * * * fires once per minute so the count assertions below are
+    // exact (a per-second expression would fire 61+ times across the advance).
     const job: ScheduledJob = {
       id: 'retry-test',
-      cronExpression: '*/1 * * * * *',
+      cronExpression: '0 * * * * *',
       taskName: 'Retry Test',
       execute: mockExecute,
       retryOnFailure: true,
@@ -249,7 +259,7 @@ describe('CronScheduler - Retry Logic', () => {
 
     const job: ScheduledJob = {
       id: 'no-retry-test',
-      cronExpression: '*/1 * * * * *',
+      cronExpression: '0 * * * * *',
       taskName: 'No Retry Test',
       execute: mockExecute,
       retryOnFailure: false,
@@ -287,6 +297,10 @@ describe('CronScheduler - Retry Logic', () => {
     scheduler.register(job);
 
     await vi.advanceTimersByTimeAsync(61000);
+    // Settle the last tick's pending retry timer so afterEach's
+    // gracefulShutdown doesn't wait on it.
+    scheduler.stop('execution-count-test');
+    await vi.advanceTimersByTimeAsync(1500);
 
     const status = scheduler.getStatus('execution-count-test');
     expect((status as any).executionCount).toBeGreaterThan(0);

--- a/tests/indexer/error-queue-metrics.test.ts
+++ b/tests/indexer/error-queue-metrics.test.ts
@@ -1,0 +1,171 @@
+/**
+ * #912 — Indexer error-queue retries and poison (dead-lettered) items must be
+ * visible in /metrics: indexer_error_queue_depth gauges, an
+ * indexer_error_retries_total counter, and an indexer_error_dlq_total counter
+ * labelled with a bounded reason derived via failure-parser.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/db', () => {
+  const mockFindFirst = vi.fn();
+  const mockCreate = vi.fn();
+  const mockUpdate = vi.fn();
+  const mockFindMany = vi.fn();
+  const mockDelete = vi.fn();
+  const mockCount = vi.fn();
+  const mockDeadCreate = vi.fn();
+  const mockDeadCount = vi.fn();
+
+  return {
+    prismaWrite: {
+      failedItem: {
+        findFirst: mockFindFirst,
+        create: mockCreate,
+        update: mockUpdate,
+        findMany: mockFindMany,
+        delete: mockDelete,
+        count: mockCount,
+      },
+      deadLetterItem: {
+        create: mockDeadCreate,
+        count: mockDeadCount,
+      },
+    },
+  };
+});
+
+import {
+  enqueueFailure,
+  retryFailures,
+  getQueueBackpressureStatus,
+  classifyFailureReason,
+} from '../../src/indexer/errorQueue';
+import { prismaWrite } from '../../src/db';
+import { registry } from '../../src/metrics';
+
+const db = prismaWrite.failedItem as unknown as {
+  findFirst: ReturnType<typeof vi.fn>;
+  create: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  findMany: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  count: ReturnType<typeof vi.fn>;
+};
+
+const deadDb = prismaWrite.deadLetterItem as unknown as {
+  create: ReturnType<typeof vi.fn>;
+  count: ReturnType<typeof vi.fn>;
+};
+
+async function metricText(name: string): Promise<string> {
+  return registry.getSingleMetricAsString(name);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  registry.resetMetrics();
+});
+
+describe('error queue metrics (#912)', () => {
+  it('increments retries counter when an existing item is re-enqueued', async () => {
+    db.findFirst.mockResolvedValue({ id: 1, retryCount: 1 });
+    db.update.mockResolvedValue({});
+
+    await enqueueFailure({
+      itemType: 'transaction',
+      itemId: 'tx-abc',
+      ledger: 100,
+      error: new Error('decode failed'),
+    });
+
+    const out = await metricText('indexer_error_retries_total');
+    expect(out).toContain('indexer_error_retries_total{type="transaction"} 1');
+  });
+
+  it('does not count the first failure as a retry', async () => {
+    db.findFirst.mockResolvedValue(null);
+    db.create.mockResolvedValue({});
+
+    await enqueueFailure({
+      itemType: 'event',
+      itemId: 'ev-new',
+      ledger: 200,
+      error: new Error('bad format'),
+    });
+
+    const out = await metricText('indexer_error_retries_total');
+    // HELP/TYPE headers exist, but no series was recorded for any item type.
+    expect(out).not.toContain('{');
+  });
+
+  it('dead-letters poison items with a poison reason label', async () => {
+    db.findFirst.mockResolvedValue(null);
+    db.create.mockResolvedValue({});
+    deadDb.create.mockResolvedValue({});
+
+    await enqueueFailure({
+      itemType: 'ledger',
+      itemId: 'l-poison',
+      ledger: 300,
+      error: new Error('invalid xdr: cannot parse'),
+    });
+
+    const out = await metricText('indexer_error_dlq_total');
+    expect(out).toContain('indexer_error_dlq_total{reason="poison"} 1');
+  });
+
+  it('dead-letters exhausted items with a retry_exhausted reason label', async () => {
+    db.findFirst.mockResolvedValue({ id: 2, retryCount: 2 });
+    db.update.mockResolvedValue({});
+    deadDb.create.mockResolvedValue({});
+
+    await enqueueFailure({
+      itemType: 'transaction',
+      itemId: 'tx-dead',
+      ledger: 400,
+      error: new Error('persistent failure'),
+    });
+
+    const out = await metricText('indexer_error_dlq_total');
+    expect(out).toContain('indexer_error_dlq_total{reason="retry_exhausted"} 1');
+  });
+
+  it('updates queue depth gauges from backpressure reads', async () => {
+    db.count.mockResolvedValue(42);
+    deadDb.count.mockResolvedValue(7);
+
+    const status = await getQueueBackpressureStatus();
+    expect(status.pendingCount).toBe(42);
+    expect(status.deadCount).toBe(7);
+
+    const out = await metricText('indexer_error_queue_depth');
+    expect(out).toContain('indexer_error_queue_depth{queue="pending"} 42');
+    expect(out).toContain('indexer_error_queue_depth{queue="dead"} 7');
+  });
+
+  it('refreshes depth gauges at the end of a retryFailures cycle', async () => {
+    db.findMany.mockResolvedValue([
+      { id: 10, itemType: 'transaction', itemId: 'tx-1', ledger: 1, rawXdr: null, context: null },
+    ]);
+    db.delete.mockResolvedValue({});
+    db.count.mockResolvedValue(0);
+    deadDb.count.mockResolvedValue(0);
+
+    const handler = vi.fn().mockResolvedValue(undefined);
+    await retryFailures(handler);
+
+    const out = await metricText('indexer_error_queue_depth');
+    expect(out).toContain('indexer_error_queue_depth{queue="pending"} 0');
+    expect(out).toContain('indexer_error_queue_depth{queue="dead"} 0');
+  });
+
+  it('classifies failure reasons into bounded buckets via failure-parser', () => {
+    expect(classifyFailureReason(new Error('invalid xdr'))).toBe('poison');
+    expect(classifyFailureReason(new Error('syntaxerror in payload'))).toBe('poison');
+    expect(classifyFailureReason(new Error('request timed out after 30s'))).toBe('timeout');
+    expect(classifyFailureReason(new Error('socket hang up'))).toBe('network');
+    expect(classifyFailureReason(new Error('rate limit exceeded'))).toBe('rate_limit');
+    expect(classifyFailureReason(new Error('unrelated issue'))).toBe('other');
+  });
+});

--- a/tests/indexer/error-queue.test.ts
+++ b/tests/indexer/error-queue.test.ts
@@ -7,6 +7,9 @@ vi.mock('../../src/db', () => {
   const mockUpdate = vi.fn();
   const mockFindMany = vi.fn();
   const mockDelete = vi.fn();
+  const mockCount = vi.fn().mockResolvedValue(0);
+  const mockDeadCreate = vi.fn().mockResolvedValue({});
+  const mockDeadCount = vi.fn().mockResolvedValue(0);
 
   return {
     prismaWrite: {
@@ -16,6 +19,13 @@ vi.mock('../../src/db', () => {
         update: mockUpdate,
         findMany: mockFindMany,
         delete: mockDelete,
+        count: mockCount,
+      },
+      // #912 — retryFailures() refreshes the queue-depth gauges each cycle
+      // and enqueueFailure() dead-letters via prismaWrite.deadLetterItem.
+      deadLetterItem: {
+        create: mockDeadCreate,
+        count: mockDeadCount,
       },
     },
   };

--- a/tests/indexer/rpc-metrics.test.ts
+++ b/tests/indexer/rpc-metrics.test.ts
@@ -1,0 +1,141 @@
+/**
+ * #910 — Outbound Stellar RPC and Horizon calls must be instrumented:
+ * rpc_call_duration_seconds / horizon_call_duration_seconds histograms plus
+ * error and retry counters, with operation/status labels. Instrumentation
+ * lives inside retry()/horizonCall() so every call site is covered for free.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { registry } from '../../src/metrics';
+
+const { sharedMockServer } = vi.hoisted(() => ({
+  sharedMockServer: {
+    getEvents: vi.fn(),
+    getLatestLedger: vi.fn(),
+    getTransaction: vi.fn(),
+    getLedger: vi.fn(),
+  },
+}));
+
+vi.mock('@stellar/stellar-sdk', () => {
+  function MockServer() {
+    return sharedMockServer;
+  }
+  return { SorobanRpc: { Server: MockServer } };
+});
+
+vi.mock('../../src/cache', () => ({
+  cacheGet: vi.fn().mockResolvedValue(null),
+  cacheSet: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/config', () => ({
+  config: {
+    profile: { name: 'devnet' },
+    stellarRpcUrl: 'http://localhost:8000',
+    stellarRpcWsUrl: 'ws://localhost:8000',
+    horizonUrl: 'https://horizon-testnet.stellar.org',
+  },
+}));
+
+const { axiosGetMock } = vi.hoisted(() => ({ axiosGetMock: vi.fn() }));
+vi.mock('axios', () => ({
+  __esModule: true,
+  default: { get: axiosGetMock },
+}));
+
+import { fetchEvents, getLatestLedger, getTransactionFromHorizon } from '../../src/indexer/rpc';
+
+async function metricText(name: string): Promise<string> {
+  return registry.getSingleMetricAsString(name);
+}
+
+describe('RPC/Horizon outbound metrics (#910)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registry.resetMetrics();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('records rpc_call_duration_seconds with operation and status on success', async () => {
+    sharedMockServer.getEvents.mockResolvedValue({ events: [] });
+    await fetchEvents(1000, 1010);
+
+    const out = await metricText('rpc_call_duration_seconds');
+    expect(out).toContain(
+      'rpc_call_duration_seconds_count{operation="getEvents",status="success"}',
+    );
+  });
+
+  it('records duration and error counter on RPC failure', async () => {
+    sharedMockServer.getEvents.mockRejectedValue(new Error('Network error'));
+    await expect(fetchEvents(1000, 1010)).rejects.toThrow('Network error');
+
+    const duration = await metricText('rpc_call_duration_seconds');
+    expect(duration).toContain(
+      'rpc_call_duration_seconds_count{operation="getEvents",status="error"}',
+    );
+
+    const errors = await metricText('rpc_call_errors_total');
+    expect(errors).toContain('rpc_call_errors_total{operation="getEvents",type="error"} 1');
+  });
+
+  it('counts rate-limit retries in rpc_call_retries_total', async () => {
+    const rateLimitError = { response: { status: 429 } };
+    sharedMockServer.getEvents
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValueOnce({ events: [] });
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const fetchPromise = fetchEvents(1000, 1010);
+    await vi.runAllTimersAsync();
+    await fetchPromise;
+
+    const retries = await metricText('rpc_call_retries_total');
+    expect(retries).toContain('rpc_call_retries_total{operation="getEvents"} 1');
+
+    const errors = await metricText('rpc_call_errors_total');
+    expect(errors).toContain('rpc_call_errors_total{operation="getEvents",type="rate_limit"} 1');
+  });
+
+  it('records horizon_call_duration_seconds for Horizon transaction lookups', async () => {
+    axiosGetMock.mockResolvedValue({
+      data: {
+        successful: true,
+        source_account: 'GABC',
+        fee_charged: '100',
+        envelope_xdr: 'AAAA',
+      },
+    });
+
+    const result = await getTransactionFromHorizon('tx-hash-1');
+    expect(result.status).toBe('SUCCESS');
+
+    const out = await metricText('horizon_call_duration_seconds');
+    expect(out).toContain(
+      'horizon_call_duration_seconds_count{operation="transactions",status="success"}',
+    );
+  });
+
+  it('records horizon errors in horizon_call_errors_total', async () => {
+    axiosGetMock.mockRejectedValue(new Error('Horizon 500'));
+
+    await expect(getTransactionFromHorizon('tx-hash-2')).rejects.toThrow('Horizon 500');
+
+    const out = await metricText('horizon_call_errors_total');
+    expect(out).toContain('horizon_call_errors_total{operation="transactions",type="error"} 1');
+  });
+
+  it('labels getLatestLedger operations', async () => {
+    sharedMockServer.getLatestLedger.mockResolvedValue({ sequence: '12345' });
+    await getLatestLedger();
+
+    const out = await metricText('rpc_call_duration_seconds');
+    expect(out).toContain(
+      'rpc_call_duration_seconds_count{operation="getLatestLedger",status="success"}',
+    );
+  });
+});

--- a/tests/indexer/rpc.test.ts
+++ b/tests/indexer/rpc.test.ts
@@ -23,6 +23,7 @@ vi.mock('../../src/cache', () => ({
 
 vi.mock('../../src/config', () => ({
   config: {
+    profile: { name: 'devnet' },
     stellarRpcUrl: 'http://localhost:8000',
     stellarRpcWsUrl: 'ws://localhost:8000',
     horizonUrl: 'https://horizon-testnet.stellar.org',


### PR DESCRIPTION
## Summary

Implements three Stellar Wave **Observability** issues and one **Performance** issue for the Soroban backend, adding proper instrumentation to the subsystems that previously had none and a per-route cache TTL policy. Also includes several small, pre-existing CI blockers that were failing `main` (detailed below) so this PR is buildable end-to-end.

| Issue | Area | Deliverable |
|---|---|---|
| **#910** (O5) | Outbound RPC / Horizon | Latency histograms, error counters, and retry counters for every RPC & Horizon call |
| **#911** (O6) | Cron-scheduled jobs | `cron_job_runs_total`, `cron_job_duration_seconds`, `cron_job_last_success_timestamp` |
| **#912** (O7) | Indexer error queue | Queue-depth gauges, retry counter, DLQ (dead-letter) counter with reason labels |
| **#917** (P5) | Cache TTL policy | Single per-route TTL registry; `cacheSet` resolves TTL by key namespace |

All new metrics are registered on the shared Prometheus `registry`, so they are exposed automatically by the existing `/metrics` endpoint (no config change needed).

---

## O5 — #910: Outbound RPC/Horizon calls are uninstrumented

**What changed**
- `src/indexer/rpc.ts`:
  - `retry(operation, fn)` now records, on **every attempt**, a latency observation on `rpc_call_duration_seconds{operation,status}` and, on failure, `rpc_call_errors_total{operation,type}` (`type` distinguishes `rate_limit` vs `error`). Each actual retry increments `rpc_call_retries_total{operation}`.
  - All four call sites (`getEvents`, `getLatestLedger`, `getLedger`, `getTransaction`) flow through the instrumented `retry()`, so **every caller is covered for free** exactly as the issue requested.
  - New `horizonCall(operation, fn)` helper wraps the two Horizon REST calls (transaction lookup, ledger metadata) and records `horizon_call_duration_seconds{operation,status}` + `horizon_call_errors_total{operation,type}`.

**Why it matters**
RPC degradation was invisible until ingestion lag spiked, and the cause (RPC latency vs DB write speed) was guesswork. Retry storms — each retry being another paid RPC call — had no counter, so quota burn during outages was unmeasured. These metrics make both observable, and give catch-up capacity planning a latency baseline (per-call-site p95 is now queryable in Prometheus).

**Tests** (`tests/indexer/rpc-metrics.test.ts`): asserts success/error durations, error counters, and the retry counter on a 429-backed `fetchEvents` path, plus Horizon transaction success/error metrics.

---

## O6 — #911: Cron-scheduled jobs have no success/failure metrics

**What changed** (`src/scheduler/cron-scheduler.ts`)
- On every run, `executeJob` emits `cron_job_duration_seconds{job}`.
- `recordHeartbeat(...)` (the single funnel for **both** scheduler-managed jobs **and** externally-managed recurring tasks such as price updates, key rotation, and reconciliation sweeps) emits `cron_job_runs_total{job,status}` and, on success, `cron_job_last_success_timestamp{job}`.

**Why it matters**
A silently failing recurring job (fee aggregation, token-metadata refresh) was undetectable until a downstream symptom appeared, and there was no way to alert on “job X has not completed in N cycles”. Combined with the existing `#906` health registry, these metrics mean `/health` and `/metrics` now both reflect reality, and the worker-health summary has Prometheus backing for alerting on staleness.

**Tests** (`tests/cron-metrics.test.ts`): uses fake timers and drives the real scheduler to assert the counter/histogram/gauge land for success and failure runs, that last-success is not updated on failure, and that externally-`recordHeartbeat`-ed jobs are covered (no double-counting).

---

## O7 — #912: Indexer error queue retries and poison items are invisible

**What changed** (`src/indexer/errorQueue.ts`)
- `indexer_error_queue_depth{queue}` gauge — set to the live `pending` and `dead` (DLQ) counts; refreshed from `getQueueBackpressureStatus()` and at the end of every `retryFailures()` cycle, so gauges track reality between scans.
- `indexer_error_retries_total{type}` — incremented each time an existing failed item is re-enqueued (a retry).
- `indexer_error_dlq_total{reason}` — incremented in `moveToDeadLetter` every time an item is permanently dead-lettered, labelled with a **bounded reason** (`poison`, `retry_exhausted`, or one derived via `failure-parser.ts`'s translation layer: `parse_error`, `timeout`, `rate_limit`, `network`, `resource_limit`, `auth`, `other`).
- New `classifyFailureReason(error)` helper keeps label cardinality low.

**Why it matters**
A ledger failing 50 times was indistinguishable from a one-off error in `/metrics`; there was no queue-depth gauge to drive the backpressure/`DLQ` handling the indexer calls for, and post-incident analysis couldn’t answer “how many items eventually died.” Operators can now see the queue backing up and alert on depth or DLQ rate.

**Tests** (`tests/indexer/error-queue-metrics.test.ts`): asserts the retry counter on re-enqueue, poison/exhaustion reason labels on DLQ, depth-gauge updates from backpressure reads and after a retry cycle, plus reason classification buckets.

---

## P5 — #917: Uniform cache TTLs — no per-route tuning policy

**What changed**
- New module `src/cache-ttl.ts` — a single `RESOURCE_TTL_SECONDS` registry mapping each key namespace to its intended freshness:
  - **Volatile (seconds):** `cg_price`, `cmc_price`, `se_price`, `chain_price` (30s), `dex_price`, `composite_price`, `arbitrage`, `graph` (5s), `fee` (60s).
  - **Stable (minutes–days):** `abi` (7d), `token-metadata` (1h), `classic-asset` (1d), `ledger` (1d, immutable history), `proof` (1d), `audit-*` (2–60m), `profile` (1h), etc.
  - Unknown namespaces fall back to a documented 300s legacy default.
- `src/cache.ts` — `cacheSet(key, value)` with **no explicit TTL now resolves the TTL from the registry** by the key’s first `:`-segment (namespace). **Explicit TTLs always win**, so already-tuned call sites are untouched. This routes essentially every `cacheGet`/`cacheSet` path through a single auditable policy instead of ad-hoc per-call numbers.
- Migrated the flagged volatile call sites in `src/services/pricing/*` to drop their hard-coded `300`/`5` values and rely on the registry.

**Why it matters**
Volatile endpoints could serve stale values for up to 5 minutes (misleading price/fee data) while stable data was either unbounded (ABIs) or thrashed by expiring soon. Freshness per resource is now documented in one place and auditable.

**Tests** (`tests/cache-ttl.test.ts`): asserts volatile namespaces use ≤60s TTLs, stable namespaces ≥1h, unknown → 300s default, namespace resolution from key prefixes, and — with a mocked clock — that `cacheSet` without a TTL actually expires volatile keys in ~30s while long-TTL keys survive; also covers explicit-TTL precedence and `null` (no-expiry) semantics.

---

## CI / build pre-work (necessary to make this PR green)

`main` was not buildable end-to-end, so this PR also fixes several small, pre-existing blockers in the touched areas:

1. **Prisma schema block comment** — `prisma/schema.prisma` contained a `/* ... */` block comment (`CatchUpCheckpoint`), which Prisma 5.22 cannot parse; this broke **`npm ci` → `prisma generate`**, failing the **Build, Lint, Test, and Security** CI jobs on `main` before any code ran. Converted to `///` doc comments.
2. **Self-terminating JSDoc comment** — `src/scheduler/cron-scheduler.ts`'s `approxCronIntervalMs` comment contained the literal `*/N * * * *` sequence, which closes the block comment early and is a **TypeScript syntax error** (10 errors on `main`). Rephrased.
3. **Missing `crypto` import** — `src/cache.ts` used `createHash` without importing it (`ReferenceError` in the #894 key-normalization tests). Added `import { createHash } from 'crypto'`.
4. **Duplicate `config` import** in `src/cache.ts` (removed).
5. **Never-reset scheduler shutdown flag** — `gracefulShutdown()` set `isShuttingDown = true` and never reset it, so after the first shutdown every later job is skipped and shutdown calls short-circuit without clearing jobs. Reset at the end so the scheduler is reusable (also unblocks the scheduler test suite).
6. **Pre-existing broken tests repaired** in `tests/cron-scheduler.test.ts`, `tests/indexer/error-queue.test.ts`, and `tests/indexer/rpc.test.ts` (missing mocks/config fields, count assertions vs per-second cron expressions, dangling fake-timer executions that hung `afterEach` for 30s).
7. **Router validation drift** — `scripts/validate-routes.ts`: removed the stale `upgrade-trace.ts` allowlist entry and fixed a false-positive “exact conflict” at `/admin` caused by a middleware-only `router.use('/admin', adminRateLimit)` mount being counted as a router. The extractor now only records mounts that pass a real router.

## Validation performed

- `tsc -p tsconfig.json --noEmit`: **1363 pre-existing errors → under the 1374 budget** (`typecheck:budget:ci` passes; no new errors introduced).
- `npm run typecheck:scripts` — pass.
- `npm run lint` — **no new lint warnings introduced** (count is unchanged vs `main`; the repo is currently ~65 warnings over the 1750 budget due to unrelated, pre-existing `no-explicit-any`/`no-console` drift, which is tracked separately and out of scope for this change).
- `npm run format` on all changed files — pass.
- `npm run build` — completes (repository `build` step is tolerant of the pre-existing type backlog).
- `npm run validate:prisma`, `npm run validate-routes:ci`, `npm run test:guard` — pass.
- Vitest: all new tests (`cron-metrics`, `rpc-metrics`, `error-queue-metrics`, `cache-ttl`) and all affected existing suites (`cron-scheduler`, `cache`, `rpc`, `error-queue`) pass (**111/111**). Failing suites observed locally (`token-metadata`, `cacheFallback`, `protocol26`, `api-integration`, `ws-broadcasters`) fail **identically on `main`** — pre-existing and unrelated to this PR.

## Checklist

- [x] Metrics registered on the shared Prometheus `registry` (auto-exposed at `/metrics`)
- [x] Per-issue tests with fake timers / metric assertions
- [x] Cache TTL registry covers volatile (seconds) and stable (hours+days) namespaces
- [x] No new type errors, no new lint warnings
- [x] Type-check budget, route validation, prisma validation, and affected tests verified locally

Closes #910
Closes #911
Closes #912
Closes #917