### PR TITLE
perf: bound Horizon/RPC concurrency, batch writes, cursor pagination

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -20,6 +20,9 @@ const eventListQuerySchema = paginationSchema.merge(
     contract: stellarAddress.optional(),
     type: safeLabel.optional(),
     topic: safeLabel.optional(),
+    // #914 — cursor-based pagination (preferred for deep pages); page/limit
+    // remains supported as a compatibility shim.
+    cursor: z.string().optional(),
   }),
 );
 
@@ -50,6 +53,10 @@ const eventListQuerySchema = paginationSchema.merge(
  *         name: limit
  *         schema: { type: integer, minimum: 1, maximum: 100, default: 20 }
  *         description: Page size
+ *       - in: query
+ *         name: cursor
+ *         schema: { type: string }
+ *         description: Event id to resume after (cursor pagination, preferred for deep pages). Takes precedence over `page` when set.
  *     responses:
  *       200:
  *         description: Paginated list of events (summary fields only)
@@ -75,6 +82,7 @@ const eventListQuerySchema = paginationSchema.merge(
  *                 total: { type: integer, description: 'Total number of events matching the filter' }
  *                 page: { type: integer }
  *                 limit: { type: integer }
+ *                 nextCursor: { type: string, nullable: true, description: 'Pass as `cursor` to fetch the next page' }
  *               example:
  *                 data:
  *                   - id: '3389e9f0f1a4e32477b1c0d9e8a6f5b4c3d2e1f0a9b8c7d6e5f40312233445566-AAAADwAAAAh0cmFuc2Zlcg=='

--- a/src/indexer/indexer.ts
+++ b/src/indexer/indexer.ts
@@ -15,6 +15,7 @@ import {
   getTransactionFromHorizon,
   type LedgerEvent,
   fetchLedgerMetadata,
+  fetchLedgerMetadataBatch,
 } from './rpc';
 import { decodeTransaction, decodeEvent } from './decoder';
 import { decodeZkpVerification, recordZkpVerification } from './zkp-verifier';
@@ -237,11 +238,19 @@ export async function processLedgerRange(
   // Stage 1: FETCH metadata & Reorg check
   const stopFetchTimer = indexerPipelineStageDuration.startTimer({ stage: 'fetch' });
 
+  // #913 — prefetch ledger metadata for this worker's sequences with bounded
+  // concurrency instead of awaiting one RPC/Horizon round-trip per ledger.
+  // Downstream reorg-check/persist logic below still runs strictly in order.
+  const responsibleSeqs: number[] = [];
   for (let seq = start; seq <= end; seq++) {
-    if (!opts.force && !(await amIResponsibleFor(seq))) {
-      continue;
+    if (opts.force || (await amIResponsibleFor(seq))) {
+      responsibleSeqs.push(seq);
     }
-    const ledgerMeta = await fetchLedgerMetadata(seq);
+  }
+  const prefetchedMeta = await fetchLedgerMetadataBatch(responsibleSeqs);
+
+  for (const seq of responsibleSeqs) {
+    const ledgerMeta = prefetchedMeta.get(seq) ?? (await fetchLedgerMetadata(seq));
 
     // Deep Reorg Check & Extended Backtracking
     const prevSeq = seq - 1;

--- a/src/indexer/rpc.ts
+++ b/src/indexer/rpc.ts
@@ -302,3 +302,29 @@ export async function fetchLedgerMetadata(sequence: number): Promise<{
 
   throw new Error(`Failed to fetch ledger ${sequence}`);
 }
+
+const CATCHUP_PREFETCH_CONCURRENCY = 8;
+
+/**
+ * #913 — fetch ledger metadata for multiple sequences with bounded
+ * concurrency instead of one RPC/Horizon round-trip at a time. Used by
+ * catch-up to pipeline network calls while downstream processing (reorg
+ * checks, persistence) stays sequential.
+ */
+export async function fetchLedgerMetadataBatch(
+  sequences: number[],
+): Promise<Map<number, Awaited<ReturnType<typeof fetchLedgerMetadata>>>> {
+  const results = new Map<number, Awaited<ReturnType<typeof fetchLedgerMetadata>>>();
+  let cursor = 0;
+
+  async function worker() {
+    while (cursor < sequences.length) {
+      const seq = sequences[cursor++];
+      results.set(seq, await fetchLedgerMetadata(seq));
+    }
+  }
+
+  const workerCount = Math.min(CATCHUP_PREFETCH_CONCURRENCY, sequences.length);
+  await Promise.all(Array.from({ length: workerCount }, worker));
+  return results;
+}

--- a/src/indexer/token-metadata.ts
+++ b/src/indexer/token-metadata.ts
@@ -164,9 +164,49 @@ interface HorizonAssetRecord {
   name?: string;
 }
 
+// ─── Bounded concurrency + rate-limit handling for Horizon fetches ───────────
+// #916 — resolving many unresolved assets (cache warm-up, fresh contracts)
+// used to fire one sequential Horizon HTTP call per asset with no cap and no
+// 429-awareness. This bounds in-flight requests and backs off on 429s using
+// Retry-After, independent of the RPC retry policy in indexer/rpc.ts.
+
+const HORIZON_ASSET_CONCURRENCY = 5;
+const HORIZON_MAX_RETRIES = 3;
+let horizonActive = 0;
+const horizonQueue: Array<() => void> = [];
+
+async function withHorizonLimit<T>(fn: () => Promise<T>): Promise<T> {
+  if (horizonActive >= HORIZON_ASSET_CONCURRENCY) {
+    await new Promise<void>((resolve) => horizonQueue.push(resolve));
+  }
+  horizonActive++;
+  try {
+    return await fn();
+  } finally {
+    horizonActive--;
+    const next = horizonQueue.shift();
+    if (next) next();
+  }
+}
+
+function parseRetryAfterMs(headers: Record<string, string> | undefined): number {
+  const raw = headers?.['retry-after'];
+  if (!raw) return 1000;
+  const asSeconds = Number(raw);
+  if (Number.isFinite(asSeconds)) return Math.max(0, asSeconds * 1000);
+  const asDate = Date.parse(raw);
+  return Number.isFinite(asDate) ? Math.max(0, asDate - Date.now()) : 1000;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 /**
  * Fetch classic Stellar asset metadata from Horizon.
  * Returns null if the asset is not found or the request fails.
+ * Bounded to HORIZON_ASSET_CONCURRENCY in-flight requests, and retries on
+ * 429 responses respecting `Retry-After` up to HORIZON_MAX_RETRIES times.
  */
 async function fetchClassicAssetMetadata(
   assetCode: string,
@@ -175,25 +215,39 @@ async function fetchClassicAssetMetadata(
   // XLM (native) has no Horizon asset record
   if (!assetIssuer) return { name: 'Stellar Lumens' };
 
-  try {
+  return withHorizonLimit(async () => {
     const url = `${config.horizonUrl}/assets`;
-    const response = await safeGet(
-      url,
-      { asset_code: assetCode, asset_issuer: assetIssuer, limit: 1 },
-      undefined,
-      6000,
-    );
-    const data = response.data as {
-      _embedded: { records: HorizonAssetRecord[] };
-    };
+    for (let attempt = 0; attempt <= HORIZON_MAX_RETRIES; attempt++) {
+      try {
+        const response = await safeGet(
+          url,
+          { asset_code: assetCode, asset_issuer: assetIssuer, limit: 1 },
+          undefined,
+          6000,
+        );
 
-    const record = data?._embedded?.records?.[0];
-    if (!record) return null;
+        if (response.status === 429 && attempt < HORIZON_MAX_RETRIES) {
+          logger.warn(
+            `[token-metadata] Horizon rate limit hit for ${assetCode}:${assetIssuer}, retrying (attempt ${attempt + 1})`,
+          );
+          await sleep(parseRetryAfterMs(response.headers));
+          continue;
+        }
 
-    return { name: record.name ?? null };
-  } catch {
+        const data = response.data as {
+          _embedded: { records: HorizonAssetRecord[] };
+        };
+
+        const record = data?._embedded?.records?.[0];
+        if (!record) return null;
+
+        return { name: record.name ?? null };
+      } catch {
+        return null;
+      }
+    }
     return null;
-  }
+  });
 }
 
 // ─── Core resolution logic ────────────────────────────────────────────────────

--- a/src/indexer/yield-distribution.ts
+++ b/src/indexer/yield-distribution.ts
@@ -98,7 +98,22 @@ export async function backfillYieldDistributions(
   endLedger: number,
 ): Promise<number> {
   const events = await fetchEvents(startLedger, endLedger);
-  let stored = 0;
+  // #915 — build rows in-memory and insert with a single createMany instead
+  // of one upsert round-trip per event; each `id` is deterministic and the
+  // original upsert never updated an existing row (`update: {}`), so
+  // skipDuplicates preserves identical idempotent-insert semantics.
+  const rows: Array<{
+    id: string;
+    transactionHash: string;
+    contractAddress: string;
+    distributionId: string;
+    recipient: string;
+    amount: string;
+    tokenSymbol?: string;
+    windowLabel: string;
+    ledgerSequence: number;
+    ledgerCloseTime: Date;
+  }> = [];
 
   for (const event of events) {
     const topics = event.topics;
@@ -133,25 +148,26 @@ export async function backfillYieldDistributions(
     const windowLabel = 'Corporate Yield Distribution Sync';
     const id = `${event.transactionHash}-${event.contractId}-${extracted.recipient}-${topicSymbol}`;
 
-    await prisma.yieldDistribution.upsert({
-      where: { id },
-      update: {},
-      create: {
-        id,
-        transactionHash: event.transactionHash,
-        contractAddress: event.contractId,
-        distributionId: extracted.distributionId,
-        recipient: extracted.recipient,
-        amount: extracted.amount,
-        tokenSymbol: extracted.tokenSymbol,
-        windowLabel,
-        ledgerSequence: event.ledgerSequence,
-        ledgerCloseTime: event.ledgerCloseTime,
-      },
+    rows.push({
+      id,
+      transactionHash: event.transactionHash,
+      contractAddress: event.contractId,
+      distributionId: extracted.distributionId,
+      recipient: extracted.recipient,
+      amount: extracted.amount,
+      tokenSymbol: extracted.tokenSymbol,
+      windowLabel,
+      ledgerSequence: event.ledgerSequence,
+      ledgerCloseTime: event.ledgerCloseTime,
     });
-
-    stored++;
   }
 
-  return stored;
+  if (rows.length === 0) return 0;
+
+  const result = await prisma.yieldDistribution.createMany({
+    data: rows,
+    skipDuplicates: true,
+  });
+
+  return result.count;
 }

--- a/src/repositories/event.repository.ts
+++ b/src/repositories/event.repository.ts
@@ -16,14 +16,18 @@ export interface EventFindOptions {
   take?: number;
   skip?: number;
   orderBy?: Record<string, 'asc' | 'desc'>;
+  /** #914 — keyset cursor (event id) for cursor-based pagination. */
+  cursorId?: string;
 }
 
 export class EventRepository {
   async findManySummary(options: EventFindOptions) {
     return prisma.event.findMany({
       where: options.where,
-      orderBy: options.orderBy ?? { ledgerSequence: 'desc' },
-      skip: options.skip,
+      orderBy: options.orderBy ? options.orderBy : [{ ledgerSequence: 'desc' }, { id: 'desc' }],
+      ...(options.cursorId
+        ? { cursor: { id: options.cursorId }, skip: 1 }
+        : { skip: options.skip }),
       take: options.take,
       select: EVENT_SUMMARY_SELECT,
     });

--- a/src/services/event.service.ts
+++ b/src/services/event.service.ts
@@ -10,6 +10,8 @@ export interface EventListFilter {
   topic?: string;
   page?: number;
   limit?: number;
+  /** #914 — keyset cursor (event id) for cursor-based pagination. */
+  cursor?: string;
 }
 
 export interface EventListResult {
@@ -17,6 +19,8 @@ export interface EventListResult {
   total: number;
   page: number;
   limit: number;
+  /** #914 — pass back as `cursor` to fetch the next page without OFFSET. */
+  nextCursor: string | null;
 }
 
 export class EventService {
@@ -33,19 +37,28 @@ export class EventService {
   async listEvents(query: EventListFilter): Promise<EventListResult> {
     const page = query.page ?? 1;
     const limit = query.limit ?? 20;
-    const skip = (page - 1) * limit;
     const where = this.buildFilterWhere(query);
 
+    // #914 — cursor pagination (keyset on id, via composite index) avoids the
+    // OFFSET rescan cost of deep pages. `page`/`limit` remains the compatibility
+    // shim for existing callers that haven't migrated to `cursor` yet.
+    if (query.cursor) {
+      const [events, total] = await Promise.all([
+        this.repo.findManySummary({ where, cursorId: query.cursor, take: limit }),
+        this.repo.count(where),
+      ]);
+      const nextCursor = events.length === limit ? events[events.length - 1].id : null;
+      return { data: events, total, page, limit, nextCursor };
+    }
+
+    const skip = (page - 1) * limit;
     const [events, total] = await Promise.all([
-      this.repo.findManySummary({
-        where,
-        skip,
-        take: limit,
-      }),
+      this.repo.findManySummary({ where, skip, take: limit }),
       this.repo.count(where),
     ]);
+    const nextCursor = events.length === limit ? events[events.length - 1].id : null;
 
-    return { data: events, total, page, limit };
+    return { data: events, total, page, limit, nextCursor };
   }
 
   async getEventById(id: string): Promise<any | null> {


### PR DESCRIPTION
## Summary
- Bound Horizon asset-metadata concurrency (5 in-flight) and retry on 429 respecting `Retry-After`, separate from the RPC retry policy.
- Prefetch catch-up ledger metadata with a bounded-concurrency batch fetcher instead of one RPC/Horizon round-trip per ledger, while keeping downstream reorg-check/persist logic strictly sequential.
- Replace per-event upserts in the yield-distribution backfill with a single `createMany` + `skipDuplicates` call.
- Add cursor-based pagination (`cursor` param, keyset on event id via the existing `[contractAddress, ledgerSequence, id]` index) to `GET /events`, keeping `page`/`limit` as a compatibility shim.

Closes #913
Closes #914
Closes #915
Closes #916

## Validation performed
- `npx tsc --noEmit` — no new errors introduced by these changes (pre-existing unrelated errors elsewhere in the repo, e.g. `src/ws/*`, `src/webhooks/*`, left untouched)
- `npx eslint` on all changed files — 0 errors (only pre-existing warning categories consistent with the rest of the codebase)
- `npx prettier --check` on all changed files — passes